### PR TITLE
#4: feat(#4): enhance local module path resolution and add regression…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ The format follows the principles from Keep a Changelog and the project aims to 
 - Fixed generated help activation so module and command help can be loaded with `Get-Help` after build/import.
 - Fixed manifest handling so unsupported `Manifest` keys now fail fast with a clear validation error instead of being
   silently tolerated.
+- Fixed local module path resolution maintainability by refactoring `Get-LocalModulePath` to Code Health `10.0` and
+  adding regression coverage for both the matching and error paths.
 
 ### Documentation
 

--- a/src/private/release/FindLocalModulePathMatch.ps1
+++ b/src/private/release/FindLocalModulePathMatch.ps1
@@ -1,0 +1,17 @@
+function Find-LocalModulePathMatch {
+    param(
+        [Parameter(Mandatory)][string[]]$ModulePaths,
+        [Parameter(Mandatory)][string]$MatchPattern,
+        [Parameter(Mandatory)][string]$ErrorMessage
+    )
+
+    $result = $ModulePaths |
+            Where-Object {$_ -match $MatchPattern} |
+            Select-Object -First 1
+
+    if ($result -and (Test-Path $result)) {
+        return $result
+    }
+
+    throw $ErrorMessage
+}

--- a/src/private/release/GetLocalModulePath.ps1
+++ b/src/private/release/GetLocalModulePath.ps1
@@ -1,24 +1,7 @@
 function Get-LocalModulePath {
-    $sep = [IO.Path]::PathSeparator
-    
-    $ModulePaths = $env:PSModulePath -split $sep | ForEach-Object { $_.Trim() } | Select-Object -Unique
+    $modulePaths = Get-LocalModulePathEntryList
+    $matchPattern = Get-LocalModulePathPattern
+    $errorMessage = Get-LocalModulePathErrorMessage -MatchPattern $matchPattern
 
-    if ($IsWindows) {
-        $MatchPattern = '\\Documents\\PowerShell\\Modules'
-        $Result = $ModulePaths | Where-Object { $_ -match $MatchPattern } | Select-Object -First 1
-        if ($Result -and (Test-Path $Result)) { 
-            return $Result 
-        } else { 
-            throw "No windows module path matching $MatchPattern found" 
-        }
-    } else {
-        # For Mac and Linux
-        $MatchPattern = '/\.local/share/powershell/Modules$'
-        $Result = $ModulePaths | Where-Object { $_ -match $MatchPattern } | Select-Object -First 1
-        if ($Result -and (Test-Path $Result)) {
-            return $Result 
-        } else {
-            throw "No macOS/Linux module path matching $MatchPattern found in PSModulePath."
-        }
-    }
+    return Find-LocalModulePathMatch -ModulePaths $modulePaths -MatchPattern $matchPattern -ErrorMessage $errorMessage
 }

--- a/src/private/release/GetLocalModulePathEntryList.ps1
+++ b/src/private/release/GetLocalModulePathEntryList.ps1
@@ -1,0 +1,9 @@
+function Get-LocalModulePathEntryList {
+    $separator = [IO.Path]::PathSeparator
+
+    return @(
+    $env:PSModulePath -split $separator |
+            ForEach-Object {$_.Trim()} |
+            Select-Object -Unique
+    )
+}

--- a/src/private/release/GetLocalModulePathErrorMessage.ps1
+++ b/src/private/release/GetLocalModulePathErrorMessage.ps1
@@ -1,0 +1,11 @@
+function Get-LocalModulePathErrorMessage {
+    param(
+        [Parameter(Mandatory)][string]$MatchPattern
+    )
+
+    if ($IsWindows) {
+        return "No windows module path matching $MatchPattern found"
+    }
+
+    return "No macOS/Linux module path matching $MatchPattern found in PSModulePath."
+}

--- a/src/private/release/GetLocalModulePathPattern.ps1
+++ b/src/private/release/GetLocalModulePathPattern.ps1
@@ -1,0 +1,7 @@
+function Get-LocalModulePathPattern {
+    if ($IsWindows) {
+        return '\\Documents\\PowerShell\\Modules'
+    }
+
+    return '/\.local/share/powershell/Modules$'
+}

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -227,6 +227,65 @@ title: Invoke-NovaBuild
         }
     }
 
+    It 'Get-LocalModulePath returns the first matching local module path for the current platform' {
+        InModuleScope $script:moduleName {
+            $originalModulePath = $env:PSModulePath
+            $script:expectedModulePath = if ($IsWindows) {
+                'C:\Users\Stiwi\Documents\PowerShell\Modules'
+            }
+            else {
+                '/Users/stiwi.courage/.local/share/powershell/Modules'
+            }
+
+            $env:PSModulePath = if ($IsWindows) {
+                'C:\Program Files\PowerShell\Modules;C:\Users\Stiwi\Documents\PowerShell\Modules;C:\Temp\Modules'
+            }
+            else {
+                '/usr/local/share/powershell/Modules:/Users/stiwi.courage/.local/share/powershell/Modules:/tmp/modules'
+            }
+
+            Mock Test-Path {
+                param($Path)
+                return $Path -eq $script:expectedModulePath
+            }
+
+            try {
+                Get-LocalModulePath | Should -Be $script:expectedModulePath
+            }
+            finally {
+                $env:PSModulePath = $originalModulePath
+            }
+        }
+    }
+
+    It 'Get-LocalModulePath throws a platform-specific error when no matching path exists' {
+        InModuleScope $script:moduleName {
+            $originalModulePath = $env:PSModulePath
+            $env:PSModulePath = if ($IsWindows) {
+                'C:\Program Files\PowerShell\Modules;C:\Temp\Modules'
+            }
+            else {
+                '/usr/local/share/powershell/Modules:/tmp/modules'
+            }
+
+            Mock Test-Path {$false}
+
+            $expectedError = if ($IsWindows) {
+                'No windows module path matching*'
+            }
+            else {
+                'No macOS/Linux module path matching*'
+            }
+
+            try {
+                {Get-LocalModulePath} | Should -Throw $expectedError
+            }
+            finally {
+                $env:PSModulePath = $originalModulePath
+            }
+        }
+    }
+
     It 'built module keeps Publish-NovaModule local path resolution before build and test' {
         $packagedModulePath = (Get-Module $script:moduleName).Path
 


### PR DESCRIPTION
### Fixed local module path resolution maintainability by refactoring `Get-LocalModulePath` to Code Health `10.0` and adding regression coverage for both the matching and error paths.

- Refactor Get-LocalModulePath for improved maintainability
- Introduce Find-LocalModulePathMatch for path matching logic
- Add Get-LocalModulePathEntryList, Get-LocalModulePathPattern, and Get-LocalModulePathErrorMessage functions
- Implement tests for local module path retrieval and error handling

Closes #4 