### PR TITLE
Enhance nova launcher, error handling, and project template consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,10 @@ The format follows the principles from Keep a Changelog and the project aims to 
 - Added optional `Preamble` support in `project.json` so builds can inject module-level setup lines at the very top of
   the generated `.psm1` before any `# Source:` markers or other generated content.
 
+
 ### Changed
 
+- Standardized the project setting name on `CopyResourcesToModuleRoot` across templates, tests, code, and documentation.
 - Internal build, scaffold, and CI entrypoints no longer rely on blanket `$ErrorActionPreference = 'Stop'` settings;
   they now use
   explicit terminating errors where needed, and the repository examples were updated to match.
@@ -110,7 +112,7 @@ The format follows the principles from Keep a Changelog and the project aims to 
 - Fixed local module path resolution maintainability by refactoring `Get-LocalModulePath` to Code Health `10.0` and
   adding regression coverage for both the matching and error paths.
 - Fixed resource-copy maintainability by refactoring `Copy-ProjectResource` to Code Health `10.0` and adding regression
-  coverage for both `copyResourcesToModuleRoot` modes.
+  coverage for both `CopyResourcesToModuleRoot` modes.
 - Fixed `Test-NovaBuild` so the generated Pester XML report is now written to `artifacts/TestResults.xml` instead of the
   `dist` folder.
 
@@ -218,7 +220,8 @@ The format follows the principles from Keep a Changelog and the project aims to 
 
 ### Added
 
