### PR TITLE
#41: feat(#41): add support for optional Preamble in project.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ node_modules/
 artifacts/
 dist/
 run.ps1
+reload.ps1
 /.tmp-nova-bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ The format follows the principles from Keep a Changelog and the project aims to 
   JUnit/Cobertura test
   reports, remap coverage to source paths, and upload coverage to CodeScene.
 - Added regression coverage for the Cobertura source-path remapping used by the CodeScene upload flow.
+- Added optional `Preamble` support in `project.json` so builds can inject module-level setup lines at the very top of
+  the generated `.psm1` before any `# Source:` markers or other generated content.
 
 ### Changed
 
@@ -113,6 +115,8 @@ The format follows the principles from Keep a Changelog and the project aims to 
   secrets.
 - Documented how to install the standalone `nova` launcher with `Install-NovaCli` and when to use the PowerShell alias
   instead.
+- Documented the new `Preamble` build setting in `README.md` and updated the example project to show a practical
+  module-level preamble configuration.
 - Replaced the outdated `New-NovaModule` screenshot in `README.md` with a concrete `project.json` example that shows the
   expected NovaModuleTools output more clearly.
 - Refreshed the `README.md` contribution guidance so contributors are clearly asked to follow the Nova workflow, run the

--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ If a setting is omitted, NovaModuleTools now treats it as `true` by default:
   - When `true`, NovaModuleTools writes exactly one `# Source: <relative path>` line before each concatenated source file in the generated `dist/<Project>/<Project>.psm1`.
   - Relative paths are project-relative and normalized to `/`, for example `# Source: src/private/core/security/SetTls12SecurityProtocol.ps1`.
   - This is useful when parser errors or runtime exceptions point at line numbers in the generated `.psm1` and you need to map them back to files under `src`.
+- `Preamble` (default: omitted / no output)
+    - When present, this must be a top-level array of strings in `project.json`.
+    - NovaModuleTools writes each configured line at the very top of the generated `dist/<Project>/<Project>.psm1`, then
+      inserts one blank line before the rest of the generated module content.
+    - `Preamble` is independent from `SetSourcePath`: if both are used, the preamble is written first and the generated
+      `# Source: ...` markers come after the blank line.
 - `FailOnDuplicateFunctionNames` (default: `true`)
   - When `true`, NovaModuleTools will parse the generated `dist/<Project>/<Project>.psm1` and fail the build if duplicate **top-level** function names exist.
 
@@ -105,6 +111,10 @@ Example:
 {
   "BuildRecursiveFolders": true,
   "SetSourcePath": true,
+  "Preamble": [
+    "Set-StrictMode -Version Latest",
+    "$ErrorActionPreference = 'Stop'"
+  ],
   "FailOnDuplicateFunctionNames": true
 }
 ```
@@ -132,6 +142,31 @@ class AgentListing {
 
 # Source: src/private/core/security/SetTls12SecurityProtocol.ps1
 function Set-Tls12SecurityProtocol {
+    # ...
+}
+```
+
+With `Preamble`, you can inject module-level setup lines before those source markers and before any generated class or
+function content:
+
+```json
+{
+  "Preamble": [
+    "Set-StrictMode -Version Latest",
+    "$ErrorActionPreference = 'Stop'"
+  ],
+  "SetSourcePath": true
+}
+```
+
+This produces a generated module that starts like this:
+
+```powershell
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# Source: src/classes/AgentListing.ps1
+class AgentListing {
     # ...
 }
 ```
@@ -347,6 +382,10 @@ outlined above, and you can run `Invoke-NovaBuild` (`nova build`) to build the m
 
 If `SetSourcePath` is enabled in `project.json`, `Invoke-NovaBuild` (`nova build`) also annotates the generated `.psm1`
 with `# Source: src/...` comments before each concatenated file block to make debugging easier.
