### PR TITLE
Update Test-NovaBuild output path and enhance CHANGELOG with links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ The format follows the principles from Keep a Changelog and the project aims to 
   implementation.
 - Internal source files were reorganized into clearer areas such as build, CLI, release, shared, scaffold, and duplicate
   validation.
+- Semantic release support helpers now live in `scripts/release/support/` as one function per file while keeping the
+  existing `Prepare-SemanticRelease.ps1` entrypoint and dot-sourced compatibility loader.
 - `Publish-NovaModule` and `Invoke-NovaRelease` now use a cleaner publish flow that resolves targets before build/test
   steps run.
 - `New-NovaModule` was refactored into smaller pieces, improving maintainability and bringing its Code Health back to
@@ -41,6 +43,8 @@ The format follows the principles from Keep a Changelog and the project aims to 
 - README and command documentation were refreshed to consistently use the Nova command names and describe the
   CLI/release workflow more clearly.
 - Release and test automation files were updated to better support the new Nova workflow.
+- The semantic-release preparation step now rebuilds the changelog footer so release entries keep up-to-date GitHub
+  comparison links.
 - The repository example, local helper workflow, and command documentation were updated to better reflect how
   NovaModuleTools
   is intended to be used in day-to-day development.
@@ -93,6 +97,8 @@ The format follows the principles from Keep a Changelog and the project aims to 
   local quality loop, update documentation, and keep the codebase maintainable.
 - Renamed and refreshed command documentation to match the Nova command model.
 - Documented that `Test-NovaBuild` now places its Pester XML output in `artifacts/TestResults.xml`.
+- Added GitHub comparison links to `CHANGELOG.md` so each release entry and the `Unreleased` section can be traced back
+  to repository diffs.
 
 ## [1.9.0] - 2026-04-10
 
@@ -219,4 +225,30 @@ The format follows the principles from Keep a Changelog and the project aims to 
 ### Added
 - First release to `psgallery`
 - All basic functionality of Module is ready
+
+[Unreleased]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_1.9.0...HEAD
+
+[1.9.0]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_1.8.0...Version_1.9.0
+
+[1.8.0]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_1.7.0...Version_1.8.0
+
+[1.3.0]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_1.2.5-preview...Version_1.3.0
+
+[1.2.0]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_1.1.4-preview...Version_1.2.0
+
+[1.1.3]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_1.1.0...Version_1.1.3
+
+[1.1.0]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_1.0.0...Version_1.1.0
+
+[1.0.0]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.9...Version_1.0.0
+
+[0.0.9]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.8...Version_0.0.9
+
+[0.0.7]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.6...Version_0.0.7
+
+[0.0.6]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.5...Version_0.0.6
+
+[0.0.5]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.4...Version_0.0.5
+
+[0.0.4]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.3...Version_0.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ The format follows the principles from Keep a Changelog and the project aims to 
   adding regression coverage for both the matching and error paths.
 - Fixed resource-copy maintainability by refactoring `Copy-ProjectResource` to Code Health `10.0` and adding regression
   coverage for both `copyResourcesToModuleRoot` modes.
+- Fixed `Test-NovaBuild` so the generated Pester XML report is now written to `artifacts/TestResults.xml` instead of the
+  `dist` folder.
 
 ### Documentation
 
@@ -90,6 +92,7 @@ The format follows the principles from Keep a Changelog and the project aims to 
 - Refreshed the `README.md` contribution guidance so contributors are clearly asked to follow the Nova workflow, run the
   local quality loop, update documentation, and keep the codebase maintainable.
 - Renamed and refreshed command documentation to match the Nova command model.
+- Documented that `Test-NovaBuild` now places its Pester XML output in `artifacts/TestResults.xml`.
 
 ## [1.9.0] - 2026-04-10
 

--- a/README.md
+++ b/README.md
@@ -367,6 +367,9 @@ file in your favorite editor. This command makes it easy to update the semantic 
 
 This is not required for local module builds. In this repository, GitHub Actions uses `semantic-release` on `main` to determine the next version from conventional commits, update `project.json` and `CHANGELOG.md`, create the `Version_<semver>` tag, create the GitHub release, and then publish the built module to PowerShell Gallery.
 