-- New optional project setting `copyResourcesToModuleRoot`. Setting to true places resource files in the root directory of module. Default is `false` to provide backward compatibility. Thanks to @[BrooksV](https://github.com/BrooksV)
+- New optional project setting `CopyResourcesToModuleRoot`. Setting to true places resource files in the root directory
+  of module. Default is `false` to provide backward compatibility. Thanks to @[BrooksV](https://github.com/BrooksV)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,13 @@ The format follows the principles from Keep a Changelog and the project aims to 
   NovaModuleTools
   is intended to be used in day-to-day development.
 
+### Fixed
+
+- Fixed the standalone macOS/Linux `nova` launcher so `nova build -Verbose` now forwards the verbose flag into the
+  actual build command instead of being consumed at the launcher boundary.
+- Fixed `Get-NovaProjectInfo` to report empty `project.json` files with a clear configuration error instead of failing
+  later with a null-argument binding exception.
+
 ### Removed
 
 - Removed the legacy `MT` command implementation in favor of the Nova equivalents, including:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ The format follows the principles from Keep a Changelog and the project aims to 
 ### Changed
 
 - Standardized the project setting name on `CopyResourcesToModuleRoot` across templates, tests, code, and documentation.
+- Made `CopyResourcesToModuleRoot` optional in `project.json`; when omitted, NovaModuleTools now defaults it to `false`.
+- Kept `CopyResourcesToModuleRoot` visible in `example/project.json` so new users can still discover the setting from
+  the
+  working reference project even though generated projects may omit it.
 - Internal build, scaffold, and CI entrypoints no longer rely on blanket `$ErrorActionPreference = 'Stop'` settings;
   they now use
   explicit terminating errors where needed, and the repository examples were updated to match.
@@ -241,6 +245,8 @@ The format follows the principles from Keep a Changelog and the project aims to 
 
 ## Fixed
 
+- Fixed the example project README so it no longer suggests that `example/` includes a `run.ps1` helper script; it now
+  points users to building `NovaModuleTools` from the repository root or using the Gallery workflow.
 - Corrected typo in ProjectUri from `ProjecUri` to correct spelling.
 
 ## [0.0.6] - 2024-07-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ The format follows the principles from Keep a Changelog and the project aims to 
 
 ### Changed
 
+- Internal build, scaffold, and CI entrypoints no longer rely on blanket `$ErrorActionPreference = 'Stop'` settings;
+  they now use
+  explicit terminating errors where needed, and the repository examples were updated to match.
 - `nova --version` now reports the installed `NovaModuleTools` module version, while `nova version` reports the
   current project version from `project.json`.
 - BREAKING CHANGE: The codebase is now fully centered on the Nova command model instead of a mixed MT/Nova
@@ -113,6 +116,8 @@ The format follows the principles from Keep a Changelog and the project aims to 
 
 ### Documentation
 
+- Updated `README.md` and `CONTRIBUTING.md` to remove stale `$ErrorActionPreference = 'Stop'` examples from the default
+  preamble and local quality workflow.
 - Updated `README.md` with:
     - a dedicated `Publish-NovaModule` section
     - local and repository publish examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ The format follows the principles from Keep a Changelog and the project aims to 
   actual build command instead of being consumed at the launcher boundary.
 - Fixed `Get-NovaProjectInfo` to report empty `project.json` files with a clear configuration error instead of failing
   later with a null-argument binding exception.
+- Fixed internal build, release, and CLI code paths so enabling a module preamble such as
+  `Set-StrictMode -Version Latest`
+  and `$ErrorActionPreference = 'Stop'` no longer breaks the repository test suite or the example project build.
 
 ### Removed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,6 @@ If you want to contribute, please work in the same style as the project:
 
 ```powershell title="run.ps1"
 #run.ps1
-$ErrorActionPreference = 'Stop'
 Set-Location $PSScriptRoot
 
 $projectName = (Get-Content -LiteralPath (Join-Path $PSScriptRoot 'project.json') -Raw | ConvertFrom-Json).ProjectName

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ class AgentListing {
 - All functions in the `public` folder are exported during the module build.
 - All functions in the `private` folder are accessible internally within the module but are not exposed outside the module.
 - `src/classes` should contain classes and enums. These files are placed at the top of the generated `psm1`.
-- `src/resources` content is handled based on `CopyResourcesToModuleRoot`.
+- `src/resources` content is handled based on the optional `CopyResourcesToModuleRoot` setting.
 
 #### Deterministic processing order
 To ensure builds are deterministic across platforms, files are processed in this order:
@@ -201,9 +201,10 @@ The `resources` folder within the `src` directory is intended for including any 
 - **Data files**: Store any data files that are used by your module, such as CSV or JSON files.
 - **Subfolder**: Include any additional folders and their content to be included with the module, such as dependant Modules, APIs, DLLs, etc... organized by a subfolder.
 
-By default, resource files from `src/resources` go into `dist/resources`. To place them directly in dist (avoiding the
-resources subfolder), set `CopyResourcesToModuleRoot` to `true`. This provides greater control in certain deployment
-scenarios where resources files are preferred in module root directory.
+By default, resource files from `src/resources` go into `dist/resources`. You do not need to add
+`CopyResourcesToModuleRoot` to `project.json` unless you want to override that default. To place resources directly in
+dist (avoiding the resources subfolder), set `CopyResourcesToModuleRoot` to `true`. This provides greater control in
+certain deployment scenarios where resources files are preferred in module root directory.
 
 Leave `src\resources` empty if there is no need to include any additional content in the `dist` folder.
 

--- a/README.md
+++ b/README.md
@@ -112,8 +112,7 @@ Example:
   "BuildRecursiveFolders": true,
   "SetSourcePath": true,
   "Preamble": [
-    "Set-StrictMode -Version Latest",
-    "$ErrorActionPreference = 'Stop'"
+    "Set-StrictMode -Version Latest"
   ],
   "FailOnDuplicateFunctionNames": true
 }
@@ -152,8 +151,7 @@ function content:
 ```json
 {
   "Preamble": [
-    "Set-StrictMode -Version Latest",
-    "$ErrorActionPreference = 'Stop'"
+    "Set-StrictMode -Version Latest"
   ],
   "SetSourcePath": true
 }
@@ -163,7 +161,6 @@ This produces a generated module that starts like this:
 
 ```powershell
 Set-StrictMode -Version Latest
-$ErrorActionPreference = 'Stop'
 
 # Source: src/classes/AgentListing.ps1
 class AgentListing {
@@ -270,7 +267,6 @@ For local repository work, a practical quality loop is:
 
 ```powershell
 #run.ps1
-$ErrorActionPreference = 'Stop'
 Set-Location $PSScriptRoot
 
 $projectName = (Get-Content -LiteralPath (Join-Path $PSScriptRoot 'project.json') -Raw | ConvertFrom-Json).ProjectName
@@ -283,6 +279,12 @@ Import-Module $distModuleDir -Force
 
 Test-NovaBuild
 ```
+
+You generally do not need to add `$ErrorActionPreference = 'Stop'` to a module preamble or helper script.
+NovaModuleTools now
+uses explicit terminating errors in its own build/test paths, so examples in this repository keep the preamble focused
+on
+module setup such as `Set-StrictMode -Version Latest`.
 
 This keeps ScriptAnalyzer as a separate code-quality step while `Test-NovaBuild` remains focused on Pester tests.
 When ScriptAnalyzer runs this way, its findings are written to `artifacts/scriptanalyzer.txt` and are not counted as

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ class AgentListing {
 - All functions in the `public` folder are exported during the module build.
 - All functions in the `private` folder are accessible internally within the module but are not exposed outside the module.
 - `src/classes` should contain classes and enums. These files are placed at the top of the generated `psm1`.
-- `src/resources` content is handled based on `copyResourcesToModuleRoot`.
+- `src/resources` content is handled based on `CopyResourcesToModuleRoot`.
 
 #### Deterministic processing order
 To ensure builds are deterministic across platforms, files are processed in this order:
@@ -201,11 +201,13 @@ The `resources` folder within the `src` directory is intended for including any 
 - **Data files**: Store any data files that are used by your module, such as CSV or JSON files.
 - **Subfolder**: Include any additional folders and their content to be included with the module, such as dependant Modules, APIs, DLLs, etc... organized by a subfolder.
 
-By default, resource files from `src/resources` go into `dist/resources`. To place them directly in dist (avoiding the resources subfolder), set `copyResourcesToModuleRoot` to `true`. This provides greater control in certain deployment scenarios where resources files are preferred in module root directory.
+By default, resource files from `src/resources` go into `dist/resources`. To place them directly in dist (avoiding the
+resources subfolder), set `CopyResourcesToModuleRoot` to `true`. This provides greater control in certain deployment
+scenarios where resources files are preferred in module root directory.
 
 Leave `src\resources` empty if there is no need to include any additional content in the `dist` folder.
 
-An example of the module build where resources were included and `copyResourcesToModuleRoot` is set to true.
+An example of the module build where resources were included and `CopyResourcesToModuleRoot` is set to true.
 ```powershell
 dist
 └── TestModule

--- a/example/README.md
+++ b/example/README.md
@@ -13,6 +13,8 @@ It is meant to help a new user understand the smallest useful setup that can:
 
 - `project.json` – the NovaModuleTools project definition
     - includes a `Preamble` example that is written at the top of the built `.psm1`
+  - intentionally keeps common top-level settings visible, including `CopyResourcesToModuleRoot`, so new users can
+    see the available configuration keys in one place
 - `src/public/Get-ExampleGreeting.ps1` – a public function exported from the built module
 - `src/private/Get-ExampleConfiguration.ps1` – a private helper used by the public function
 - `src/resources/greeting-config.json` – a resource file bundled into the built module
@@ -24,8 +26,8 @@ It is meant to help a new user understand the smallest useful setup that can:
 
 Run these commands from the repository root:
 
-If `./dist/NovaModuleTools` is not available yet, run `./run.ps1` once first or use the PowerShell Gallery workflow
-below.
+If `./dist/NovaModuleTools` is not available yet, build `NovaModuleTools` from the repository root first, or use the
+PowerShell Gallery workflow below.
 
 ```powershell
 Import-Module ./dist/NovaModuleTools -Force

--- a/example/project.json
+++ b/example/project.json
@@ -2,7 +2,7 @@
   "ProjectName": "NovaExampleModule",
   "Description": "A working example project that demonstrates how to build, test, and package a small module with NovaModuleTools.",
   "Version": "0.1.0",
-  "copyResourcesToModuleRoot": false,
+  "CopyResourcesToModuleRoot": false,
   "BuildRecursiveFolders": true,
   "SetSourcePath": true,
   "FailOnDuplicateFunctionNames": true,

--- a/example/project.json
+++ b/example/project.json
@@ -7,8 +7,7 @@
   "SetSourcePath": true,
   "FailOnDuplicateFunctionNames": true,
   "Preamble": [
-    "Set-StrictMode -Version Latest",
-    "$ErrorActionPreference = 'Stop'"
+    "Set-StrictMode -Version Latest"
   ],
   "Manifest": {
     "Author": "NovaModuleTools",

--- a/example/project.json
+++ b/example/project.json
@@ -7,7 +7,8 @@
   "SetSourcePath": true,
   "FailOnDuplicateFunctionNames": true,
   "Preamble": [
-    "Set-StrictMode -Version Latest"
+    "Set-StrictMode -Version Latest",
+    "$ErrorActionPreference = 'Stop'"
   ],
   "Manifest": {
     "Author": "NovaModuleTools",

--- a/project.json
+++ b/project.json
@@ -1,7 +1,7 @@
 {
   "ProjectName": "NovaModuleTools",
   "Description": "NovaModuleTools is an enterprise-focused evolution of ModuleTools, designed for large-scale PowerShell projects with a strong emphasis on structure, maintainability, and automated CI/CD pipelines.",
-  "Version": "1.9.7",
+  "Version": "1.9.8",
   "copyResourcesToModuleRoot": false,
   "BuildRecursiveFolders": true,
   "SetSourcePath": true,

--- a/project.json
+++ b/project.json
@@ -7,8 +7,7 @@
   "SetSourcePath": true,
   "FailOnDuplicateFunctionNames": true,
   "Preamble": [
-    "Set-StrictMode -Version Latest",
-    "$ErrorActionPreference = 'Stop'"
+    "Set-StrictMode -Version Latest"
   ],
   "Manifest": {
     "Author": "Stiwi Gabriel Courage",

--- a/project.json
+++ b/project.json
@@ -1,13 +1,14 @@
 {
   "ProjectName": "NovaModuleTools",
   "Description": "NovaModuleTools is an enterprise-focused evolution of ModuleTools, designed for large-scale PowerShell projects with a strong emphasis on structure, maintainability, and automated CI/CD pipelines.",
-  "Version": "1.9.8",
+  "Version": "1.9.9",
   "copyResourcesToModuleRoot": false,
   "BuildRecursiveFolders": true,
   "SetSourcePath": true,
   "FailOnDuplicateFunctionNames": true,
   "Preamble": [
-    "Set-StrictMode -Version Latest"
+    "Set-StrictMode -Version Latest",
+    "$ErrorActionPreference = 'Stop'"
   ],
   "Manifest": {
     "Author": "Stiwi Gabriel Courage",

--- a/project.json
+++ b/project.json
@@ -1,11 +1,7 @@
 {
   "ProjectName": "NovaModuleTools",
   "Description": "NovaModuleTools is an enterprise-focused evolution of ModuleTools, designed for large-scale PowerShell projects with a strong emphasis on structure, maintainability, and automated CI/CD pipelines.",
-  "Version": "1.9.9",
-  "CopyResourcesToModuleRoot": false,
-  "BuildRecursiveFolders": true,
-  "SetSourcePath": true,
-  "FailOnDuplicateFunctionNames": true,
+  "Version": "1.9.10",
   "Preamble": [
     "Set-StrictMode -Version Latest",
     "$ErrorActionPreference = 'Stop'"

--- a/project.json
+++ b/project.json
@@ -2,7 +2,7 @@
   "ProjectName": "NovaModuleTools",
   "Description": "NovaModuleTools is an enterprise-focused evolution of ModuleTools, designed for large-scale PowerShell projects with a strong emphasis on structure, maintainability, and automated CI/CD pipelines.",
   "Version": "1.9.9",
-  "copyResourcesToModuleRoot": false,
+  "CopyResourcesToModuleRoot": false,
   "BuildRecursiveFolders": true,
   "SetSourcePath": true,
   "FailOnDuplicateFunctionNames": true,

--- a/project.json
+++ b/project.json
@@ -6,6 +6,10 @@
   "BuildRecursiveFolders": true,
   "SetSourcePath": true,
   "FailOnDuplicateFunctionNames": true,
+  "Preamble": [
+    "Set-StrictMode -Version Latest",
+    "$ErrorActionPreference = 'Stop'"
+  ],
   "Manifest": {
     "Author": "Stiwi Gabriel Courage",
     "PowerShellHostVersion": "7.4",

--- a/scripts/build/Invoke-ScriptAnalyzerCI.ps1
+++ b/scripts/build/Invoke-ScriptAnalyzerCI.ps1
@@ -3,7 +3,6 @@ param(
     [switch]$IncludeTests
 )
 
-$ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
 Set-Location (Split-Path -Parent $PSScriptRoot | Split-Path -Parent)

--- a/scripts/build/ci/Install-CiPowerShellModules.ps1
+++ b/scripts/build/ci/Install-CiPowerShellModules.ps1
@@ -6,7 +6,6 @@ param(
 )
 )
 
-$ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
 function Install-CiModule {

--- a/scripts/build/ci/Invoke-CodeSceneAnalysis.ps1
+++ b/scripts/build/ci/Invoke-CodeSceneAnalysis.ps1
@@ -3,7 +3,6 @@ param(
     [switch]$TriggerAnalysis
 )
 
-$ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
 function Get-RequiredCodeSceneValue {

--- a/scripts/build/ci/Invoke-NovaModuleToolsCI.ps1
+++ b/scripts/build/ci/Invoke-NovaModuleToolsCI.ps1
@@ -3,7 +3,6 @@ param(
     [string[]]$ExcludeTag = @()
 )
 
-$ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
 . (Join-Path $PSScriptRoot 'CodeSceneCoverageMap.ps1')

--- a/scripts/release/Prepare-SemanticRelease.ps1
+++ b/scripts/release/Prepare-SemanticRelease.ps1
@@ -5,7 +5,6 @@ param(
 )
 
 Set-StrictMode -Version Latest
-$ErrorActionPreference = 'Stop'
 
 $scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
 . (Join-Path $scriptRoot 'SemanticReleaseSupport.ps1')

--- a/scripts/release/Publish-ToPSGallery.ps1
+++ b/scripts/release/Publish-ToPSGallery.ps1
@@ -4,7 +4,6 @@ param(
 )
 
 Set-StrictMode -Version Latest
-$ErrorActionPreference = 'Stop'
 
 if ([string]::IsNullOrWhiteSpace($ApiKey)) {
     throw 'PSGALLERY_API environment variable is required.'

--- a/scripts/release/SemanticReleaseSupport.ps1
+++ b/scripts/release/SemanticReleaseSupport.ps1
@@ -1,5 +1,4 @@
 Set-StrictMode -Version Latest
-$ErrorActionPreference = 'Stop'
 
 $script:supportRoot = Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) 'support'
 $script:supportFileList = @(

--- a/src/private/build/BuildManifest.ps1
+++ b/src/private/build/BuildManifest.ps1
@@ -62,8 +62,8 @@ function Build-Manifest {
     }
 
     try {
-        New-ModuleManifest @ParmsManifest -ErrorAction Stop
+        New-ModuleManifest @ParmsManifest
     } catch {
-        'Failed to create Manifest: {0}' -f $_.Exception.Message | Write-Error -ErrorAction Stop
+        throw ('Failed to create Manifest: {0}' -f $_.Exception.Message)
     }
 }

--- a/src/private/build/BuildManifest.ps1
+++ b/src/private/build/BuildManifest.ps1
@@ -16,7 +16,7 @@ function Build-Manifest {
     ## Import Format.ps1xml (if any)
     $FormatsToProcess = @()
     Get-ChildItem -Path $data.ResourcesDir -File -Filter '*Format.ps1xml' -ErrorAction SilentlyContinue | ForEach-Object {
-        if ($data.copyResourcesToModuleRoot) { 
+        if ($data.CopyResourcesToModuleRoot) {
             $FormatsToProcess += $_.Name
         } else {
             $FormatsToProcess += Join-Path -Path 'resources' -ChildPath $_.Name
@@ -26,7 +26,7 @@ function Build-Manifest {
     ## Import Types.ps1xml1 (if any)
     $TypesToProcess = @()
     Get-ChildItem -Path $data.ResourcesDir -File -Filter '*Types.ps1xml' -ErrorAction SilentlyContinue | ForEach-Object {
-        if ($data.copyResourcesToModuleRoot) { 
+        if ($data.CopyResourcesToModuleRoot) {
             $TypesToProcess += $_.Name
         } else {
             $TypesToProcess += Join-Path -Path 'resources' -ChildPath $_.Name

--- a/src/private/build/BuildManifest.ps1
+++ b/src/private/build/BuildManifest.ps1
@@ -5,12 +5,12 @@ function Build-Manifest {
     Write-Verbose 'Building psd1 data file Manifest'
     $data = Get-NovaProjectInfo
 
-    $PubFunctionFiles = Get-ChildItem -Path $data.PublicDir -Filter *.ps1
+    $PubFunctionFiles = @(Get-ChildItem -Path $data.PublicDir -Filter *.ps1)
     $functionToExport = @()
     $aliasToExport = @()
-    $PubFunctionFiles.FullName | ForEach-Object {
-        $functionToExport += Get-FunctionNameFromFile -filePath $_
-        $aliasToExport += Get-AliasInFunctionFromFile -filePath $_
+    foreach ($pubFunctionFile in $PubFunctionFiles) {
+        $functionToExport += Get-FunctionNameFromFile -filePath $pubFunctionFile.FullName
+        $aliasToExport += Get-AliasInFunctionFromFile -filePath $pubFunctionFile.FullName
     }
 
     ## Import Format.ps1xml (if any)

--- a/src/private/build/BuildModule.ps1
+++ b/src/private/build/BuildModule.ps1
@@ -13,8 +13,8 @@ function Build-Module {
         Add-ScriptFileContentToModuleBuilder -Builder $sb -ProjectInfo $data -File $file
     }
     try {
-        Set-Content -Path $data.ModuleFilePSM1 -Value $sb.ToString() -Encoding 'UTF8' -ErrorAction Stop # psm1 file
+        Set-Content -Path $data.ModuleFilePSM1 -Value $sb.ToString() -Encoding 'UTF8' # psm1 file
     } catch {
-        Write-Error 'Failed to create psm1 file' -ErrorAction Stop
+        throw ('Failed to create psm1 file: {0}' -f $_.Exception.Message)
     }
 }

--- a/src/private/build/CopyProjectResource.ps1
+++ b/src/private/build/CopyProjectResource.ps1
@@ -10,7 +10,7 @@ function Copy-ProjectResource {
         return
     }
 
-    if ($data.copyResourcesToModuleRoot) {
+    if ($data.CopyResourcesToModuleRoot) {
         Copy-ProjectResourceContentToModuleRoot -ItemList $resourceItemList -OutputModuleDir $data.OutputModuleDir
         return
     }

--- a/src/private/build/CopyProjectResource.ps1
+++ b/src/private/build/CopyProjectResource.ps1
@@ -5,7 +5,7 @@ function Copy-ProjectResource {
         return
     }
 
-    $resourceItemList = Get-ProjectResourceItemList -ResourceFolder $resourceFolder
+    $resourceItemList = @(Get-ProjectResourceItemList -ResourceFolder $resourceFolder)
     if ($resourceItemList.Count -eq 0) {
         return
     }

--- a/src/private/build/ResetProjectDist.ps1
+++ b/src/private/build/ResetProjectDist.ps1
@@ -2,17 +2,16 @@ function Reset-ProjectDist {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
     )
-    $ErrorActionPreference = 'Stop'
     $data = Get-NovaProjectInfo
     try {
         Write-Verbose 'Running dist folder reset'
         if (Test-Path $data.OutputDir) {
-            Remove-Item -Path $data.OutputDir -Recurse -Force -ProgressAction SilentlyContinue
+            Remove-Item -Path $data.OutputDir -Recurse -Force -ProgressAction SilentlyContinue -ErrorAction Stop
         }
         # Setup Folders
-        New-Item -Path $data.OutputDir -ItemType Directory -Force | Out-Null # Dist folder
-        New-Item -Path $data.OutputModuleDir -Type Directory -Force | Out-Null # Module Folder
+        New-Item -Path $data.OutputDir -ItemType Directory -Force -ErrorAction Stop | Out-Null # Dist folder
+        New-Item -Path $data.OutputModuleDir -Type Directory -Force -ErrorAction Stop | Out-Null # Module Folder
     } catch {
-        Write-Error 'Failed to reset Dist folder'
+        throw "Failed to reset Dist folder: $( $_.Exception.Message )"
     }
 }

--- a/src/private/build/TestProjectSchema.ps1
+++ b/src/private/build/TestProjectSchema.ps1
@@ -12,8 +12,12 @@ function Test-ProjectSchema {
         Pester = Get-ResourceFilePath -FileName 'Schema-Pester.json'
     }
     $result = switch ($Schema) {
-        'Build' { Test-Json -Path 'project.json' -Schema (Get-Content $SchemaPath.Build -Raw) -ErrorAction Stop }
-        'Pester' { Test-Json -Path 'project.json' -Schema (Get-Content $SchemaPath.Pester -Raw) -ErrorAction Stop }
+        'Build' {
+            Test-Json -Path 'project.json' -Schema (Get-Content $SchemaPath.Build -Raw)
+        }
+        'Pester' {
+            Test-Json -Path 'project.json' -Schema (Get-Content $SchemaPath.Pester -Raw)
+        }
         Default { $false }
     }
     return $result

--- a/src/private/cli/ConvertTo-NovaCliArgumentArray.ps1
+++ b/src/private/cli/ConvertTo-NovaCliArgumentArray.ps1
@@ -1,0 +1,18 @@
+function ConvertTo-NovaCliArgumentArray {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][hashtable]$BoundParameters,
+        [AllowNull()][string[]]$Arguments
+    )
+
+    $normalizedArguments = [System.Collections.Generic.List[string]]::new()
+    if ( $BoundParameters.ContainsKey('Arguments')) {
+        foreach ($argument in $Arguments) {
+            $normalizedArguments.Add($argument)
+        }
+    }
+
+    return ,$normalizedArguments.ToArray()
+}
+
+

--- a/src/private/cli/GetNovaCliLauncherPath.ps1
+++ b/src/private/cli/GetNovaCliLauncherPath.ps1
@@ -2,7 +2,11 @@ function Get-NovaCliLauncherPath {
     [CmdletBinding()]
     param()
 
-    $command = Get-Command -Name 'Install-NovaCli' -CommandType Function -ErrorAction Stop
+    $command = Get-Command -Name 'Install-NovaCli' -CommandType Function -ErrorAction SilentlyContinue
+    if ($null -eq $command) {
+        throw 'Install-NovaCli command not found.'
+    }
+
     $commandFile = $command.ScriptBlock.File
     if ( [string]::IsNullOrWhiteSpace($commandFile)) {
         throw 'Install-NovaCli must be loaded from a file-backed module.'

--- a/src/private/cli/GetNovaCliOptions.ps1
+++ b/src/private/cli/GetNovaCliOptions.ps1
@@ -4,6 +4,7 @@ function ConvertFrom-NovaCliArgument {
         [string[]]$Arguments
     )
 
+    $Arguments = ConvertTo-NovaCliArgumentArray -BoundParameters $PSBoundParameters -Arguments $Arguments
     $options = @{}
     $index = 0
 

--- a/src/private/release/InitiateGitRepo.ps1
+++ b/src/private/release/InitiateGitRepo.ps1
@@ -11,21 +11,26 @@ function New-InitiateGitRepo {
         return
     }
     Push-Location -StackName 'GitInit'
-    # Navigate to the specified directory
-    Set-Location $DirectoryPath
+    try {
+        # Navigate to the specified directory
+        Set-Location $DirectoryPath
 
-    # Check if a Git repository already exists
-    if (Test-Path -Path '.git') {
-        Write-Warning 'A Git repository already exists in this directory.'
-        return
-    }
-    if ($PSCmdlet.ShouldProcess($DirectoryPath, ("Initiating git on $DirectoryPath"))) {
-        try {
-            git init | Out-Null
-        } catch {
-            Write-Error 'Failed to initialize Git repo'
+        # Check if a Git repository already exists
+        if (Test-Path -Path '.git') {
+            Write-Warning 'A Git repository already exists in this directory.'
+            return
         }
+
+        if ( $PSCmdlet.ShouldProcess($DirectoryPath, ("Initiating git on $DirectoryPath"))) {
+            try {
+                git init | Out-Null
+            } catch {
+                throw "Failed to initialize Git repo: $( $_.Exception.Message )"
+            }
+        }
+        Write-Verbose 'Git repository initialized successfully'
     }
-    Write-Verbose 'Git repository initialized successfully'
-    Pop-Location -StackName 'GitInit'
+    finally {
+        Pop-Location -StackName 'GitInit'
+    }
 }

--- a/src/private/scaffold/InitializeNovaModuleScaffold.ps1
+++ b/src/private/scaffold/InitializeNovaModuleScaffold.ps1
@@ -6,7 +6,7 @@ function Initialize-NovaModuleScaffold {
     )
 
     if (Test-Path $Paths.Project) {
-        Write-Error 'Project already exists, aborting' | Out-Null
+        throw 'Project already exists, aborting'
     }
 
     Write-Message "`nStarted Module Scaffolding" -color Green

--- a/src/private/scaffold/ReadNovaModuleAnswers.ps1
+++ b/src/private/scaffold/ReadNovaModuleAnswers.ps1
@@ -10,7 +10,7 @@ function Read-NovaModuleAnswerSet {
     }
 
     if ($answer.ProjectName -notmatch '^[A-Za-z][A-Za-z0-9_.]*$') {
-        Write-Error 'Module Name invalid. Module should be one word and contain only Letters,Numbers and '
+        throw 'Module name is invalid. Use a single word that starts with a letter and contains only letters, numbers, underscores, or periods.'
     }
 
     return $answer

--- a/src/private/shared/Read-ProjectJsonData.ps1
+++ b/src/private/shared/Read-ProjectJsonData.ps1
@@ -10,7 +10,7 @@ function Read-ProjectJsonData {
     }
 
     try {
-        $jsonData = $projectJsonContent | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+        $jsonData = $projectJsonContent | ConvertFrom-Json -AsHashtable
     }
     catch {
         throw "project.json is not valid JSON: $ProjectJsonPath. $( $_.Exception.Message )"

--- a/src/private/shared/Read-ProjectJsonData.ps1
+++ b/src/private/shared/Read-ProjectJsonData.ps1
@@ -1,0 +1,25 @@
+function Read-ProjectJsonData {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ProjectJsonPath
+    )
+
+    $projectJsonContent = Get-Content -LiteralPath $ProjectJsonPath -Raw
+    if ( [string]::IsNullOrWhiteSpace($projectJsonContent)) {
+        throw "project.json is empty: $ProjectJsonPath"
+    }
+
+    try {
+        $jsonData = $projectJsonContent | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+    }
+    catch {
+        throw "project.json is not valid JSON: $ProjectJsonPath. $( $_.Exception.Message )"
+    }
+
+    if ($jsonData -isnot [hashtable]) {
+        throw "project.json must contain a top-level JSON object: $ProjectJsonPath"
+    }
+
+    return $jsonData
+}
+

--- a/src/public/GetNovaProjectInfo.ps1
+++ b/src/public/GetNovaProjectInfo.ps1
@@ -12,7 +12,7 @@ function Get-NovaProjectInfo {
         throw "Not a project folder. project.json not found: $projectJson"
     }
 
-    $jsonData = Get-Content -LiteralPath $projectJson -Raw | ConvertFrom-Json -AsHashtable
+    $jsonData = Read-ProjectJsonData -ProjectJsonPath $projectJson
 
     $Out = @{}
     $Out['ProjectJSON'] = $ProjectJson

--- a/src/public/GetNovaProjectInfo.ps1
+++ b/src/public/GetNovaProjectInfo.ps1
@@ -21,9 +21,16 @@ function Get-NovaProjectInfo {
         $Out[$key] = $jsonData[$key]
     }
 
-    foreach ($boolKey in @('BuildRecursiveFolders', 'FailOnDuplicateFunctionNames', 'SetSourcePath')) {
+    $booleanDefaults = [ordered]@{
+        BuildRecursiveFolders = $true
+        FailOnDuplicateFunctionNames = $true
+        SetSourcePath = $true
+        CopyResourcesToModuleRoot = $false
+    }
+
+    foreach ($boolKey in $booleanDefaults.Keys) {
         if (-not $Out.ContainsKey($boolKey)) {
-            $Out[$boolKey] = $true
+            $Out[$boolKey] = $booleanDefaults[$boolKey]
             continue
         }
 

--- a/src/public/InvokeNovaBuild.ps1
+++ b/src/public/InvokeNovaBuild.ps1
@@ -2,7 +2,6 @@ function Invoke-NovaBuild {
     [CmdletBinding()]
     param (
     )
-    $ErrorActionPreference = 'Stop'
     Reset-ProjectDist
     Build-Module
 

--- a/src/public/InvokeNovaCli.ps1
+++ b/src/public/InvokeNovaCli.ps1
@@ -9,36 +9,41 @@ function Invoke-NovaCli {
         [string[]]$Arguments
     )
 
+    $commonParameters = @{}
+    if ( $PSBoundParameters.ContainsKey('Verbose')) {
+        $commonParameters.Verbose = $true
+    }
+
     switch ($Command) {
         'info' {
-            return Get-NovaProjectInfo
+            return Get-NovaProjectInfo @commonParameters
         }
         'version' {
             return Get-NovaProjectInfo -Version
         }
         'build' {
-            return Invoke-NovaBuild
+            return Invoke-NovaBuild @commonParameters
         }
         'test' {
-            return Test-NovaBuild
+            return Test-NovaBuild @commonParameters
         }
         'init' {
             if ($Arguments.Count -gt 0) {
-                return New-NovaModule -Path $Arguments[0]
+                return New-NovaModule -Path $Arguments[0] @commonParameters
             }
 
-            return New-NovaModule
+            return New-NovaModule @commonParameters
         }
         'bump' {
-            return Update-NovaModuleVersion
+            return Update-NovaModuleVersion @commonParameters
         }
         'publish' {
             $options = ConvertFrom-NovaCliArgument -Arguments $Arguments
-            return Publish-NovaModule @options
+            return Publish-NovaModule @options @commonParameters
         }
         'release' {
             $options = ConvertFrom-NovaCliArgument -Arguments $Arguments
-            return Invoke-NovaRelease -PublishOption $options
+            return Invoke-NovaRelease -PublishOption $options @commonParameters
         }
         '--version' {
             return Get-NovaCliInstalledVersion

--- a/src/public/InvokeNovaCli.ps1
+++ b/src/public/InvokeNovaCli.ps1
@@ -14,6 +14,8 @@ function Invoke-NovaCli {
         $commonParameters.Verbose = $true
     }
 
+    $Arguments = ConvertTo-NovaCliArgumentArray -BoundParameters $PSBoundParameters -Arguments $Arguments
+
     switch ($Command) {
         'info' {
             return Get-NovaProjectInfo @commonParameters

--- a/src/public/InvokeNovaRelease.ps1
+++ b/src/public/InvokeNovaRelease.ps1
@@ -9,15 +9,22 @@ function Invoke-NovaRelease {
     try {
         $projectInfo = Get-NovaProjectInfo
         $publishParams = @{ProjectInfo = $projectInfo}
+        $hasRepository = $PublishOption.ContainsKey('Repository')
 
-        if ( $PublishOption.ContainsKey('Repository')) {
+        if ($hasRepository) {
             $publishAction = (Get-Command -Name Publish-NovaBuiltModuleToRepository -CommandType Function).ScriptBlock
             $publishParams.Repository = $PublishOption.Repository
             $publishParams.ApiKey = $PublishOption.ApiKey
         }
         else {
             $publishAction = (Get-Command -Name Publish-NovaBuiltModuleToDirectory -CommandType Function).ScriptBlock
-            $resolvedModuleDirectoryPath = $PublishOption.ModuleDirectoryPath
+            $resolvedModuleDirectoryPath = if ( $PublishOption.ContainsKey('ModuleDirectoryPath')) {
+                $PublishOption.ModuleDirectoryPath
+            }
+            else {
+                $null
+            }
+
             if ( [string]::IsNullOrWhiteSpace($resolvedModuleDirectoryPath)) {
                 $resolvedModuleDirectoryPath = Get-LocalModulePath
             }
@@ -25,7 +32,7 @@ function Invoke-NovaRelease {
             $publishParams.ModuleDirectoryPath = $resolvedModuleDirectoryPath
         }
 
-        if ($PublishOption.Local) {
+        if ($PublishOption.ContainsKey('Local') -and $PublishOption.Local) {
             Write-Verbose 'Using local release mode.'
         }
 

--- a/src/public/NewNovaModule.ps1
+++ b/src/public/NewNovaModule.ps1
@@ -3,10 +3,9 @@ function New-NovaModule {
     param (
         [string]$Path = (Get-Location).Path
     )
-    $ErrorActionPreference = 'Stop'
 
     if (-not (Test-Path $Path)) {
-        Write-Error 'Not a valid path'
+        throw 'Not a valid path'
     }
 
     $questionSet = Get-NovaModuleQuestionSet

--- a/src/public/TestNovaBuild.ps1
+++ b/src/public/TestNovaBuild.ps1
@@ -43,7 +43,7 @@ function Test-NovaBuild {
     $pesterConfig.TestResult.OutputPath = $testResultPath
     $TestResult = Invoke-Pester -Configuration $pesterConfig
     if ($TestResult.Result -ne 'Passed') {
-        Write-Error 'Tests failed' -ErrorAction Stop
+        throw 'Tests failed'
         return $LASTEXITCODE
     }
 }

--- a/src/public/UpdateNovaModuleVersion.ps1
+++ b/src/public/UpdateNovaModuleVersion.ps1
@@ -6,7 +6,7 @@ function Update-NovaModuleVersion {
 
     $projectRoot = (Resolve-Path -LiteralPath $Path).Path
     $before = Get-NovaProjectInfo -Path $projectRoot
-    $commitMessages = Get-GitCommitMessageForVersionBump -ProjectRoot $projectRoot
+    $commitMessages = @(Get-GitCommitMessageForVersionBump -ProjectRoot $projectRoot)
     $label = Get-VersionLabelFromCommitSet -Messages $commitMessages
 
     Push-Location -LiteralPath $projectRoot

--- a/src/resources/ProjectTemplate.json
+++ b/src/resources/ProjectTemplate.json
@@ -2,10 +2,6 @@
     "ProjectName": "",
     "Description": "",
     "Version": "",
-  "CopyResourcesToModuleRoot": false,
-    "BuildRecursiveFolders": true,
-    "SetSourcePath": true,
-    "FailOnDuplicateFunctionNames": true,
   "Preamble": [],
     "Manifest": {
         "Author": "",

--- a/src/resources/ProjectTemplate.json
+++ b/src/resources/ProjectTemplate.json
@@ -2,7 +2,7 @@
     "ProjectName": "",
     "Description": "",
     "Version": "",
-    "copyResourcesToModuleRoot": false,
+  "CopyResourcesToModuleRoot": false,
     "BuildRecursiveFolders": true,
     "SetSourcePath": true,
     "FailOnDuplicateFunctionNames": true,

--- a/src/resources/Schema-Build.json
+++ b/src/resources/Schema-Build.json
@@ -12,7 +12,7 @@
         "Version": {
             "type": "string"
         },
-        "copyResourcesToModuleRoot": {
+      "CopyResourcesToModuleRoot": {
             "type": "boolean"
         },
         "BuildRecursiveFolders": {

--- a/src/resources/nova
+++ b/src/resources/nova
@@ -14,6 +14,32 @@ else {
     @()
 }
 
+$forwardVerbose = $false
+$remainingArguments = New-Object 'System.Collections.Generic.List[string]'
+
+foreach ($argument in $Arguments) {
+    switch -Regex ($argument) {
+        '^(--verbose|-Verbose)$' {
+            $forwardVerbose = $true
+            continue
+        }
+        default {
+            $remainingArguments.Add($argument)
+        }
+    }
+}
+
+$Arguments = @($remainingArguments)
+
 Import-Module NovaModuleTools -Force
 
-Invoke-NovaCli -Command $Command @Arguments
+$invokeParameters = @{
+    Command = $Command
+    Arguments = @($Arguments)
+}
+
+if ($forwardVerbose) {
+    $invokeParameters.Verbose = $true
+}
+
+Invoke-NovaCli @invokeParameters

--- a/tests/BuildOptions.TestSupport.ps1
+++ b/tests/BuildOptions.TestSupport.ps1
@@ -37,7 +37,7 @@ function Write-TestProjectJson {
         ProjectName = ('' + $Options.ProjectName)
         Description = 'Test project'
         Version = '0.0.1'
-        copyResourcesToModuleRoot = $false
+        CopyResourcesToModuleRoot = $false
         Manifest = [ordered]@{
             Author = 'Test'
             PowerShellHostVersion = '7.4'
@@ -72,8 +72,8 @@ function Write-TestProjectJson {
         $project.Preamble = $Options.Preamble
     }
 
-    if ( $Options.ContainsKey('copyResourcesToModuleRoot')) {
-        $project.copyResourcesToModuleRoot = [bool]$Options.copyResourcesToModuleRoot
+    if ( $Options.ContainsKey('CopyResourcesToModuleRoot')) {
+        $project.CopyResourcesToModuleRoot = [bool]$Options.CopyResourcesToModuleRoot
     }
 
     $json = $project | ConvertTo-Json -Depth 10
@@ -354,7 +354,7 @@ function New-TestProjectWithResources {
         ProjectName = $Name
         BuildRecursiveFolders = $false
         FailOnDuplicateFunctionNames = $false
-        copyResourcesToModuleRoot = $CopyResourcesToModuleRoot
+        CopyResourcesToModuleRoot = $CopyResourcesToModuleRoot
     }
 
     New-Item -ItemType Directory -Path (Join-Path $root 'src/resources/nested') -Force | Out-Null

--- a/tests/BuildOptions.TestSupport.ps1
+++ b/tests/BuildOptions.TestSupport.ps1
@@ -37,7 +37,6 @@ function Write-TestProjectJson {
         ProjectName = ('' + $Options.ProjectName)
         Description = 'Test project'
         Version = '0.0.1'
-        CopyResourcesToModuleRoot = $false
         Manifest = [ordered]@{
             Author = 'Test'
             PowerShellHostVersion = '7.4'

--- a/tests/BuildOptions.TestSupport.ps1
+++ b/tests/BuildOptions.TestSupport.ps1
@@ -321,7 +321,6 @@ function Invoke-TestProjectTests {
 
     $scriptPath = Join-Path $ProjectRoot 'Run-TestNovaBuild.ps1'
     $script = @"
-`$ErrorActionPreference = 'Stop'
 Import-Module '$ModulePath' -Force
 Set-Location -LiteralPath '$ProjectRoot'
 Invoke-NovaBuild

--- a/tests/BuildOptions.Tests.ps1
+++ b/tests/BuildOptions.Tests.ps1
@@ -56,6 +56,7 @@ Describe 'Invoke-NovaBuild options' {
         $example = Get-Content -LiteralPath (Join-Path $repoRoot 'example/project.json') -Raw | ConvertFrom-Json
 
         foreach ($project in @($template, $example)) {
+            $project.PSObject.Properties.Name | Should -Contain 'CopyResourcesToModuleRoot'
             $project.BuildRecursiveFolders | Should -BeTrue
             $project.SetSourcePath | Should -BeTrue
             $project.FailOnDuplicateFunctionNames | Should -BeTrue
@@ -194,7 +195,7 @@ Describe 'Invoke-NovaBuild options' {
         Remove-Module SetSourceOn -ErrorAction SilentlyContinue
     }
 
-    It 'copyResourcesToModuleRoot=true copies resource content directly into the built module root' {
+    It 'CopyResourcesToModuleRoot=true copies resource content directly into the built module root' {
         $project = New-TestProjectWithResources -TestDriveRoot $TestDrive -Name 'ResourceToRoot' -CopyResourcesToModuleRoot $true
 
         (Test-Path -LiteralPath (Join-Path $project.ModuleDir 'config.json')) | Should -BeTrue
@@ -202,7 +203,7 @@ Describe 'Invoke-NovaBuild options' {
         (Test-Path -LiteralPath (Join-Path $project.ModuleDir 'resources')) | Should -BeFalse
     }
 
-    It 'copyResourcesToModuleRoot=false keeps resources inside a resources folder in the built module' {
+    It 'CopyResourcesToModuleRoot=false keeps resources inside a resources folder in the built module' {
         $project = New-TestProjectWithResources -TestDriveRoot $TestDrive -Name 'ResourceToFolder' -CopyResourcesToModuleRoot $false
 
         (Test-Path -LiteralPath (Join-Path $project.ModuleDir 'resources/config.json')) | Should -BeTrue

--- a/tests/BuildOptions.Tests.ps1
+++ b/tests/BuildOptions.Tests.ps1
@@ -51,16 +51,17 @@ BeforeAll {
 
 Describe 'Invoke-NovaBuild options' {
 
-    It 'project template and example project use enterprise defaults' {
+    It 'project template can omit CopyResourcesToModuleRoot because the default is false' {
         $template = Get-Content -LiteralPath (Join-Path $repoRoot 'src/resources/ProjectTemplate.json') -Raw | ConvertFrom-Json
+
+        $template.PSObject.Properties.Name | Should -Not -Contain 'CopyResourcesToModuleRoot'
+    }
+
+    It 'example project shows CopyResourcesToModuleRoot explicitly for discoverability' {
         $example = Get-Content -LiteralPath (Join-Path $repoRoot 'example/project.json') -Raw | ConvertFrom-Json
 
-        foreach ($project in @($template, $example)) {
-            $project.PSObject.Properties.Name | Should -Contain 'CopyResourcesToModuleRoot'
-            $project.BuildRecursiveFolders | Should -BeTrue
-            $project.SetSourcePath | Should -BeTrue
-            $project.FailOnDuplicateFunctionNames | Should -BeTrue
-        }
+        $example.PSObject.Properties.Name | Should -Contain 'CopyResourcesToModuleRoot'
+        $example.CopyResourcesToModuleRoot | Should -BeFalse
     }
 
     It 'example project builds and tests successfully as a working reference project' {

--- a/tests/CodeSceneAnalysis.Tests.ps1
+++ b/tests/CodeSceneAnalysis.Tests.ps1
@@ -22,7 +22,6 @@ Describe 'Invoke-CodeSceneAnalysis' {
     It 'supports trigger-only runs when CoveragePath is omitted' {
         $requestLogPath = Join-Path $TestDrive 'codescene-request.txt'
         $runnerContent = @"
-`$ErrorActionPreference = 'Stop'
 function Invoke-WebRequest {
     param(
         [string]`$Uri,
@@ -57,7 +56,6 @@ function Invoke-WebRequest {
         Set-Content -LiteralPath $coveragePath -Value '<coverage />' -Encoding utf8
 
         $runnerContent = @"
-`$ErrorActionPreference = 'Stop'
 function cs-coverage {
     param([Parameter(ValueFromRemainingArguments = `$true)][string[]]`$ArgumentList)
 

--- a/tests/CoverageGaps.Tests.ps1
+++ b/tests/CoverageGaps.Tests.ps1
@@ -190,6 +190,7 @@ Describe 'Coverage gaps for scaffold, CLI, release, and helper internals' {
             $project.ProjectName | Should -Be 'NovaJson'
             $project.Description | Should -Be 'Generated project'
             $project.Version | Should -Be '2.3.4'
+            $project.CopyResourcesToModuleRoot | Should -BeFalse
             $project.Manifest.Author | Should -Be 'Test Author'
             $project.Manifest.PowerShellHostVersion | Should -Be '7.4'
             $project.Manifest.GUID | Should -Be '11111111-1111-1111-1111-111111111111'
@@ -457,7 +458,7 @@ Describe 'Coverage gaps for scaffold, CLI, release, and helper internals' {
             $projectInfo = [pscustomobject]@{
                 PublicDir = '/tmp/public'
                 ResourcesDir = '/tmp/resources'
-                copyResourcesToModuleRoot = $false
+                CopyResourcesToModuleRoot = $false
                 Manifest = [ordered]@{Author = 'Tester'; CompanyName = 'Nova'}
                 Version = '1.2.3-preview'
                 Description = 'Example'
@@ -494,7 +495,7 @@ Describe 'Coverage gaps for scaffold, CLI, release, and helper internals' {
                 [pscustomobject]@{
                     PublicDir = '/tmp/public'
                     ResourcesDir = '/tmp/resources'
-                    copyResourcesToModuleRoot = $false
+                    CopyResourcesToModuleRoot = $false
                     Manifest = [ordered]@{Author = 'Tester'; CompanyName = 'Nova'}
                     Version = '1.2.3-preview'
                     Description = 'Example'

--- a/tests/CoverageGaps.Tests.ps1
+++ b/tests/CoverageGaps.Tests.ps1
@@ -124,9 +124,7 @@ Describe 'Coverage gaps for scaffold, CLI, release, and helper internals' {
                     }
                 }
             }
-            Mock Write-Error {throw $Message}
-
-            {Read-NovaModuleAnswerSet -Questions $questions} | Should -Throw 'Module Name invalid*'
+            {Read-NovaModuleAnswerSet -Questions $questions} | Should -Throw 'Module name is invalid*'
         }
     }
 
@@ -161,14 +159,16 @@ Describe 'Coverage gaps for scaffold, CLI, release, and helper internals' {
                 Tests = Join-Path $TestDrive 'ExistingProject/tests'
             }
             $null = New-Item -ItemType Directory -Path $paths.Project -Force
-            Mock Write-Error {}
             Mock Write-Message {}
             Mock New-Item {}
             Mock New-InitiateGitRepo {}
 
-            Initialize-NovaModuleScaffold -Answer @{EnablePester = 'No'; EnableGit = 'No'} -Paths $paths
+            {
+                Initialize-NovaModuleScaffold -Answer @{EnablePester = 'No'; EnableGit = 'No'} -Paths $paths
+            } | Should -Throw 'Project already exists, aborting'
 
-            Assert-MockCalled Write-Error -Times 1 -ParameterFilter {$Message -like 'Project already exists*'}
+            Assert-MockCalled New-Item -Times 0
+            Assert-MockCalled New-InitiateGitRepo -Times 0
         }
     }
 
@@ -232,15 +232,23 @@ Describe 'Coverage gaps for scaffold, CLI, release, and helper internals' {
                     ProjectJsonFile = '/tmp/NovaDryRun/project.json'
                 }
             }
-            Mock Write-Error {}
             Mock Initialize-NovaModuleScaffold {}
             Mock Write-NovaModuleProjectJson {}
 
-            New-NovaModule -Path '/tmp/does-not-exist' -WhatIf
+            {New-NovaModule -Path '/tmp/does-not-exist' -WhatIf} | Should -Throw 'Not a valid path'
 
-            Assert-MockCalled Write-Error -Times 1 -ParameterFilter {$Message -eq 'Not a valid path'}
             Assert-MockCalled Initialize-NovaModuleScaffold -Times 0
             Assert-MockCalled Write-NovaModuleProjectJson -Times 0
+        }
+    }
+
+    It 'Read-NovaModuleAnswerSet rejects invalid module names with a terminating error' {
+        InModuleScope $script:moduleName {
+            Mock Read-AwesomeHost {'invalid name!'}
+
+            {
+                Read-NovaModuleAnswerSet -Questions @{ProjectName = @{Prompt = 'Name?'}}
+            } | Should -Throw 'Module name is invalid*'
         }
     }
 

--- a/tests/CoverageGaps.Tests.ps1
+++ b/tests/CoverageGaps.Tests.ps1
@@ -190,7 +190,7 @@ Describe 'Coverage gaps for scaffold, CLI, release, and helper internals' {
             $project.ProjectName | Should -Be 'NovaJson'
             $project.Description | Should -Be 'Generated project'
             $project.Version | Should -Be '2.3.4'
-            $project.CopyResourcesToModuleRoot | Should -BeFalse
+            $project.ContainsKey('CopyResourcesToModuleRoot') | Should -BeFalse
             $project.Manifest.Author | Should -Be 'Test Author'
             $project.Manifest.PowerShellHostVersion | Should -Be '7.4'
             $project.Manifest.GUID | Should -Be '11111111-1111-1111-1111-111111111111'

--- a/tests/CoverageGaps.Tests.ps1
+++ b/tests/CoverageGaps.Tests.ps1
@@ -177,20 +177,14 @@ Describe 'Coverage gaps for scaffold, CLI, release, and helper internals' {
             $projectJsonPath = Join-Path $TestDrive 'project.json'
             Mock New-Guid {[guid]'11111111-1111-1111-1111-111111111111'}
 
-            Push-Location -LiteralPath $script:repoRoot
-            try {
-                Write-NovaModuleProjectJson -Answer @{
-                    ProjectName = 'NovaJson'
-                    Description = 'Generated project'
-                    Version = '2.3.4'
-                    Author = 'Test Author'
-                    PowerShellHostVersion = '7.4'
-                    EnablePester = 'No'
-                } -ProjectJsonFile $projectJsonPath
-            }
-            finally {
-                Pop-Location
-            }
+            Write-NovaModuleProjectJson -Answer @{
+                ProjectName = 'NovaJson'
+                Description = 'Generated project'
+                Version = '2.3.4'
+                Author = 'Test Author'
+                PowerShellHostVersion = '7.4'
+                EnablePester = 'No'
+            } -ProjectJsonFile $projectJsonPath
 
             $project = Get-Content -LiteralPath $projectJsonPath -Raw | ConvertFrom-Json -AsHashtable
             $project.ProjectName | Should -Be 'NovaJson'

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -39,6 +39,16 @@ Describe 'Nova command model' {
         }
     }
 
+    It 'Get-NovaProjectInfo throws a clear error when project.json is empty' {
+        InModuleScope $script:moduleName {
+            $projectRoot = Join-Path $TestDrive 'empty-project-json'
+            New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+            Set-Content -LiteralPath (Join-Path $projectRoot 'project.json') -Value '' -Encoding utf8
+
+            {Get-NovaProjectInfo -Path $projectRoot} | Should -Throw 'project.json is empty:*'
+        }
+    }
+
     It 'build output includes the generated external help file' {
         Test-Path -LiteralPath $script:helpXmlPath | Should -BeTrue
     }
@@ -404,6 +414,75 @@ title: Invoke-NovaBuild
             $helpText | Should -Match 'usage: nova \[--version\] \[--help\] <command> \[<args>\]'
             $helpText | Should -Match 'version\s+Show the current project version from project.json'
             $versionText | Should -Match ([regex]::Escape($installedModuleVersion))
+        }
+        finally {
+            $env:PSModulePath = $originalModulePath
+        }
+    }
+
+    It 'Install-NovaCli forwards -Verbose from the standalone launcher to build output' {
+        $targetDirectory = Join-Path $TestDrive 'verbose-bin'
+        $installedPath = Join-Path $targetDirectory 'nova'
+        $projectRoot = Join-Path $TestDrive 'CliVerboseBuildProject'
+        $originalModulePath = $env:PSModulePath
+        $modulePathSeparator = [string][System.IO.Path]::PathSeparator
+        $distParent = Split-Path -Parent $distModuleDir
+
+        $env:PSModulePath = "$distParent$modulePathSeparator$originalModulePath"
+
+        New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+        foreach ($dir in @('src/public', 'src/private', 'src/classes', 'src/resources', 'tests', 'docs')) {
+            New-Item -ItemType Directory -Path (Join-Path $projectRoot $dir) -Force | Out-Null
+        }
+
+        @'
+{
+  "ProjectName": "CliVerboseBuildProject",
+  "Description": "CLI verbose forwarding test project",
+  "Version": "0.0.1",
+  "copyResourcesToModuleRoot": false,
+  "Manifest": {
+    "Author": "Test",
+    "PowerShellHostVersion": "7.4",
+    "GUID": "22222222-2222-2222-2222-222222222222",
+    "Tags": [],
+    "ProjectUri": ""
+  },
+  "Pester": {
+    "TestResult": {
+      "Enabled": true,
+      "OutputFormat": "NUnitXml"
+    },
+    "Output": {
+      "Verbosity": "Detailed"
+    }
+  }
+}
+'@ | Set-Content -LiteralPath (Join-Path $projectRoot 'project.json') -Encoding utf8
+
+        @'
+function Invoke-TestCliVerbose {
+    'ok'
+}
+'@ | Set-Content -LiteralPath (Join-Path $projectRoot 'src/public/Invoke-TestCliVerbose.ps1') -Encoding utf8
+
+        try {
+            Install-NovaCli -DestinationDirectory $targetDirectory -Force | Out-Null
+
+            Push-Location $projectRoot
+            try {
+                $buildOutput = & $installedPath build -Verbose 2>&1
+                $buildText = @($buildOutput) -join [Environment]::NewLine
+                $buildExitCode = $LASTEXITCODE
+            }
+            finally {
+                Pop-Location
+            }
+
+            $buildExitCode | Should -Be 0
+            $buildText | Should -Match 'VERBOSE: Running NovaModuleTools Version:'
+            $buildText | Should -Match 'VERBOSE: Buidling module psm1 file'
+            (Test-Path -LiteralPath (Join-Path $projectRoot 'dist/CliVerboseBuildProject/CliVerboseBuildProject.psm1')) | Should -BeTrue
         }
         finally {
             $env:PSModulePath = $originalModulePath

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -49,6 +49,30 @@ Describe 'Nova command model' {
         }
     }
 
+    It 'Get-NovaProjectInfo exposes CopyResourcesToModuleRoot with a false default when omitted' {
+        InModuleScope $script:moduleName {
+            $projectRoot = Join-Path $TestDrive 'default-copy-resources-option'
+            New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+            $projectJson = ([ordered]@{
+                ProjectName = 'DefaultCopyResourcesProject'
+                Description = 'Defaulted option test'
+                Version = '0.0.1'
+                Manifest = [ordered]@{
+                    Author = 'Test'
+                    PowerShellHostVersion = '7.4'
+                    GUID = '11111111-1111-1111-1111-111111111111'
+                }
+            } | ConvertTo-Json -Depth 5)
+
+            Set-Content -LiteralPath (Join-Path $projectRoot 'project.json') -Value $projectJson -Encoding utf8
+
+            $projectInfo = Get-NovaProjectInfo -Path $projectRoot
+
+            $projectInfo.PSObject.Properties.Name | Should -Contain 'CopyResourcesToModuleRoot'
+            $projectInfo.CopyResourcesToModuleRoot | Should -BeFalse
+        }
+    }
+
     It 'build output includes the generated external help file' {
         Test-Path -LiteralPath $script:helpXmlPath | Should -BeTrue
     }
@@ -440,7 +464,7 @@ title: Invoke-NovaBuild
   "ProjectName": "CliVerboseBuildProject",
   "Description": "CLI verbose forwarding test project",
   "Version": "0.0.1",
-  "copyResourcesToModuleRoot": false,
+  "CopyResourcesToModuleRoot": false,
   "Manifest": {
     "Author": "Test",
     "PowerShellHostVersion": "7.4",

--- a/tests/PreambleBuild.Tests.ps1
+++ b/tests/PreambleBuild.Tests.ps1
@@ -72,7 +72,7 @@ Describe 'Invoke-NovaBuild Preamble setting' {
             Preamble = @(
                 '# Module initialization'
                 'Set-StrictMode -Version Latest'
-                "`$ErrorActionPreference = 'Stop'"
+                "`$script:ModuleInitialized = `$true"
             )
         }
         $content = Get-BuiltModuleContent -ProjectRoot $root
@@ -80,7 +80,7 @@ Describe 'Invoke-NovaBuild Preamble setting' {
         $expectedStart = @(
             '# Module initialization'
             'Set-StrictMode -Version Latest'
-            "`$ErrorActionPreference = 'Stop'"
+            "`$script:ModuleInitialized = `$true"
             ''
             'function Invoke-PublicTop { "public" }'
         ) -join $newLine
@@ -94,7 +94,7 @@ Describe 'Invoke-NovaBuild Preamble setting' {
             IncludeClassAndPrivate = $true
             Preamble = @(
                 'Set-StrictMode -Version Latest'
-                "`$ErrorActionPreference = 'Stop'"
+                "`$script:ModuleInitialized = `$true"
             )
         }
 
@@ -103,7 +103,7 @@ Describe 'Invoke-NovaBuild Preamble setting' {
         $firstMarker = '# Source: src/classes/nested/Thing.ps1'
         $expectedStart = @(
             'Set-StrictMode -Version Latest'
-            "`$ErrorActionPreference = 'Stop'"
+            "`$script:ModuleInitialized = `$true"
             ''
             $firstMarker
         ) -join $newLine


### PR DESCRIPTION
- Standardized the project setting name on `CopyResourcesToModuleRoot` across templates, tests, code, and documentation.
- Made `CopyResourcesToModuleRoot` optional in `project.json`; when omitted, NovaModuleTools now defaults it to `false`.
- Kept `CopyResourcesToModuleRoot` visible in `example/project.json` so new users can still discover the setting from
  the
  working reference project even though generated projects may omit it.
- Internal build, scaffold, and CI entrypoints no longer rely on blanket `$ErrorActionPreference = 'Stop'` settings;
  they now use
  explicit terminating errors where needed, and the repository examples were updated to match.
  
  
- Fixed the standalone macOS/Linux `nova` launcher so `nova build -Verbose` now forwards the verbose flag into the
  actual build command instead of being consumed at the launcher boundary.
- Fixed `Get-NovaProjectInfo` to report empty `project.json` files with a clear configuration error instead of failing
  later with a null-argument binding exception.
- Fixed internal build, release, and CLI code paths so enabling a module preamble such as
  `Set-StrictMode -Version Latest`
  and `$ErrorActionPreference = 'Stop'` no longer breaks the repository test suite or the example project build.
  
  - Updated `README.md` and `CONTRIBUTING.md` to remove stale `$ErrorActionPreference = 'Stop'` examples from the default
  preamble and local quality workflow.

- New optional project setting `CopyResourcesToModuleRoot`. Setting to true places resource files in the root directory
  of module. Default is `false` to provide backward compatibility. 

- Fixed the example project README so it no longer suggests that `example/` includes a `run.ps1` helper script; it now
  points users to building `NovaModuleTools` from the repository root or using the Gallery workflow.