+
+If `Preamble` is present, `Invoke-NovaBuild` writes those lines first, adds one blank line, and then continues with the
+normal generated module content. This keeps module-level initialization explicit while preserving the existing build
+order for classes, public functions, private functions, exports, and resource handling.
 
 ```powershell
 # From the Module root 

--- a/example/README.md
+++ b/example/README.md
@@ -12,6 +12,7 @@ It is meant to help a new user understand the smallest useful setup that can:
 ## What is in this example?
 
 - `project.json` – the NovaModuleTools project definition
+    - includes a `Preamble` example that is written at the top of the built `.psm1`
 - `src/public/Get-ExampleGreeting.ps1` – a public function exported from the built module
 - `src/private/Get-ExampleConfiguration.ps1` – a private helper used by the public function
 - `src/resources/greeting-config.json` – a resource file bundled into the built module
@@ -73,6 +74,7 @@ Hello, Nova user!
 This example is intentionally small, but it demonstrates the most important NovaModuleTools concepts:
 
 - the real project folder layout under `src/`
+- how module-level preamble lines from `project.json` are emitted before the generated source markers and module code
 - how public and private functions are combined into one module
 - how resource files are copied and used at runtime
 - how tests should import the built module from `dist/`

--- a/example/project.json
+++ b/example/project.json
@@ -6,6 +6,10 @@
   "BuildRecursiveFolders": true,
   "SetSourcePath": true,
   "FailOnDuplicateFunctionNames": true,
+  "Preamble": [
+    "Set-StrictMode -Version Latest",
+    "$ErrorActionPreference = 'Stop'"
+  ],
   "Manifest": {
     "Author": "NovaModuleTools",
     "PowerShellHostVersion": "7.4",

--- a/project.json
+++ b/project.json
@@ -1,7 +1,7 @@
 {
   "ProjectName": "NovaModuleTools",
   "Description": "NovaModuleTools is an enterprise-focused evolution of ModuleTools, designed for large-scale PowerShell projects with a strong emphasis on structure, maintainability, and automated CI/CD pipelines.",
-  "Version": "1.9.6",
+  "Version": "1.9.7",
   "copyResourcesToModuleRoot": false,
   "BuildRecursiveFolders": true,
   "SetSourcePath": true,

--- a/src/private/build/AddProjectPreambleToModuleBuilder.ps1
+++ b/src/private/build/AddProjectPreambleToModuleBuilder.ps1
@@ -1,0 +1,17 @@
+function Add-ProjectPreambleToModuleBuilder {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][System.Text.StringBuilder]$Builder,
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo
+    )
+
+    if ($ProjectInfo.Preamble.Count -eq 0) {
+        return
+    }
+
+    foreach ($line in $ProjectInfo.Preamble) {
+        $Builder.AppendLine($line) | Out-Null
+    }
+
+    $Builder.AppendLine() | Out-Null
+}

--- a/src/private/build/BuildModule.ps1
+++ b/src/private/build/BuildModule.ps1
@@ -6,6 +6,7 @@ function Build-Module {
     Test-ProjectSchema -Schema Build | Out-Null
 
     $sb = [System.Text.StringBuilder]::new()
+    Add-ProjectPreambleToModuleBuilder -Builder $sb -ProjectInfo $data
 
     $files = Get-ProjectScriptFile -ProjectInfo $data
     foreach ($file in $files) {

--- a/src/private/build/Format-ProjectJsonValue.ps1
+++ b/src/private/build/Format-ProjectJsonValue.ps1
@@ -1,0 +1,15 @@
+function Format-ProjectJsonValue {
+    [CmdletBinding()]
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) {
+        return 'null'
+    }
+
+    try {
+        return ($Value | ConvertTo-Json -Compress -Depth 10)
+    }
+    catch {
+        return [string]$Value
+    }
+}

--- a/src/private/build/Get-ProjectJsonValueTypeName.ps1
+++ b/src/private/build/Get-ProjectJsonValueTypeName.ps1
@@ -1,0 +1,10 @@
+function Get-ProjectJsonValueTypeName {
+    [CmdletBinding()]
+    param([AllowNull()]$Value)
+
+    if ($null -eq $Value) {
+        return 'null'
+    }
+
+    return $Value.GetType().FullName
+}

--- a/src/private/build/Get-ProjectPreamble.ps1
+++ b/src/private/build/Get-ProjectPreamble.ps1
@@ -1,0 +1,33 @@
+function Get-ProjectPreamble {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][hashtable]$ProjectData
+    )
+
+    if (-not $ProjectData.ContainsKey('Preamble')) {
+        return @()
+    }
+
+    $preamble = $ProjectData.Preamble
+    if ($preamble -is [string] -or $preamble -isnot [System.Collections.IEnumerable]) {
+        $typeName = Get-ProjectJsonValueTypeName -Value $preamble
+        $valueText = Format-ProjectJsonValue -Value $preamble
+        throw "Invalid project.json Preamble value: expected top-level Preamble as string[] but found type '$typeName' with value $valueText. Preamble must be a top-level project.json array of strings."
+    }
+
+    $lines = New-Object 'System.Collections.Generic.List[string]'
+    $index = 0
+    foreach ($item in @($preamble)) {
+        if ($item -isnot [string]) {
+            $typeName = Get-ProjectJsonValueTypeName -Value $item
+            $valueText = Format-ProjectJsonValue -Value $item
+            throw "Invalid project.json Preamble value: expected top-level Preamble as string[] but found entry at index $index with type '$typeName' and value $valueText. Preamble must be a top-level project.json array of strings."
+        }
+
+        $lines.Add($item)
+        $index++
+    }
+
+    return @($lines)
+}
+

--- a/src/private/quality/duplicates/GetOrCreateHashtableList.ps1
+++ b/src/private/quality/duplicates/GetOrCreateHashtableList.ps1
@@ -9,5 +9,5 @@ function Get-OrCreateHashtableList {
         $Index[$Key] = New-Object 'System.Collections.Generic.List[object]'
     }
 
-    return $Index[$Key]
+    return ,$Index[$Key]
 }

--- a/src/public/GetNovaProjectInfo.ps1
+++ b/src/public/GetNovaProjectInfo.ps1
@@ -30,6 +30,8 @@ function Get-NovaProjectInfo {
         $Out[$boolKey] = [bool]$Out[$boolKey]
     }
 
+    $Out['Preamble'] = @(Get-ProjectPreamble -ProjectData $jsonData)
+
     $Out.ProjectJson = $projectJson
     $Out.PSTypeName = 'MTProjectInfo'
     $ProjectName = $jsonData.ProjectName

--- a/src/resources/ProjectTemplate.json
+++ b/src/resources/ProjectTemplate.json
@@ -6,6 +6,7 @@
     "BuildRecursiveFolders": true,
     "SetSourcePath": true,
     "FailOnDuplicateFunctionNames": true,
+  "Preamble": [],
     "Manifest": {
         "Author": "",
         "PowerShellHostVersion": "",

--- a/src/resources/Schema-Build.json
+++ b/src/resources/Schema-Build.json
@@ -27,6 +27,13 @@
             "type": "boolean",
             "description": "Default enabled validation: fail build when duplicate top-level function names exist in the generated dist/<Project>/<Project>.psm1."
         },
+      "Preamble": {
+        "type": "array",
+        "description": "Optional module-level lines written at the very top of the generated dist/<Project>/<Project>.psm1 before any source markers or other generated content.",
+        "items": {
+          "type": "string"
+        }
+      },
         "Manifest": {
             "type": "object",
             "properties": {

--- a/tests/BuildOptions.TestSupport.ps1
+++ b/tests/BuildOptions.TestSupport.ps1
@@ -68,6 +68,10 @@ function Write-TestProjectJson {
         $project.FailOnDuplicateFunctionNames = [bool]$Options.FailOnDuplicateFunctionNames
     }
 
+    if ( $Options.ContainsKey('Preamble')) {
+        $project.Preamble = $Options.Preamble
+    }
+
     if ( $Options.ContainsKey('copyResourcesToModuleRoot')) {
         $project.copyResourcesToModuleRoot = [bool]$Options.copyResourcesToModuleRoot
     }
@@ -215,10 +219,11 @@ function New-TestProjectWithDuplicateFunctions {
 function Assert-InvokeNovaBuildThrows {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][string]$ProjectRoot
+        [Parameter(Mandatory)][string]$ProjectRoot,
+        [string]$ExpectedMessage
     )
 
-    {
+    $scriptBlock = {
         Push-Location -LiteralPath $ProjectRoot
         try {
             Invoke-NovaBuild
@@ -226,7 +231,36 @@ function Assert-InvokeNovaBuildThrows {
         finally {
             Pop-Location
         }
-    } | Should -Throw
+    }
+
+    if ( [string]::IsNullOrWhiteSpace($ExpectedMessage)) {
+        $scriptBlock | Should -Throw
+        return
+    }
+
+    $scriptBlock | Should -Throw $ExpectedMessage
+}
+
+function Get-InvokeNovaBuildErrorMessage {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ProjectRoot
+    )
+
+    Push-Location -LiteralPath $ProjectRoot
+    try {
+        try {
+            Invoke-NovaBuild
+        }
+        catch {
+            return $_.Exception.Message
+        }
+    }
+    finally {
+        Pop-Location
+    }
+
+    throw 'Expected Invoke-NovaBuild to throw, but it succeeded.'
 }
 
 function Get-TopLevelFunctionAstFromAst {
@@ -380,5 +414,36 @@ function New-TestProjectWithMarkerTests {
         TopMarker = $topMarker
         NestedMarker = $nestedMarker
     }
+}
+
+function New-TestProjectWithPreamble {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$TestDriveRoot,
+        [Parameter(Mandatory)][string]$Name,
+        [hashtable]$Options = @{}
+    )
+
+    $projectOptions = @{
+        ProjectName = $Name
+        BuildRecursiveFolders = [bool]$Options.IncludeClassAndPrivate
+        SetSourcePath = [bool]$Options.SetSourcePath
+        FailOnDuplicateFunctionNames = $false
+    }
+    if ( $Options.ContainsKey('Preamble')) {
+        $projectOptions.Preamble = $Options.Preamble
+    }
+
+    $root = New-TestProjectRoot -TestDriveRoot $TestDriveRoot -Name $Name
+    Write-TestProjectJson -ProjectRoot $root -Options $projectOptions
+
+    Set-Content -LiteralPath (Join-Path $root 'src/public/PublicTop.ps1') -Value 'function Invoke-PublicTop { "public" }' -Encoding utf8
+    if (-not $projectOptions.BuildRecursiveFolders) {
+        return $root
+    }
+
+    Set-Content -LiteralPath (Join-Path $root 'src/classes/nested/Thing.ps1') -Value 'class NestedThing { [string]$Name }' -Encoding utf8
+    Set-Content -LiteralPath (Join-Path $root 'src/private/a/PrivateA.ps1') -Value 'function Invoke-PrivateA { "private" }' -Encoding utf8
+    return $root
 }
 

--- a/tests/BuildOptions.TestSupport.ps1
+++ b/tests/BuildOptions.TestSupport.ps1
@@ -424,10 +424,13 @@ function New-TestProjectWithPreamble {
         [hashtable]$Options = @{}
     )
 
+    $includeClassAndPrivate = $Options.ContainsKey('IncludeClassAndPrivate') -and [bool]$Options.IncludeClassAndPrivate
+    $setSourcePath = $Options.ContainsKey('SetSourcePath') -and [bool]$Options.SetSourcePath
+
     $projectOptions = @{
         ProjectName = $Name
-        BuildRecursiveFolders = [bool]$Options.IncludeClassAndPrivate
-        SetSourcePath = [bool]$Options.SetSourcePath
+        BuildRecursiveFolders = $includeClassAndPrivate
+        SetSourcePath = $setSourcePath
         FailOnDuplicateFunctionNames = $false
     }
     if ( $Options.ContainsKey('Preamble')) {

--- a/tests/PreambleBuild.Tests.ps1
+++ b/tests/PreambleBuild.Tests.ps1
@@ -1,0 +1,135 @@
+$script:preambleBuildTestSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'BuildOptions.TestSupport.ps1')).Path
+$global:preambleBuildTestSupportFunctionNameList = @(
+    'New-TestProjectRoot'
+    'Write-TestProjectJson'
+    'Get-BuiltModuleFilePath'
+    'Invoke-TestProjectBuild'
+    'Get-BuiltModuleContent'
+    'Get-InvokeNovaBuildErrorMessage'
+    'New-TestProjectWithPreamble'
+)
+
+. $script:preambleBuildTestSupportPath
+
+foreach ($functionName in $global:preambleBuildTestSupportFunctionNameList) {
+    $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
+    Set-Item -Path "function:global:$functionName" -Value $scriptBlock
+}
+
+BeforeAll {
+    $buildOptionsTestSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'BuildOptions.TestSupport.ps1')).Path
+    $functionNameList = $global:preambleBuildTestSupportFunctionNameList
+    $repoRoot = Split-Path -Parent $PSScriptRoot
+    $moduleName = (Get-Content -LiteralPath (Join-Path $repoRoot 'project.json') -Raw | ConvertFrom-Json).ProjectName
+    $distModuleDir = Join-Path $repoRoot "dist/$moduleName"
+
+    . $buildOptionsTestSupportPath
+
+    foreach ($functionName in $functionNameList) {
+        $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
+        Set-Item -Path "function:global:$functionName" -Value $scriptBlock
+    }
+
+    if (-not (Test-Path -LiteralPath $distModuleDir)) {
+        throw "Expected built $moduleName module at: $distModuleDir. Run Invoke-NovaBuild in the repo root first."
+    }
+
+    Remove-Module $moduleName -ErrorAction SilentlyContinue
+    Import-Module $distModuleDir -Force
+}
+
+Describe 'Invoke-NovaBuild Preamble setting' {
+    Context 'exact output with <Name>' -ForEach @(
+        @{Name = 'missing Preamble'; ProjectName = 'PreambleMissing'; Preamble = $null; ExpectedContent = 'function Invoke-PublicTop { "public" }'}
+        @{Name = 'empty Preamble'; ProjectName = 'PreambleEmpty'; Preamble = @(); ExpectedContent = 'function Invoke-PublicTop { "public" }'}
+        @{Name = 'single-line Preamble'; ProjectName = 'PreambleSingle'; Preamble = @('Set-StrictMode -Version Latest'); ExpectedContent = 'Set-StrictMode -Version Latest'}
+    ) {
+        It 'writes the expected module preamble and spacing' {
+            $root = if ($null -eq $Preamble) {
+                New-TestProjectWithPreamble -TestDriveRoot $TestDrive -Name $ProjectName
+            }
+            else {
+                New-TestProjectWithPreamble -TestDriveRoot $TestDrive -Name $ProjectName -Options @{Preamble = $Preamble}
+            }
+
+            $content = Get-BuiltModuleContent -ProjectRoot $root
+            $newLine = [Environment]::NewLine
+            $expected = switch ($ProjectName) {
+                'PreambleSingle' {
+                    $ExpectedContent + $newLine + $newLine + 'function Invoke-PublicTop { "public" }'
+                }
+                default {
+                    $ExpectedContent
+                }
+            }
+
+            $content | Should -Be ($expected + $newLine + $newLine + $newLine + $newLine)
+        }
+    }
+
+    It 'multi-line Preamble preserves order and inserts a blank line before the rest of the module content' {
+        $root = New-TestProjectWithPreamble -TestDriveRoot $TestDrive -Name 'PreambleMulti' -Options @{
+            Preamble = @(
+                '# Module initialization'
+                'Set-StrictMode -Version Latest'
+                "`$ErrorActionPreference = 'Stop'"
+            )
+        }
+        $content = Get-BuiltModuleContent -ProjectRoot $root
+        $newLine = [Environment]::NewLine
+        $expectedStart = @(
+            '# Module initialization'
+            'Set-StrictMode -Version Latest'
+            "`$ErrorActionPreference = 'Stop'"
+            ''
+            'function Invoke-PublicTop { "public" }'
+        ) -join $newLine
+
+        $content.StartsWith($expectedStart) | Should -BeTrue
+    }
+
+    It 'Preamble appears before all source markers when SetSourcePath=true' {
+        $root = New-TestProjectWithPreamble -TestDriveRoot $TestDrive -Name 'PreambleWithSourcePath' -Options @{
+            SetSourcePath = $true
+            IncludeClassAndPrivate = $true
+            Preamble = @(
+                'Set-StrictMode -Version Latest'
+                "`$ErrorActionPreference = 'Stop'"
+            )
+        }
+
+        $content = Get-BuiltModuleContent -ProjectRoot $root
+        $newLine = [Environment]::NewLine
+        $firstMarker = '# Source: src/classes/nested/Thing.ps1'
+        $expectedStart = @(
+            'Set-StrictMode -Version Latest'
+            "`$ErrorActionPreference = 'Stop'"
+            ''
+            $firstMarker
+        ) -join $newLine
+
+        $content.StartsWith($expectedStart) | Should -BeTrue
+        $content.IndexOf('Set-StrictMode -Version Latest') | Should -BeLessThan $content.IndexOf($firstMarker)
+    }
+
+    Context 'invalid Preamble value <ProjectName>' -ForEach @(
+        @{ProjectName = 'PreambleInvalidType'; Preamble = 'Set-StrictMode -Version Latest'; ExpectedPatterns = @('Preamble', 'string\[\]', 'Set-StrictMode -Version Latest', 'top-level project\.json array of strings')}
+        @{ProjectName = 'PreambleInvalidItem'; Preamble = @('Set-StrictMode -Version Latest', 123); ExpectedPatterns = @('Preamble', 'string\[\]', 'index 1', '123', 'top-level project\.json array of strings')}
+    ) {
+        It 'fails build with a clear validation error' {
+            $root = New-TestProjectWithPreamble -TestDriveRoot $TestDrive -Name $ProjectName -Options @{Preamble = $Preamble}
+            $message = Get-InvokeNovaBuildErrorMessage -ProjectRoot $root
+
+            foreach ($pattern in $ExpectedPatterns) {
+                $message | Should -Match $pattern
+            }
+        }
+    }
+}
+
+
+
+
+
+
+


### PR DESCRIPTION
- Introduced a Preamble setting to allow module-level setup lines in generated .psm1 files.
- Updated related functions to handle Preamble validation and retrieval.
- Enhanced documentation to include examples of Preamble usage.