### PR TITLE
Improve Nova CLI commands and enhance version reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ The format follows the principles from Keep a Changelog and the project aims to 
 
 ### Changed
 
+- `nova --version` now reports the installed `NovaModuleTools` module version, while `nova version` reports the
+  current project version from `project.json`.
 - BREAKING CHANGE: The codebase is now fully centered on the Nova command model instead of a mixed MT/Nova
   implementation.
 - Internal CI helper scripts now live under `scripts/build/ci/` so internal project automation stays grouped under one

--- a/README.md
+++ b/README.md
@@ -356,10 +356,12 @@ Invoke-NovaBuild -Verbose
 nova build
 ```
 
-### Get-NovaProjectInfo (`nova info` / `nova --version`)
+### Get-NovaProjectInfo (`nova info` / `nova version`)
 
 This function provides complete info about the project, which can be used in Pester tests or for general
-troubleshooting. Use `nova info` for the full project object or `nova --version` for just the version.
+troubleshooting. Use `nova info` for the full project object or `nova version` for just the project version.
+
+Use `nova --version` when you want to see the installed `NovaModuleTools` module version on the current machine.
 
 ### Test-NovaBuild (`nova test`)
 

--- a/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
@@ -28,7 +28,8 @@ Invoke-NovaCli [[-Command] <string>] [[-Arguments] <string[]>] [<CommonParameter
 `Invoke-NovaCli` is the cmdlet behind the `nova` alias. In day-to-day usage, the intended experience is to run the
 `nova` command rather than call `Invoke-NovaCli` directly.
 
-It dispatches high-level commands such as `nova info`, `nova --version`, `nova --help`, `nova build`, `nova test`,
+It dispatches high-level commands such as `nova info`, `nova version`, `nova --version`, `nova --help`, `nova build`,
+`nova test`,
 `nova init`, `nova publish`, `nova bump`, and `nova release` to the matching Nova cmdlet.
 
 Use `Invoke-NovaCli` when you need a scriptable PowerShell command entrypoint. Use `nova` when you want the more
@@ -45,9 +46,17 @@ from zsh/bash on macOS or Linux, install the launcher once with `Install-NovaCli
 nova --version
 ```
 
-Returns the version from `project.json`.
+Returns the installed `NovaModuleTools` module version.
 
 ### EXAMPLE 2
+
+```powershell
+nova version
+```
+
+Returns the current project version from `project.json`.
+
+### EXAMPLE 3
 
 ```powershell
 nova build
@@ -55,7 +64,7 @@ nova build
 
 Builds the module using `Invoke-NovaBuild`.
 
-### EXAMPLE 3
+### EXAMPLE 4
 
 ```powershell
 nova publish --repository PSGallery --apikey ***
@@ -63,7 +72,7 @@ nova publish --repository PSGallery --apikey ***
 
 Parses CLI arguments and publishes using `Publish-NovaModule`.
 
-### EXAMPLE 4
+### EXAMPLE 5
 
 ```powershell
 nova --help
@@ -71,7 +80,7 @@ nova --help
 
 Displays the built-in Nova CLI help text.
 
-### EXAMPLE 5
+### EXAMPLE 6
 
 ```powershell
 Invoke-NovaCli -Command build
@@ -83,7 +92,8 @@ Shows the equivalent scripted PowerShell form behind `nova build`.
 
 ### -Command
 
-The command to execute. Supported values: `info`, `--version`, `--help`, `build`, `test`, `init`, `publish`, `bump`,
+The command to execute. Supported values: `info`, `version`, `--version`, `--help`, `build`, `test`, `init`, `publish`,
+`bump`,
 `release`.
 
 ```yaml
@@ -99,7 +109,7 @@ ParameterSets:
     ValueFromPipelineByPropertyName: false
     ValueFromRemainingArguments: false
 DontShow: false