+As part of that prepare step, NovaModuleTools also refreshes the comparison links at the bottom of `CHANGELOG.md` so the
+`[Unreleased]` section and each released version point to the matching GitHub diff view.
+
 If you are running GitHub Actions, use the following yaml workflow template to test, build and publish a module, which helps to automate the process of:
 1. Checking out the repository code.
 1. Installing the `NovaModuleTools` bootstrap module from the PowerShell Gallery.

--- a/README.md
+++ b/README.md
@@ -226,7 +226,8 @@ Test-NovaBuild
 
 This keeps ScriptAnalyzer as a separate code-quality step while `Test-NovaBuild` remains focused on Pester tests.
 When ScriptAnalyzer runs this way, its findings are written to `artifacts/scriptanalyzer.txt` and are not counted as
-Pester test cases.
+Pester test cases. `Test-NovaBuild` also writes the Pester XML report to `artifacts/TestResults.xml` so test output and
+quality artifacts stay in the same place.
 
 ## Commands
 
@@ -308,6 +309,8 @@ All Pester configuration is stored in `project.json`. Run `Test-NovaBuild` (`nov
 default
 `BuildRecursiveFolders=true`, it discovers test files in nested folders under `tests`; set `BuildRecursiveFolders=false`
 to run only top-level `tests/*.Tests.ps1` files, matching Pester's normal test-file convention.
+
+- The generated Pester XML report is written to `artifacts/TestResults.xml`.
 - To skip a test inside the test directory, use `-skip` in a `Describe`/`It`/`Context` block within the Pester test.
 - Use `Get-NovaProjectInfo` (`nova info`) inside Pester to get detailed information about the project and files.
 

--- a/docs/NovaModuleTools/en-US/Test-NovaBuild.md
+++ b/docs/NovaModuleTools/en-US/Test-NovaBuild.md
@@ -30,7 +30,10 @@ This cmdlet has the following aliases,
 
 ## DESCRIPTION
 
-Run Pester tests using the specified configuration and settings as defined in project.json. With the default `BuildRecursiveFolders=true`, test files in nested folders under `tests` are discovered and run. Set `BuildRecursiveFolders=false` to limit discovery to top-level `tests/*.Tests.ps1` files, following Pester's normal test-file convention.
+Run Pester tests using the specified configuration and settings as defined in project.json. With the default
+`BuildRecursiveFolders=true`, test files in nested folders under `tests` are discovered and run. Set
+`BuildRecursiveFolders=false` to limit discovery to top-level `tests/*.Tests.ps1` files, following Pester's normal
+test-file convention. The generated Pester XML report is written to `artifacts/TestResults.xml`.
 
 ## EXAMPLES
 

--- a/example/tests/Pester.Some.Tests.ps1
+++ b/example/tests/Pester.Some.Tests.ps1
@@ -14,10 +14,10 @@ Describe 'NovaExampleModule example project' {
     }
 
     It 'can return greeting metadata for inspection' {
-        $result = Get-ExampleGreeting -Name 'Copilot' -AsObject
+        $result = Get-ExampleGreeting -Name 'CodeScene' -AsObject
 
-        $result.Message | Should -Be 'Hello, Copilot!'
-        $result.Audience | Should -Be 'Copilot'
+        $result.Message | Should -Be 'Hello, CodeScene!'
+        $result.Audience | Should -Be 'CodeScene'
         (Test-Path -LiteralPath $result.ConfigurationPath) | Should -BeTrue
     }
 }

--- a/scripts/release/SemanticReleaseSupport.ps1
+++ b/scripts/release/SemanticReleaseSupport.ps1
@@ -1,117 +1,28 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-function Get-ReleaseDateString {
-    return (Get-Date -Format 'yyyy-MM-dd')
-}
+$script:supportRoot = Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) 'support'
+$script:supportFileList = @(
+    'Get-ReleaseDateString.ps1'
+    'Get-ReleaseRepositoryUrl.ps1'
+    'ConvertTo-ReleaseTagName.ps1'
+    'Read-JsonFile.ps1'
+    'Write-JsonFile.ps1'
+    'Write-ProjectJsonVersion.ps1'
+    'Get-UnreleasedSectionMatch.ps1'
+    'Get-ClearedUnreleasedBody.ps1'
+    'Get-ChangelogReleaseVersionList.ps1'
+    'Get-AvailableReleaseVersionList.ps1'
+    'Get-OrderedReleaseVersionList.ps1'
+    'Get-PreviousReleaseVersion.ps1'
+    'Get-ChangelogWithoutReferenceFooter.ps1'
+    'Get-ChangelogReferenceFooter.ps1'
+    'Format-ReleaseChangelogText.ps1'
+    'Write-ChangelogFileForRelease.ps1'
+)
 
-function Read-JsonFile {
-    param(
-        [Parameter(Mandatory)][string]$Path
-    )
-
-    return (Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -AsHashtable)
-}
-
-function Write-JsonFile {
-    param(
-        [Parameter(Mandatory)][string]$Path,
-        [Parameter(Mandatory)][hashtable]$Data
-    )
-
-    $json = $Data | ConvertTo-Json -Depth 20
-    Set-Content -LiteralPath $Path -Value $json -Encoding utf8
-}
-
-function Write-ProjectJsonVersion {
-    param(
-        [Parameter(Mandatory)][string]$Path,
-        [Parameter(Mandatory)][string]$Version
-    )
-
-    $project = Read-JsonFile -Path $Path
-    $project.Version = $Version
-    Write-JsonFile -Path $Path -Data $project
-}
-
-function Get-UnreleasedSectionMatch {
-    param(
-        [Parameter(Mandatory)][string]$Text
-    )
-
-    $pattern = '(?ms)^##\s+\[Unreleased\]\s*\r?\n(?<body>.*?)(?=^##\s+\[|\z)'
-    $match = [regex]::Match($Text, $pattern)
-
-    if (-not $match.Success) {
-        throw 'Could not find ## [Unreleased] section in CHANGELOG.md.'
-    }
-
-    return $match
-}
-
-function Get-ClearedUnreleasedBody {
-    param(
-        [Parameter(Mandatory)][AllowEmptyString()][string]$Body
-    )
-
-    $headings = @(
-        $Body -split '\r?\n' |
-            Where-Object { $_ -match '^\s*###\s+' } |
-            ForEach-Object { $_.TrimEnd() }
-    )
-
-    if (-not $headings) {
-        return ''
-    }
-
-    return ($headings -join "`n`n")
-}
-
-function Format-ReleaseChangelogText {
-    param(
-        [Parameter(Mandatory)][string]$Text,
-        [Parameter(Mandatory)][string]$Version,
-        [Parameter(Mandatory)][string]$Date
-    )
-
-    $match = Get-UnreleasedSectionMatch -Text $Text
-    $unreleasedBody = $match.Groups['body'].Value.TrimEnd()
-    $clearedUnreleasedBody = Get-ClearedUnreleasedBody -Body $unreleasedBody
-
-    $before = $Text.Substring(0, $match.Index).TrimEnd()
-    $afterStart = $match.Index + $match.Length
-    $after = $Text.Substring($afterStart).TrimStart("`r", "`n")
-
-    $unreleasedLines = @('## [Unreleased]')
-    if (-not [string]::IsNullOrWhiteSpace($clearedUnreleasedBody)) {
-        $unreleasedLines += ''
-        $unreleasedLines += $clearedUnreleasedBody
-    }
-
-    $releaseLines = @("## [$Version] - $Date")
-    if (-not [string]::IsNullOrWhiteSpace($unreleasedBody)) {
-        $releaseLines += ''
-        $releaseLines += $unreleasedBody
-    }
-
-    $sections = @($before, ($unreleasedLines -join "`n"), ($releaseLines -join "`n"))
-    if (-not [string]::IsNullOrWhiteSpace($after)) {
-        $sections += $after
-    }
-
-    return (($sections | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) -join "`n`n").TrimEnd() + "`n"
-}
-
-function Write-ChangelogFileForRelease {
-    param(
-        [Parameter(Mandatory)][string]$Path,
-        [Parameter(Mandatory)][string]$Version,
-        [Parameter(Mandatory)][string]$Date
-    )
-
-    $text = Get-Content -LiteralPath $Path -Raw
-    $updated = Format-ReleaseChangelogText -Text $text -Version $Version -Date $Date
-    Set-Content -LiteralPath $Path -Value $updated -Encoding utf8
+foreach ($supportFile in $script:supportFileList) {
+    . (Join-Path $script:supportRoot $supportFile)
 }
 
 

--- a/scripts/release/support/ConvertTo-ReleaseTagName.ps1
+++ b/scripts/release/support/ConvertTo-ReleaseTagName.ps1
@@ -1,0 +1,8 @@
+function ConvertTo-ReleaseTagName {
+    param(
+        [Parameter(Mandatory)][string]$Version
+    )
+
+    return "Version_$Version"
+}
+

--- a/scripts/release/support/Format-ReleaseChangelogText.ps1
+++ b/scripts/release/support/Format-ReleaseChangelogText.ps1
@@ -1,0 +1,45 @@
+function Format-ReleaseChangelogText {
+    param(
+        [Parameter(Mandatory)][string]$Text,
+        [Parameter(Mandatory)][string]$Version,
+        [Parameter(Mandatory)][string]$Date,
+        [string[]]$AvailableReleaseVersions = (Get-AvailableReleaseVersionList),
+        [string]$RepositoryUrl = (Get-ReleaseRepositoryUrl)
+    )
+
+    $match = Get-UnreleasedSectionMatch -Text $Text
+    $unreleasedBody = $match.Groups['body'].Value.TrimEnd()
+    $clearedUnreleasedBody = Get-ClearedUnreleasedBody -Body $unreleasedBody
+
+    $before = $Text.Substring(0, $match.Index).TrimEnd()
+    $afterStart = $match.Index + $match.Length
+    $after = $Text.Substring($afterStart).TrimStart("`r", "`n")
+
+    $unreleasedLines = @('## [Unreleased]')
+    if (-not [string]::IsNullOrWhiteSpace($clearedUnreleasedBody)) {
+        $unreleasedLines += ''
+        $unreleasedLines += $clearedUnreleasedBody
+    }
+
+    $releaseLines = @("## [$Version] - $Date")
+    if (-not [string]::IsNullOrWhiteSpace($unreleasedBody)) {
+        $releaseLines += ''
+        $releaseLines += $unreleasedBody
+    }
+
+    $sections = @($before, ($unreleasedLines -join "`n"), ($releaseLines -join "`n"))
+    if (-not [string]::IsNullOrWhiteSpace($after)) {
+        $sections += $after
+    }
+
+    $bodyText = (($sections | Where-Object {-not [string]::IsNullOrWhiteSpace($_)}) -join "`n`n").TrimEnd()
+    $bodyWithoutFooter = Get-ChangelogWithoutReferenceFooter -Text $bodyText
+    $referenceFooter = Get-ChangelogReferenceFooter -Text $bodyWithoutFooter -AvailableReleaseVersions $AvailableReleaseVersions -RepositoryUrl $RepositoryUrl
+
+    if ( [string]::IsNullOrWhiteSpace($referenceFooter)) {
+        return $bodyWithoutFooter.TrimEnd() + "`n"
+    }
+
+    return ($bodyWithoutFooter.TrimEnd() + "`n`n" + $referenceFooter.TrimEnd() + "`n")
+}
+

--- a/scripts/release/support/Get-AvailableReleaseVersionList.ps1
+++ b/scripts/release/support/Get-AvailableReleaseVersionList.ps1
@@ -1,0 +1,17 @@
+function Get-AvailableReleaseVersionList {
+    param(
+        [string]$RepositoryRoot = (Get-Location).Path
+    )
+
+    if (-not (Test-Path -LiteralPath (Join-Path $RepositoryRoot '.git'))) {
+        return @()
+    }
+
+    return @(
+    git -C $RepositoryRoot tag --list 'Version_*' |
+            ForEach-Object {$_ -replace '^Version_', ''} |
+            Where-Object {-not [string]::IsNullOrWhiteSpace($_)}
+    )
+}
+
+

--- a/scripts/release/support/Get-ChangelogReferenceFooter.ps1
+++ b/scripts/release/support/Get-ChangelogReferenceFooter.ps1
@@ -1,0 +1,32 @@
+function Get-ChangelogReferenceFooter {
+    param(
+        [Parameter(Mandatory)][string]$Text,
+        [string[]]$AvailableReleaseVersions = (Get-AvailableReleaseVersionList),
+        [string]$RepositoryUrl = (Get-ReleaseRepositoryUrl)
+    )
+
+    $releaseVersions = Get-ChangelogReleaseVersionList -Text $Text
+    if (-not $releaseVersions) {
+        return ''
+    }
+
+    $allKnownVersions = @($releaseVersions + $AvailableReleaseVersions)
+    $footerLines = [System.Collections.Generic.List[string]]::new()
+    $footerLines.Add("[Unreleased]: $RepositoryUrl/compare/$( ConvertTo-ReleaseTagName -Version $releaseVersions[0] )...HEAD")
+
+    foreach ($releaseVersion in $releaseVersions) {
+        $previousVersion = Get-PreviousReleaseVersion -Version $releaseVersion -AvailableVersions $allKnownVersions
+        $currentTag = ConvertTo-ReleaseTagName -Version $releaseVersion
+
+        if ( [string]::IsNullOrWhiteSpace($previousVersion)) {
+            $footerLines.Add("[$releaseVersion]: $RepositoryUrl/releases/tag/$currentTag")
+            continue
+        }
+
+        $previousTag = ConvertTo-ReleaseTagName -Version $previousVersion
+        $footerLines.Add("[$releaseVersion]: $RepositoryUrl/compare/$previousTag...$currentTag")
+    }
+
+    return $footerLines -join "`n"
+}
+

--- a/scripts/release/support/Get-ChangelogReleaseVersionList.ps1
+++ b/scripts/release/support/Get-ChangelogReleaseVersionList.ps1
@@ -1,0 +1,11 @@
+function Get-ChangelogReleaseVersionList {
+    param(
+        [Parameter(Mandatory)][string]$Text
+    )
+
+    return @(
+    [regex]::Matches($Text, '(?m)^##\s+\[(?<version>[^\]]+)\]\s+-\s+') |
+            ForEach-Object {$_.Groups['version'].Value}
+    )
+}
+

--- a/scripts/release/support/Get-ChangelogWithoutReferenceFooter.ps1
+++ b/scripts/release/support/Get-ChangelogWithoutReferenceFooter.ps1
@@ -1,0 +1,26 @@
+function Get-ChangelogWithoutReferenceFooter {
+    param(
+        [Parameter(Mandatory)][string]$Text
+    )
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    foreach ($line in ($Text -split '\r?\n')) {
+        $lines.Add($line)
+    }
+
+    while ($lines.Count -gt 0 -and [string]::IsNullOrWhiteSpace($lines[$lines.Count - 1])) {
+        $lines.RemoveAt($lines.Count - 1)
+    }
+
+    while ($lines.Count -gt 0 -and $lines[$lines.Count - 1] -match '^\[[^\]]+\]:\s+https://github\.com/.+$') {
+        $lines.RemoveAt($lines.Count - 1)
+    }
+
+    while ($lines.Count -gt 0 -and [string]::IsNullOrWhiteSpace($lines[$lines.Count - 1])) {
+        $lines.RemoveAt($lines.Count - 1)
+    }
+
+    return ($lines -join "`n")
+}
+
+

--- a/scripts/release/support/Get-ClearedUnreleasedBody.ps1
+++ b/scripts/release/support/Get-ClearedUnreleasedBody.ps1
@@ -1,0 +1,18 @@
+function Get-ClearedUnreleasedBody {
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Body
+    )
+
+    $headings = @(
+    $Body -split '\r?\n' |
+            Where-Object {$_ -match '^\s*###\s+'} |
+            ForEach-Object {$_.TrimEnd()}
+    )
+
+    if (-not $headings) {
+        return ''
+    }
+
+    return ($headings -join "`n`n")
+}
+

--- a/scripts/release/support/Get-OrderedReleaseVersionList.ps1
+++ b/scripts/release/support/Get-OrderedReleaseVersionList.ps1
@@ -1,0 +1,19 @@
+function Get-OrderedReleaseVersionList {
+    param(
+        [Parameter(Mandatory)][string[]]$Versions
+    )
+
+    return @(
+    $Versions |
+            Sort-Object -Unique |
+            ForEach-Object {
+                [pscustomobject]@{
+                    Version = $_
+                    SemanticVersion = [System.Management.Automation.SemanticVersion]::Parse($_)
+                }
+            } |
+            Sort-Object SemanticVersion |
+            ForEach-Object {$_.Version}
+    )
+}
+

--- a/scripts/release/support/Get-PreviousReleaseVersion.ps1
+++ b/scripts/release/support/Get-PreviousReleaseVersion.ps1
@@ -1,0 +1,18 @@
+function Get-PreviousReleaseVersion {
+    param(
+        [Parameter(Mandatory)][string]$Version,
+        [Parameter(Mandatory)][string[]]$AvailableVersions
+    )
+
+    $orderedVersions = Get-OrderedReleaseVersionList -Versions $AvailableVersions
+    $currentVersionValue = [System.Management.Automation.SemanticVersion]::Parse($Version)
+
+    return @(
+    $orderedVersions |
+            Where-Object {
+                [System.Management.Automation.SemanticVersion]::Parse($_) -lt $currentVersionValue
+            } |
+            Select-Object -Last 1
+    )[0]
+}
+

--- a/scripts/release/support/Get-ReleaseDateString.ps1
+++ b/scripts/release/support/Get-ReleaseDateString.ps1
@@ -1,0 +1,4 @@
+function Get-ReleaseDateString {
+    return (Get-Date -Format 'yyyy-MM-dd')
+}
+

--- a/scripts/release/support/Get-ReleaseRepositoryUrl.ps1
+++ b/scripts/release/support/Get-ReleaseRepositoryUrl.ps1
@@ -1,0 +1,4 @@
+function Get-ReleaseRepositoryUrl {
+    return 'https://github.com/stiwicourage/NovaModuleTools'
+}
+

--- a/scripts/release/support/Get-UnreleasedSectionMatch.ps1
+++ b/scripts/release/support/Get-UnreleasedSectionMatch.ps1
@@ -1,0 +1,15 @@
+function Get-UnreleasedSectionMatch {
+    param(
+        [Parameter(Mandatory)][string]$Text
+    )
+
+    $pattern = '(?ms)^##\s+\[Unreleased\]\s*\r?\n(?<body>.*?)(?=^##\s+\[|\z)'
+    $match = [regex]::Match($Text, $pattern)
+
+    if (-not $match.Success) {
+        throw 'Could not find ## [Unreleased] section in CHANGELOG.md.'
+    }
+
+    return $match
+}
+

--- a/scripts/release/support/Read-JsonFile.ps1
+++ b/scripts/release/support/Read-JsonFile.ps1
@@ -1,0 +1,8 @@
+function Read-JsonFile {
+    param(
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    return (Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -AsHashtable)
+}
+

--- a/scripts/release/support/Write-ChangelogFileForRelease.ps1
+++ b/scripts/release/support/Write-ChangelogFileForRelease.ps1
@@ -1,0 +1,12 @@
+function Write-ChangelogFileForRelease {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$Version,
+        [Parameter(Mandatory)][string]$Date
+    )
+
+    $text = Get-Content -LiteralPath $Path -Raw
+    $updated = Format-ReleaseChangelogText -Text $text -Version $Version -Date $Date
+    Set-Content -LiteralPath $Path -Value $updated -Encoding utf8
+}
+

--- a/scripts/release/support/Write-JsonFile.ps1
+++ b/scripts/release/support/Write-JsonFile.ps1
@@ -1,0 +1,10 @@
+function Write-JsonFile {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][hashtable]$Data
+    )
+
+    $json = $Data | ConvertTo-Json -Depth 20
+    Set-Content -LiteralPath $Path -Value $json -Encoding utf8
+}
+

--- a/scripts/release/support/Write-ProjectJsonVersion.ps1
+++ b/scripts/release/support/Write-ProjectJsonVersion.ps1
@@ -1,0 +1,11 @@
+function Write-ProjectJsonVersion {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$Version
+    )
+
+    $project = Read-JsonFile -Path $Path
+    $project.Version = $Version
+    Write-JsonFile -Path $Path -Data $project
+}
+

--- a/src/public/TestNovaBuild.ps1
+++ b/src/public/TestNovaBuild.ps1
@@ -33,7 +33,14 @@ function Test-NovaBuild {
         $pesterConfig.Output.RenderMode = $OutputRenderMode
     }
 
-    $pesterConfig.TestResult.OutputPath = './dist/TestResults.xml'
+    $testResultPath = [System.IO.Path]::Join($data.ProjectRoot, 'artifacts', 'TestResults.xml')
+    $testResultDirectory = Split-Path -Parent $testResultPath
+
+    if (-not (Test-Path -LiteralPath $testResultDirectory)) {
+        $null = New-Item -ItemType Directory -Path $testResultDirectory -Force
+    }
+
+    $pesterConfig.TestResult.OutputPath = $testResultPath
     $TestResult = Invoke-Pester -Configuration $pesterConfig
     if ($TestResult.Result -ne 'Passed') {
         Write-Error 'Tests failed' -ErrorAction Stop

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -89,6 +89,7 @@ title: Invoke-NovaBuild
 
     It 'Test-NovaBuild applies tag filters to Pester config' {
         InModuleScope $script:moduleName {
+            $projectRoot = '/tmp/nova-project'
             $cfg = [pscustomobject]@{
                 Run = [pscustomobject]@{Path = $null; PassThru = $false; Exit = $false; Throw = $false}
                 Filter = [pscustomobject]@{Tag = @(); ExcludeTag = @()}
@@ -96,19 +97,29 @@ title: Invoke-NovaBuild
             }
 
             Mock Test-ProjectSchema {}
-            Mock Get-NovaProjectInfo {[pscustomobject]@{Pester = @{}; BuildRecursiveFolders = $true; TestsDir = 'tests'}}
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    Pester = @{}
+                    BuildRecursiveFolders = $true
+                    TestsDir = 'tests'
+                    ProjectRoot = $projectRoot
+                }
+            }
             Mock New-PesterConfiguration {$cfg}
+            Mock Test-Path {$true}
             Mock Invoke-Pester {[pscustomobject]@{Result = 'Passed'}}
 
             Test-NovaBuild -TagFilter @('fast') -ExcludeTagFilter @('slow')
 
             $cfg.Filter.Tag | Should -Be @('fast')
             $cfg.Filter.ExcludeTag | Should -Be @('slow')
+            $cfg.TestResult.OutputPath | Should -Be ([System.IO.Path]::Join($projectRoot, 'artifacts', 'TestResults.xml'))
         }
     }
 
     It 'Test-NovaBuild can override Pester console output settings' {
         InModuleScope $script:moduleName {
+            $projectRoot = '/tmp/nova-project'
             $cfg = [pscustomobject]@{
                 Run = [pscustomobject]@{Path = $null; PassThru = $false; Exit = $false; Throw = $false}
                 Filter = [pscustomobject]@{Tag = @(); ExcludeTag = @()}
@@ -117,14 +128,23 @@ title: Invoke-NovaBuild
             }
 
             Mock Test-ProjectSchema {}
-            Mock Get-NovaProjectInfo {[pscustomobject]@{Pester = @{}; BuildRecursiveFolders = $true; TestsDir = 'tests'}}
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    Pester = @{}
+                    BuildRecursiveFolders = $true
+                    TestsDir = 'tests'
+                    ProjectRoot = $projectRoot
+                }
+            }
             Mock New-PesterConfiguration {$cfg}
+            Mock Test-Path {$true}
             Mock Invoke-Pester {[pscustomobject]@{Result = 'Passed'}}
 
             Test-NovaBuild -OutputVerbosity Normal -OutputRenderMode Plaintext
 
             $cfg.Output.Verbosity | Should -Be 'Normal'
             $cfg.Output.RenderMode | Should -Be 'Plaintext'
+            $cfg.TestResult.OutputPath | Should -Be ([System.IO.Path]::Join($projectRoot, 'artifacts', 'TestResults.xml'))
         }
     }
 

--- a/tests/SemanticRelease.Tests.ps1
+++ b/tests/SemanticRelease.Tests.ps1
@@ -3,6 +3,31 @@ BeforeAll {
 }
 
 Describe 'Semantic release support' {
+    It 'loads the split support functions through the compatibility entrypoint' {
+        $expectedFunctionList = @(
+            'Get-ReleaseDateString'
+            'Get-ReleaseRepositoryUrl'
+            'ConvertTo-ReleaseTagName'
+            'Read-JsonFile'
+            'Write-JsonFile'
+            'Write-ProjectJsonVersion'
+            'Get-UnreleasedSectionMatch'
+            'Get-ClearedUnreleasedBody'
+            'Get-ChangelogReleaseVersionList'
+            'Get-AvailableReleaseVersionList'
+            'Get-OrderedReleaseVersionList'
+            'Get-PreviousReleaseVersion'
+            'Get-ChangelogWithoutReferenceFooter'
+            'Get-ChangelogReferenceFooter'
+            'Format-ReleaseChangelogText'
+            'Write-ChangelogFileForRelease'
+        )
+
+        foreach ($functionName in $expectedFunctionList) {
+            Get-Command -Name $functionName -CommandType Function -ErrorAction Stop | Should -Not -BeNullOrEmpty
+        }
+    }
+
     It 'moves unreleased notes into a versioned changelog section and preserves headings in Unreleased' {
         $date = '2026-04-08'
         $changelog = @'
@@ -24,7 +49,7 @@ All notable changes to this project will be documented in this file.
 - Previous release notes
 '@
 
-        $updated = Format-ReleaseChangelogText -Text $changelog -Version '2.0.0' -Date $date
+        $updated = Format-ReleaseChangelogText -Text $changelog -Version '2.0.0' -Date $date -AvailableReleaseVersions @('1.6.0', '1.7.0', '2.0.0')
         $unreleasedBody = (Get-UnreleasedSectionMatch -Text $updated).Groups['body'].Value
 
         $updated | Should -Match '## \[2\.0\.0\] - 2026-04-08'
@@ -32,6 +57,50 @@ All notable changes to this project will be documented in this file.
         $updated | Should -Match '(?s)## \[2\.0\.0\] - 2026-04-08.*Fixed CI reporting'
         $unreleasedBody | Should -Match '(?s)^\s*### Added\s+### Fixed\s*$'
         $unreleasedBody | Should -Not -Match 'Added semantic-release support'
+        $updated | Should -Match '\[Unreleased\]: https://github\.com/stiwicourage/NovaModuleTools/compare/Version_2\.0\.0\.\.\.HEAD'
+        $updated | Should -Match '\[2\.0\.0\]: https://github\.com/stiwicourage/NovaModuleTools/compare/Version_1\.7\.0\.\.\.Version_2\.0\.0'
+        $updated | Should -Match '\[1\.7\.0\]: https://github\.com/stiwicourage/NovaModuleTools/compare/Version_1\.6\.0\.\.\.Version_1\.7\.0'
+    }
+
+    It 'rebuilds changelog comparison links from release headings without duplicating old footer entries' {
+        $changelog = @'
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+## [1.9.0] - 2026-04-10
+
+### Added
+- Current release notes
+
+## [1.8.0] - 2026-04-08
+
+### Added
+- Previous release notes
+
+[Unreleased]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_1.8.0...HEAD
+[1.9.0]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_1.7.0...Version_1.9.0
+[1.8.0]: https://github.com/stiwicourage/NovaModuleTools/releases/tag/Version_1.8.0
+'@
+
+        $footer = Get-ChangelogReferenceFooter -Text $changelog -AvailableReleaseVersions @('1.7.0', '1.8.0', '1.9.0')
+        $updated = Format-ReleaseChangelogText -Text $changelog -Version '1.9.1' -Date '2026-04-12' -AvailableReleaseVersions @('1.7.0', '1.8.0', '1.9.0', '1.9.1')
+
+        $footer | Should -Be @'
+[Unreleased]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_1.9.0...HEAD
+[1.9.0]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_1.8.0...Version_1.9.0
+[1.8.0]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_1.7.0...Version_1.8.0
+'@.TrimEnd()
+
+        ([regex]::Matches($updated, '(?m)^\[Unreleased\]:').Count) | Should -Be 1
+        $updated | Should -Match '\[Unreleased\]: https://github\.com/stiwicourage/NovaModuleTools/compare/Version_1\.9\.1\.\.\.HEAD'
+        $updated | Should -Match '\[1\.9\.1\]: https://github\.com/stiwicourage/NovaModuleTools/compare/Version_1\.9\.0\.\.\.Version_1\.9\.1'
+        $updated | Should -Match '\[1\.9\.0\]: https://github\.com/stiwicourage/NovaModuleTools/compare/Version_1\.8\.0\.\.\.Version_1\.9\.0'
+        $updated | Should -Match '\[1\.8\.0\]: https://github\.com/stiwicourage/NovaModuleTools/compare/Version_1\.7\.0\.\.\.Version_1\.8\.0'
     }
 
     It 'updates project.json version' {


### PR DESCRIPTION
- Semantic release support helpers now live in `scripts/release/support/` as one function per file while keeping the
  existing `Prepare-SemanticRelease.ps1` entrypoint and dot-sourced compatibility loader.
- The semantic-release preparation step now rebuilds the changelog footer so release entries keep up-to-date GitHub
  comparison links.
- Fixed `Test-NovaBuild` so the generated Pester XML report is now written to `artifacts/TestResults.xml` instead of the
  `dist` folder.
- Documented that `Test-NovaBuild` now places its Pester XML output in `artifacts/TestResults.xml`.
- Added GitHub comparison links to `CHANGELOG.md` so each release entry and the `Unreleased` section can be traced back
  to repository diffs.
  
  Closes #7 