### PR TITLE
Add and update user-focused landing page for NovaModuleTools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format follows the principles from Keep a Changelog and the project aims to 
 
 ### Added
 
+- Added a user-focused public landing page under `docs/public/` for developers who want a simpler introduction to
+  NovaModuleTools and its module workflow.
 - New Nova release and publish building blocks to support:
     - publishing to a local module directory
     - publishing to a repository

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Whether you're creating simple or robust modules, NovaModuleTools streamlines th
 
 The structure of the NovaModuleTools module is meticulously designed according to PowerShell best practices for module development. While some design decisions may seem unconventional, they are made to ensure that NovaModuleTools and the process of building modules remain straightforward and easy to manage.
 
+If you want a more user-focused overview of what NovaModuleTools does and how to get started without diving into all
+repository details, see the public landing page in `docs/public/index.html`.
+
 ## Install | [![NovaModuleTools@PowerShell Gallery][BadgeIOCount]][PSGalleryLink]
 ```PowerShell
 Install-Module -Name NovaModuleTools

--- a/docs/public/assets/site.css
+++ b/docs/public/assets/site.css
@@ -1,0 +1,362 @@
+:root {
+    --bg: #0b1020;
+    --bg-soft: #121938;
+    --panel: rgba(255, 255, 255, 0.08);
+    --panel-strong: rgba(255, 255, 255, 0.12);
+    --text: #eef3ff;
+    --muted: #b8c3df;
+    --accent: #6ee7b7;
+    --accent-strong: #22c55e;
+    --outline: rgba(255, 255, 255, 0.12);
+    --shadow: 0 20px 60px rgba(0, 0, 0, 0.28);
+    --radius: 22px;
+    --max-width: 1120px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    line-height: 1.6;
+    color: var(--text);
+    background:
+        radial-gradient(circle at top left, #1d2a5b 0%, transparent 34%),
+        radial-gradient(circle at top right, #0f6d66 0%, transparent 25%),
+        linear-gradient(180deg, #0b1020 0%, #0f1731 48%, #0d1327 100%);
+}
+
+code,
+pre {
+    font-family: "SFMono-Regular", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+code {
+    background: rgba(255, 255, 255, 0.08);
+    padding: 0.15rem 0.35rem;
+    border-radius: 8px;
+}
+
+pre {
+    margin: 0;
+    padding: 1rem 1.1rem;
+    overflow-x: auto;
+    background: #0c1329;
+    border: 1px solid var(--outline);
+    border-radius: 18px;
+}
+
+pre code {
+    background: transparent;
+    padding: 0;
+}
+
+.hero,
+.section,
+.footer {
+    padding: 2rem 1.5rem;
+}
+
+.hero {
+    max-width: var(--max-width);
+    margin: 0 auto;
+    min-height: 100vh;
+    display: grid;
+    grid-template-columns: 1.15fr 0.85fr;
+    gap: 2rem;
+    align-items: center;
+}
+
+.hero__content,
+.hero__panel,
+.section__inner,
+.footer__inner {
+    width: 100%;
+}
+
+.eyebrow {
+    display: inline-flex;
+    margin: 0 0 1rem;
+    padding: 0.35rem 0.8rem;
+    border-radius: 999px;
+    background: rgba(110, 231, 183, 0.12);
+    color: var(--accent);
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    font-size: 0.8rem;
+}
+
+h1,
+h2,
+h3 {
+    margin: 0 0 1rem;
+    line-height: 1.12;
+}
+
+h1 {
+    font-size: clamp(2.6rem, 5vw, 4.6rem);
+    max-width: 12ch;
+}
+
+h2 {
+    font-size: clamp(1.8rem, 3vw, 2.7rem);
+}
+
+h3 {
+    font-size: 1.15rem;
+}
+
+p {
+    margin: 0 0 1rem;
+    color: var(--muted);
+}
+
+.lead {
+    font-size: 1.1rem;
+    max-width: 62ch;
+}
+
+.hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.9rem;
+    margin: 1.6rem 0;
+}
+
+.button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 48px;
+    padding: 0.9rem 1.25rem;
+    border-radius: 999px;
+    text-decoration: none;
+    font-weight: 700;
+    transition: transform 140ms ease, box-shadow 140ms ease, background 140ms ease;
+    box-shadow: var(--shadow);
+}
+
+.button:hover {
+    transform: translateY(-1px);
+}
+
+.button--primary {
+    background: linear-gradient(135deg, var(--accent) 0%, #4ade80 100%);
+    color: #082113;
+}
+
+.button--secondary {
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--text);
+    border: 1px solid var(--outline);
+}
+
+.hero__signals {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    padding: 0;
+    margin: 1.25rem 0 0;
+    list-style: none;
+}
+
+.hero__signals li {
+    padding: 0.55rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid var(--outline);
+    color: var(--text);
+    font-size: 0.95rem;
+}
+
+.hero__panel {
+    display: grid;
+    gap: 1rem;
+}
+
+.panel-card,
+.info-card,
+.step-card,
+.callout,
+.code-window,
+.cta-banner,
+.faq-list details {
+    background: var(--panel);
+    border: 1px solid var(--outline);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    backdrop-filter: blur(12px);
+}
+
+.panel-card {
+    padding: 1.2rem;
+}
+
+.panel-step,
+.step-number {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 999px;
+    background: rgba(110, 231, 183, 0.16);
+    color: var(--accent);
+    font-weight: 800;
+    margin-bottom: 0.8rem;
+}
+
+.section {
+    padding-top: 4.5rem;
+    padding-bottom: 4.5rem;
+}
+
+.section--muted {
+    background: rgba(255, 255, 255, 0.03);
+    border-top: 1px solid rgba(255, 255, 255, 0.04);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.section--accent {
+    background: linear-gradient(180deg, rgba(110, 231, 183, 0.08), rgba(34, 197, 94, 0.04));
+}
+
+.section--faq {
+    padding-bottom: 5rem;
+}
+
+.section__inner,
+.footer__inner {
+    max-width: var(--max-width);
+    margin: 0 auto;
+}
+
+.narrow {
+    max-width: 760px;
+}
+
+.section-heading {
+    max-width: 760px;
+    margin-bottom: 2rem;
+}
+
+.card-grid,
+.steps {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.1rem;
+}
+
+.info-card,
+.step-card,
+.callout,
+.code-window {
+    padding: 1.35rem;
+}
+
+.split {
+    display: grid;
+    grid-template-columns: 1.1fr 0.9fr;
+    gap: 1.4rem;
+    align-items: center;
+}
+
+.check-list,
+.plain-list {
+    padding-left: 1.15rem;
+    color: var(--muted);
+}
+
+.check-list li,
+.plain-list li {
+    margin-bottom: 0.7rem;
+}
+
+.callout h3,
+.cta-banner h3 {
+    margin-bottom: 0.5rem;
+}
+
+.cta-banner {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.35rem;
+}
+
+.faq-list {
+    display: grid;
+    gap: 0.9rem;
+}
+
+.faq-list details {
+    padding: 1rem 1.1rem;
+}
+
+.faq-list summary {
+    cursor: pointer;
+    font-weight: 700;
+    color: var(--text);
+}
+
+.faq-list summary::marker {
+    color: var(--accent);
+}
+
+.footer {
+    padding-top: 0;
+    padding-bottom: 4rem;
+}
+
+.footer__inner {
+    text-align: center;
+    max-width: 780px;
+}
+
+@media (max-width: 960px) {
+    .hero,
+    .split,
+    .card-grid,
+    .steps,
+    .cta-banner {
+        grid-template-columns: 1fr;
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .hero {
+        min-height: auto;
+        padding-top: 4rem;
+        padding-bottom: 2rem;
+    }
+
+    h1 {
+        max-width: none;
+    }
+}
+
+@media (max-width: 640px) {
+    body {
+        font-size: 16px;
+    }
+
+    .hero,
+    .section,
+    .footer {
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
+
+    .button {
+        width: 100%;
+    }
+}
+

--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1" name="viewport">
+    <title>NovaModuleTools — Build consistent, well-structured PowerShell modules</title>
+    <meta content="NovaModuleTools helps developers create consistent, correctly structured PowerShell modules with less guesswork and a smoother path from scaffold to build, test, and publish."
+          name="description">
+    <link href="./assets/site.css" rel="stylesheet">
+</head>
+<body>
+<header class="hero">
+    <div class="hero__content">
+        <p class="eyebrow">NovaModuleTools for end users</p>
+        <h1>Build consistent, correctly structured PowerShell modules without reinventing the workflow</h1>
+        <p class="lead">
+            NovaModuleTools gives you a practical starting point for PowerShell module development: scaffold a project,
+            follow a clear folder structure, build a distributable module, and run tests with a repeatable workflow.
+        </p>
+        <div class="hero__actions">
+            <a class="button button--primary"
+               href="https://github.com/stiwicourage/NovaModuleTools/blob/main/README.md">Read the quick start</a>
+            <a class="button button--secondary"
+               href="https://github.com/stiwicourage/NovaModuleTools/tree/main/example">Open the working example</a>
+        </div>
+        <ul class="hero__signals">
+            <li>Clear project structure</li>
+            <li>Fast scaffold-to-build workflow</li>
+            <li>Beginner-friendly path into PowerShell modules</li>
+        </ul>
+    </div>
+    <div aria-label="Nova workflow summary" class="hero__panel">
+        <div class="panel-card">
+            <span class="panel-step">1</span>
+            <strong>Scaffold</strong>
+            <p>Start with <code>nova init</code> or <code>New-NovaModule</code>.</p>
+        </div>
+        <div class="panel-card">
+            <span class="panel-step">2</span>
+            <strong>Build</strong>
+            <p>Turn your source files into a real module with <code>nova build</code>.</p>
+        </div>
+        <div class="panel-card">
+            <span class="panel-step">3</span>
+            <strong>Test</strong>
+            <p>Run <code>nova test</code> and validate the built result, not just loose scripts.</p>
+        </div>
+    </div>
+</header>
+
+<main>
+    <section class="section section--muted">
+        <div class="section__inner narrow">
+            <h2>Who this page is for</h2>
+            <p>
+                This page is for developers who want to use NovaModuleTools to create PowerShell modules, especially if
+                they do <strong>not</strong> already feel confident about PowerShell module structure, build flow, or
+                best practices.
+            </p>
+            <p>
+                It is intentionally focused on the user experience — what NovaModuleTools helps you do, why it matters,
+                and how to get started quickly.
+            </p>
+        </div>
+    </section>
+
+    <section class="section">
+        <div class="section__inner">
+            <div class="section-heading">
+                <h2>Why developers use NovaModuleTools</h2>
+                <p>
+                    Most PowerShell module problems do not start with the business logic. They start with inconsistent
+                    structure, unclear conventions, ad-hoc packaging, and test flows that are hard to repeat.
+                </p>
+            </div>
+            <div class="card-grid">
+                <article class="info-card">
+                    <h3>Reduce guesswork</h3>
+                    <p>Use a known layout for public functions, private helpers, classes, resources, tests, and
+                        output.</p>
+                </article>
+                <article class="info-card">
+                    <h3>Build with confidence</h3>
+                    <p>Generate a real module in <code>dist/</code> so you can validate the same shape you plan to
+                        publish.</p>
+                </article>
+                <article class="info-card">
+                    <h3>Stay consistent over time</h3>
+                    <p>Keep module development predictable across one project or many projects in the same
+                        organization.</p>
+                </article>
+                <article class="info-card">
+                    <h3>Learn by doing</h3>
+                    <p>Start from a scaffold or inspect the included example project when you want a working
+                        reference.</p>
+                </article>
+            </div>
+        </div>
+    </section>
+
+    <section class="section section--accent">
+        <div class="section__inner split">
+            <div>
+                <h2>What you get out of the box</h2>
+                <ul class="check-list">
+                    <li>A scaffolded project with a practical PowerShell module layout</li>
+                    <li>A build flow that combines your source into a module under <code>dist/</code></li>
+                    <li>Test support built around validating the built module result</li>
+                    <li>Support for resources, classes, manifest settings, and help generation</li>
+                    <li>A CLI workflow through <code>nova</code> or the PowerShell cmdlets directly</li>
+                </ul>
+            </div>
+            <aside class="callout">
+                <h3>Good fit if you want to…</h3>
+                <p>
+                    create modules faster, enforce a consistent structure, and give yourself or your team a cleaner path
+                    from idea to build, test, and release.
+                </p>
+            </aside>
+        </div>
+    </section>
+
+    <section class="section">
+        <div class="section__inner">
+            <div class="section-heading">
+                <h2>Start here in 3 steps</h2>
+                <p>You do not need to know everything about PowerShell modules before you start.</p>
+            </div>
+            <div class="steps">
+                <article class="step-card">
+                    <span class="step-number">01</span>
+                    <h3>Install NovaModuleTools</h3>
+                    <pre><code>Install-Module -Name NovaModuleTools
+Import-Module NovaModuleTools</code></pre>
+                    <p>If you want a shell command on macOS/Linux, install the launcher with
+                        <code>Install-NovaCli</code>.</p>
+                </article>
+                <article class="step-card">
+                    <span class="step-number">02</span>
+                    <h3>Create a module scaffold</h3>
+                    <pre><code>nova init</code></pre>
+                    <p>Answer the prompts and let NovaModuleTools create the project structure for you.</p>
+                </article>
+                <article class="step-card">
+                    <span class="step-number">03</span>
+                    <h3>Build and test your module</h3>
+                    <pre><code>nova build
+nova test</code></pre>
+                    <p>This gives you a repeatable workflow from source files to a built module in <code>dist/</code>.
+                    </p>
+                </article>
+            </div>
+        </div>
+    </section>
+
+    <section class="section section--muted">
+        <div class="section__inner split">
+            <div>
+                <h2>What the project structure helps you do</h2>
+                <p>
+                    NovaModuleTools keeps the structure explicit so it is easier to understand what belongs where.
+                </p>
+                <ul class="plain-list">
+                    <li><strong><code>src/public</code></strong> — functions exported from the module</li>
+                    <li><strong><code>src/private</code></strong> — internal helpers used by your public commands</li>
+                    <li><strong><code>src/classes</code></strong> — classes and enums</li>
+                    <li><strong><code>src/resources</code></strong> — bundled files such as JSON config</li>
+                    <li><strong><code>tests</code></strong> — Pester tests</li>
+                    <li><strong><code>dist</code></strong> — the built module output</li>
+                </ul>
+            </div>
+            <div aria-label="Example folder structure" class="code-window">
+<pre><code>project.json
+src/
+  public/
+  private/
+  classes/
+  resources/
+tests/
+dist/</code></pre>
+            </div>
+        </div>
+    </section>
+
+    <section class="section">
+        <div class="section__inner">
+            <div class="section-heading">
+                <h2>Use the example when you want to see a complete working setup</h2>
+                <p>
+                    If you learn best by inspecting something real, the repository includes an example module project
+                    that
+                    can be built, tested, imported, and run.
+                </p>
+            </div>
+            <div class="cta-banner">
+                <div>
+                    <h3>Recommended next step for new users</h3>
+                    <p>Open the example project, run the commands, and compare the source files with the built
+                        output.</p>
+                </div>
+                <a class="button button--primary"
+                   href="https://github.com/stiwicourage/NovaModuleTools/blob/main/example/README.md">View example
+                    guide</a>
+            </div>
+        </div>
+    </section>
+
+    <section class="section section--faq">
+        <div class="section__inner narrow">
+            <h2>Frequently asked questions</h2>
+            <div class="faq-list">
+                <details>
+                    <summary>Do I need to know advanced PowerShell module concepts before using NovaModuleTools?
+                    </summary>
+                    <p>No. The tool is useful specifically because it gives you structure and a workflow you can follow
+                        while learning.</p>
+                </details>
+                <details>
+                    <summary>Can I use the CLI instead of PowerShell cmdlet names?</summary>
+                    <p>Yes. Inside PowerShell you can use the <code>nova</code> alias, and on macOS/Linux you can
+                        install a standalone launcher with <code>Install-NovaCli</code>.</p>
+                </details>
+                <details>
+                    <summary>What does <code>nova build</code> actually give me?</summary>
+                    <p>It creates a built module under <code>dist/&lt;ProjectName&gt;</code> so you can import, test,
+                        and publish the result as a proper module.</p>
+                </details>
+                <details>
+                    <summary>Should I start from the scaffold or the example?</summary>
+                    <p>Use the scaffold if you want to begin your own module immediately. Use the example if you want a
+                        working reference project you can inspect and run first.</p>
+                </details>
+            </div>
+        </div>
+    </section>
+</main>
+
+<footer class="footer">
+    <div class="footer__inner">
+        <h2>Ready to start your first well-structured module?</h2>
+        <p>Use the quick start, inspect the example, and let NovaModuleTools handle the repetitive scaffolding and build
+            workflow.</p>
+        <div class="hero__actions">
+            <a class="button button--primary"
+               href="https://github.com/stiwicourage/NovaModuleTools/blob/main/README.md">Open README</a>
+            <a class="button button--secondary"
+               href="https://github.com/stiwicourage/NovaModuleTools/blob/main/docs/NovaModuleTools/en-US/Install-NovaCli.md">Read
+                CLI install guide</a>
+        </div>
+    </div>
+</footer>
+</body>
+</html>
+

--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -51,15 +51,15 @@
 <main>
     <section class="section section--muted">
         <div class="section__inner narrow">
-            <h2>Who this page is for</h2>
+            <h2>Who NovaModuleTools is for</h2>
             <p>
-                This page is for developers who want to use NovaModuleTools to create PowerShell modules, especially if
-                they do <strong>not</strong> already feel confident about PowerShell module structure, build flow, or
-                best practices.
+                NovaModuleTools is for developers who want to create PowerShell modules with a clear, repeatable
+                structure — especially if they do <strong>not</strong> already feel confident about PowerShell module
+                layout, build flow, or best practices.
             </p>
             <p>
-                It is intentionally focused on the user experience — what NovaModuleTools helps you do, why it matters,
-                and how to get started quickly.
+                It is designed to give you a simpler path from idea to working module, without needing deep PowerShell
+                module knowledge on day one.
             </p>
         </div>
     </section>

--- a/project.json
+++ b/project.json
@@ -19,7 +19,7 @@
       "Maintainability",
       "Enterprise"
     ],
-    "ProjectUri": "https://github.com/stiwicourage/NovaModuleTools/tree/main"
+    "ProjectUri": "https://stiwicourage.github.io/NovaModuleTools/"
   },
   "Pester": {
     "TestResult": {


### PR DESCRIPTION
- Added a user-focused public landing page under `docs/public/` for developers who want a simpler introduction to
  NovaModuleTools and its module workflow.