-AcceptedValues: [ info, --version, --help, build, test, init, publish, bump, release ]
+AcceptedValues: [ info, version, --version, --help, build, test, init, publish, bump, release ]
 HelpMessage: ''
 ```
 

--- a/project.json
+++ b/project.json
@@ -1,7 +1,7 @@
 {
   "ProjectName": "NovaModuleTools",
   "Description": "NovaModuleTools is an enterprise-focused evolution of ModuleTools, designed for large-scale PowerShell projects with a strong emphasis on structure, maintainability, and automated CI/CD pipelines.",
-  "Version": "1.9.5",
+  "Version": "1.9.6",
   "copyResourcesToModuleRoot": false,
   "BuildRecursiveFolders": true,
   "SetSourcePath": true,

--- a/src/private/cli/GetNovaCliHelp.ps1
+++ b/src/private/cli/GetNovaCliHelp.ps1
@@ -9,6 +9,7 @@ start a new module project
 
 work with the current project
    info       Show project information
+   version    Show the current project version from project.json
    build      Build the module into the dist folder
    test       Run Pester tests for the project
    bump       Update the module version in project.json
@@ -19,11 +20,12 @@ publish and release
 
 global options
    --help     Show this help message
-   --version  Show the project version from project.json
+   --version  Show the installed NovaModuleTools module version
 
 Examples:
    nova init ~/Work
    nova info
+   nova version
    nova build
    nova test
    nova publish --local

--- a/src/private/cli/GetNovaCliInstalledVersion.ps1
+++ b/src/private/cli/GetNovaCliInstalledVersion.ps1
@@ -1,0 +1,7 @@
+function Get-NovaCliInstalledVersion {
+    [CmdletBinding()]
+    param()
+
+    return $ExecutionContext.SessionState.Module.Version.ToString()
+}
+

--- a/src/public/InvokeNovaCli.ps1
+++ b/src/public/InvokeNovaCli.ps1
@@ -3,7 +3,6 @@ function Invoke-NovaCli {
     [Alias('nova')]
     param(
         [Parameter(Position = 0)]
-        [ValidateSet('info', '--version', '--help', 'build', 'test', 'init', 'publish', 'bump', 'release')]
         [string]$Command = '--help',
 
         [Parameter(Position = 1, ValueFromRemainingArguments)]
@@ -14,11 +13,8 @@ function Invoke-NovaCli {
         'info' {
             return Get-NovaProjectInfo
         }
-        '--version' {
+        'version' {
             return Get-NovaProjectInfo -Version
-        }
-        '--help' {
-            return Get-NovaCliHelp
         }
         'build' {
             return Invoke-NovaBuild
@@ -43,6 +39,15 @@ function Invoke-NovaCli {
         'release' {
             $options = ConvertFrom-NovaCliArgument -Arguments $Arguments
             return Invoke-NovaRelease -PublishOption $options
+        }
+        '--version' {
+            return Get-NovaCliInstalledVersion
+        }
+        '--help' {
+            return Get-NovaCliHelp
+        }
+        default {
+            throw "Unknown command: <$Command> | Use 'nova --help' to see available commands."
         }
     }
 }

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -379,7 +379,7 @@ title: Invoke-NovaBuild
     It 'Install-NovaCli copies the launcher and the installed command returns CLI help' {
         $targetDirectory = Join-Path $TestDrive 'bin'
         $installedPath = Join-Path $targetDirectory 'nova'
-        $projectVersion = $script:projectInfo.Version
+        $installedModuleVersion = (Get-Module $script:moduleName).Version.ToString()
         $originalModulePath = $env:PSModulePath
         $modulePathSeparator = [string][System.IO.Path]::PathSeparator
         $distParent = Split-Path -Parent $distModuleDir
@@ -402,19 +402,29 @@ title: Invoke-NovaBuild
             $helpExitCode | Should -Be 0
             $versionExitCode | Should -Be 0
             $helpText | Should -Match 'usage: nova \[--version\] \[--help\] <command> \[<args>\]'
-            $versionText | Should -Match ([regex]::Escape($projectVersion))
+            $helpText | Should -Match 'version\s+Show the current project version from project.json'
+            $versionText | Should -Match ([regex]::Escape($installedModuleVersion))
         }
         finally {
             $env:PSModulePath = $originalModulePath
         }
     }
 
-    It 'Invoke-NovaCli --version maps to Get-NovaProjectInfo -Version' {
+    It 'Invoke-NovaCli version maps to Get-NovaProjectInfo -Version' {
         InModuleScope $script:moduleName {
             Mock Get-NovaProjectInfo {'1.2.3'} -ParameterFilter {$Version}
 
-            Invoke-NovaCli --version | Should -Be '1.2.3'
+            Invoke-NovaCli version | Should -Be '1.2.3'
             Assert-MockCalled Get-NovaProjectInfo -Times 1 -ParameterFilter {$Version}
+        }
+    }
+
+    It 'Invoke-NovaCli --version returns the installed NovaModuleTools version' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaCliInstalledVersion {'9.9.9'}
+
+            Invoke-NovaCli --version | Should -Be '9.9.9'
+            Assert-MockCalled Get-NovaCliInstalledVersion -Times 1
         }
     }
 
@@ -424,6 +434,8 @@ title: Invoke-NovaBuild
 
             $result | Should -Match 'usage: nova \[--version\] \[--help\] <command> \[<args>\]'
             $result | Should -Match 'init\s+Create a new Nova module scaffold'
+            $result | Should -Match 'version\s+Show the current project version from project.json'
+            $result | Should -Match '--version\s+Show the installed NovaModuleTools module version'
             $result | Should -Match 'publish\s+Build, test, and publish the module locally or to a repository'
         }
     }
@@ -447,6 +459,12 @@ title: Invoke-NovaBuild
     It 'Invoke-NovaCli throws on unsupported argument' {
         InModuleScope $script:moduleName {
             {Invoke-NovaCli publish --bogus} | Should -Throw 'Unknown argument*'
+        }
+    }
+
+    It 'Invoke-NovaCli throws on an unknown top-level command' {
+        InModuleScope $script:moduleName {
+            {Invoke-NovaCli banana} | Should -Throw 'Unknown command: <banana*'
         }
     }
 }


### PR DESCRIPTION
- `nova --version` now reports the installed `NovaModuleTools` module version, while `nova version` reports the
  current project version from `project.json`.