### PR TITLE
Enhance test coverage and improve user prompts and Git support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format follows the principles from Keep a Changelog and the project aims to 
     - build-time resource lookup from `src/resources`
     - packaged/built module publish behavior
     - `Update-NovaModuleVersion -WhatIf`
+  - `Read-AwesomeHost` standard, mandatory, default, and choice prompt flows
 - Added a working `example/` project that can be built, tested, imported, and used as a practical reference for new
   NovaModuleTools users.
 - Added a standalone `scripts/build/Invoke-ScriptAnalyzerCI.ps1` helper so ScriptAnalyzer can run as a dedicated quality
@@ -35,6 +36,8 @@ The format follows the principles from Keep a Changelog and the project aims to 
   JUnit/Cobertura test
   reports, remap coverage to source paths, and upload coverage to CodeScene.
 - Added regression coverage for the Cobertura source-path remapping used by the CodeScene upload flow.
+- Added `artifacts/coverage-low.txt` generation in the CI helper flow so low-coverage files are refreshed from the
+  latest Cobertura report.
 - Added optional `Preamble` support in `project.json` so builds can inject module-level setup lines at the very top of
   the generated `.psm1` before any `# Source:` markers or other generated content.
 
@@ -80,6 +83,8 @@ The format follows the principles from Keep a Changelog and the project aims to 
 
 - Fixed the standalone macOS/Linux `nova` launcher so `nova build -Verbose` now forwards the verbose flag into the
   actual build command instead of being consumed at the launcher boundary.
+- Fixed the CI helper flow so its second Pester pass now reloads the freshly built `dist/` module instead of relying on
+  an installed `NovaModuleTools` copy during test discovery.
 - Fixed `Get-NovaProjectInfo` to report empty `project.json` files with a clear configuration error instead of failing
   later with a null-argument binding exception.
 - Fixed internal build, release, and CLI code paths so enabling a module preamble such as
@@ -134,6 +139,7 @@ The format follows the principles from Keep a Changelog and the project aims to 
   separate ScriptAnalyzer CI workflow.
 - Documented the new GitHub Actions coverage and CodeScene integration, including artifact paths and required CodeScene
   secrets.
+- Documented the generated `artifacts/coverage-low.txt` summary in the README artifact list.
 - Documented how to install the standalone `nova` launcher with `Install-NovaCli` and when to use the PowerShell alias
   instead.
 - Documented the new `Preamble` build setting in `README.md` and updated the example project to show a practical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format follows the principles from Keep a Changelog and the project aims to 
     - `Update-NovaModuleVersion -WhatIf`
   - `Read-AwesomeHost` standard, mandatory, default, and choice prompt flows
       - `Get-GitCommitMessageForVersionBump` tagged, untagged, and git-failure flows
+    - remaining low-coverage manifest, project-json, help-locale, dist-reset, publish, and CLI install branches
 - Added a working `example/` project that can be built, tested, imported, and used as a practical reference for new
   NovaModuleTools users.
 - Added a standalone `scripts/build/Invoke-ScriptAnalyzerCI.ps1` helper so ScriptAnalyzer can run as a dedicated quality
@@ -70,6 +71,8 @@ The format follows the principles from Keep a Changelog and the project aims to 
 - README and command documentation were refreshed to consistently use the Nova command names and describe the
   CLI/release workflow more clearly.
 - Release and test automation files were updated to better support the new Nova workflow.
+- `Test-ProjectSchema` no longer carries an unreachable default branch now that `Schema` is constrained by
+  `ValidateSet('Build', 'Pester')`.
 - The bundled `nova` launcher now ships as a packaged module resource instead of a repo-root helper file.
 - The GitHub test workflow now publishes CI artifacts and runs CodeScene coverage upload/analysis in a dedicated
   follow-up

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format follows the principles from Keep a Changelog and the project aims to 
     - packaged/built module publish behavior
     - `Update-NovaModuleVersion -WhatIf`
   - `Read-AwesomeHost` standard, mandatory, default, and choice prompt flows
+      - `Get-GitCommitMessageForVersionBump` tagged, untagged, and git-failure flows
 - Added a working `example/` project that can be built, tested, imported, and used as a practical reference for new
   NovaModuleTools users.
 - Added a standalone `scripts/build/Invoke-ScriptAnalyzerCI.ps1` helper so ScriptAnalyzer can run as a dedicated quality

--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Expected CI artifacts:
 - `artifacts/novamoduletools-nunit.xml` — NUnit XML from `Test-NovaBuild`
 - `artifacts/pester-junit.xml` — JUnit XML for CI systems that expect JUnit-compatible test reports
 - `artifacts/pester-coverage.cobertura.xml` — Cobertura XML with source-relative paths suitable for CodeScene upload
+- `artifacts/coverage-low.txt` — a simple low-coverage summary sorted by the least-covered source files first
 - `artifacts/scriptanalyzer.txt` — ScriptAnalyzer findings (or a no-findings report)
 
 ## Commands

--- a/scripts/build/ci/CodeSceneCoverageMap.ps1
+++ b/scripts/build/ci/CodeSceneCoverageMap.ps1
@@ -98,6 +98,62 @@ function Get-CoberturaPackageName {
     return (ConvertTo-CoberturaRelativePath $parentPath)
 }
 
+function Get-CoberturaSourceLineRange {
+    param([Parameter(Mandatory)][object[]]$Sections)
+
+    return [pscustomobject]@{
+        FirstSourceLine = ($Sections | Measure-Object -Property StartLine -Minimum).Minimum
+        LastSourceLine = ($Sections | Measure-Object -Property EndLine -Maximum).Maximum
+    }
+}
+
+function Test-CoberturaLineOutsideSourceRange {
+    param(
+        [Parameter(Mandatory)][pscustomobject]$LineRange,
+        [Parameter(Mandatory)][int]$LineNumber
+    )
+
+    return $LineNumber -lt $LineRange.FirstSourceLine -or $LineNumber -gt $LineRange.LastSourceLine
+}
+
+function Add-CoberturaMappedLineHit {
+    param(
+        [Parameter(Mandatory)][hashtable]$LineBucketsByFile,
+        [Parameter(Mandatory)][pscustomobject]$SourceSection,
+        [Parameter(Mandatory)][int]$BuiltLineNumber,
+        [Parameter(Mandatory)][int]$Hits
+    )
+
+    if (-not $LineBucketsByFile.ContainsKey($SourceSection.RelativePath)) {
+        $LineBucketsByFile[$SourceSection.RelativePath] = Get-EmptyCoberturaLineBucket
+    }
+
+    $sourceLineNumber = $BuiltLineNumber - $SourceSection.MarkerLine
+    Add-CoberturaLineHit -Bucket $LineBucketsByFile[$SourceSection.RelativePath] -LineNumber $sourceLineNumber -Hits $Hits
+}
+
+function Add-CoberturaLineNodeHit {
+    param(
+        [Parameter(Mandatory)][System.Xml.XmlNode]$LineNode,
+        [Parameter(Mandatory)][object[]]$SourceSections,
+        [Parameter(Mandatory)][pscustomobject]$SourceLineRange,
+        [Parameter(Mandatory)][hashtable]$LineBucketsByFile
+    )
+
+    $builtLineNumber = [int]$LineNode.number
+    $sourceSection = Find-SourceSectionForLine -Sections $SourceSections -LineNumber $builtLineNumber
+    if ($null -eq $sourceSection) {
+        if (Test-CoberturaLineOutsideSourceRange -LineRange $SourceLineRange -LineNumber $builtLineNumber) {
+            return $null
+        }
+
+        return $builtLineNumber
+    }
+
+    Add-CoberturaMappedLineHit -LineBucketsByFile $LineBucketsByFile -SourceSection $sourceSection -BuiltLineNumber $builtLineNumber -Hits ([int]$LineNode.hits)
+    return $null
+}
+
 function Get-CoberturaLineBucketMap {
     param(
         [Parameter(Mandatory)][string]$CoveragePath,
@@ -117,23 +173,16 @@ function Get-CoberturaLineBucketMap {
         throw "No Cobertura class nodes were found in coverage file: $CoveragePath"
     }
 
+    $sourceLineRange = Get-CoberturaSourceLineRange -Sections $sourceSections
+
     $lineBucketsByFile = @{}
     $unmappedLineNumbers = @()
     foreach ($classNode in $classNodes) {
         foreach ($lineNode in @($classNode.lines.line)) {
-            $builtLineNumber = [int]$lineNode.number
-            $sourceSection = Find-SourceSectionForLine -Sections $sourceSections -LineNumber $builtLineNumber
-            if ($null -eq $sourceSection) {
-                $unmappedLineNumbers += $builtLineNumber
-                continue
+            $unmappedLineNumber = Add-CoberturaLineNodeHit -LineNode $lineNode -SourceSections $sourceSections -SourceLineRange $sourceLineRange -LineBucketsByFile $lineBucketsByFile
+            if ($null -ne $unmappedLineNumber) {
+                $unmappedLineNumbers += $unmappedLineNumber
             }
-
-            if (-not $lineBucketsByFile.ContainsKey($sourceSection.RelativePath)) {
-                $lineBucketsByFile[$sourceSection.RelativePath] = Get-EmptyCoberturaLineBucket
-            }
-
-            $sourceLineNumber = $builtLineNumber - $sourceSection.MarkerLine
-            Add-CoberturaLineHit -Bucket $lineBucketsByFile[$sourceSection.RelativePath] -LineNumber $sourceLineNumber -Hits ([int]$lineNode.hits)
         }
     }
 

--- a/scripts/build/ci/CoverageLowReport.ps1
+++ b/scripts/build/ci/CoverageLowReport.ps1
@@ -1,0 +1,53 @@
+function ConvertTo-CoverageLineRate {
+    param([Parameter(Mandatory)][string]$Value)
+
+    return [double]::Parse($Value, [System.Globalization.CultureInfo]::InvariantCulture)
+}
+
+function Get-CoverageLowReportEntryList {
+    param(
+        [Parameter(Mandatory)][string]$CoveragePath,
+        [double]$Threshold = 0.9
+    )
+
+    [xml]$coverageXml = Get-Content -LiteralPath $CoveragePath -Raw
+    $classNodes = @($coverageXml.SelectNodes('/coverage/packages/package/classes/class'))
+
+    return @(
+    foreach ($classNode in $classNodes) {
+        $lineRate = ConvertTo-CoverageLineRate -Value ([string]$classNode.'line-rate')
+        if ($lineRate -ge $Threshold) {
+            continue
+        }
+
+        [pscustomobject]@{
+            Path = [string]$classNode.filename
+            LineRate = $lineRate
+        }
+    }
+    )
+}
+
+function Format-CoverageLowReportLine {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][double]$LineRate
+    )
+
+    return [string]::Format([System.Globalization.CultureInfo]::InvariantCulture, '{0:F6} {1}', $LineRate, $Path)
+}
+
+function Write-CoverageLowReport {
+    param(
+        [Parameter(Mandatory)][string]$CoveragePath,
+        [Parameter(Mandatory)][string]$OutputPath,
+        [double]$Threshold = 0.9
+    )
+
+    $reportLines = Get-CoverageLowReportEntryList -CoveragePath $CoveragePath -Threshold $Threshold |
+            Sort-Object LineRate, Path |
+            ForEach-Object {Format-CoverageLowReportLine -Path $_.Path -LineRate $_.LineRate}
+
+    Set-Content -LiteralPath $OutputPath -Value $reportLines -Encoding utf8
+}
+

--- a/scripts/build/ci/Invoke-NovaModuleToolsCI.ps1
+++ b/scripts/build/ci/Invoke-NovaModuleToolsCI.ps1
@@ -7,6 +7,7 @@ Set-StrictMode -Version Latest
 
 . (Join-Path $PSScriptRoot 'CodeSceneCoverageMap.ps1')
 . (Join-Path $PSScriptRoot 'CodeSceneCoverageXml.ps1')
+. (Join-Path $PSScriptRoot 'CoverageLowReport.ps1')
 
 function Get-CiTestPath {
     param([Parameter(Mandatory)][pscustomobject]$ProjectInfo)
@@ -62,6 +63,11 @@ Import-Module Pester -ErrorAction Stop
 Invoke-NovaBuild
 
 $projectInfo = Get-NovaProjectInfo
+$builtModulePath = $projectInfo.OutputModuleDir
+Remove-Module $projectInfo.ProjectName -ErrorAction SilentlyContinue
+Import-Module $builtModulePath -Force
+$projectInfo = Get-NovaProjectInfo
+
 if (-not $projectInfo.SetSourcePath) {
     throw "Code coverage upload requires project.json to set SetSourcePath=true so dist line coverage can be remapped back to src/ files for CodeScene."
 }
@@ -86,6 +92,7 @@ finally {
 $configuration = Get-CiPesterConfiguration -ProjectInfo $projectInfo -ArtifactsDirectory $OutputDirectory -ExcludedTags $ExcludeTag
 $result = Invoke-Pester -Configuration $configuration
 Convert-CoberturaCoverageToSourcePath -CoveragePath (Join-Path $OutputDirectory 'pester-coverage.cobertura.xml') -BuiltModulePath $projectInfo.ModuleFilePSM1 -RepoRoot $projectInfo.ProjectRoot
+Write-CoverageLowReport -CoveragePath (Join-Path $OutputDirectory 'pester-coverage.cobertura.xml') -OutputPath (Join-Path $OutputDirectory 'coverage-low.txt')
 
 if ($novaModuleToolsTestFailed -or $result.FailedCount -gt 0) {
     exit 1

--- a/src/private/build/TestProjectSchema.ps1
+++ b/src/private/build/TestProjectSchema.ps1
@@ -18,7 +18,6 @@ function Test-ProjectSchema {
         'Pester' {
             Test-Json -Path 'project.json' -Schema (Get-Content $SchemaPath.Pester -Raw)
         }
-        Default { $false }
     }
     return $result
 }

--- a/src/private/cli/GetAwesomeChoiceOptionList.ps1
+++ b/src/private/cli/GetAwesomeChoiceOptionList.ps1
@@ -1,0 +1,10 @@
+function Get-AwesomeChoiceOptionList {
+    param([Parameter(Mandatory)][System.Collections.IDictionary]$Choice)
+
+    $choiceList = foreach ($key in $Choice.Keys) {
+        New-Object System.Management.Automation.Host.ChoiceDescription "&$key", $Choice[$key]
+    }
+
+    return [System.Management.Automation.Host.ChoiceDescription[]]@($choiceList)
+}
+

--- a/src/private/cli/GetAwesomeHostUi.ps1
+++ b/src/private/cli/GetAwesomeHostUi.ps1
@@ -1,0 +1,4 @@
+function Get-AwesomeHostUi {
+    return $Host.UI
+}
+

--- a/src/private/cli/GetAwesomePromptResult.ps1
+++ b/src/private/cli/GetAwesomePromptResult.ps1
@@ -1,0 +1,13 @@
+function Get-AwesomePromptResult {
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Ask,
+        [Parameter(Mandatory)][object]$Response
+    )
+
+    if ( [string]::IsNullOrEmpty($Response.Values)) {
+        return $Ask.Default
+    }
+
+    return $Response.Values
+}
+

--- a/src/private/cli/ReadAwesomeChoicePrompt.ps1
+++ b/src/private/cli/ReadAwesomeChoicePrompt.ps1
@@ -1,0 +1,13 @@
+function Read-AwesomeChoicePrompt {
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Ask,
+        [Parameter(Mandatory)][object]$HostUi
+    )
+
+    $options = Get-AwesomeChoiceOptionList -Choice $Ask.Choice
+    $defaultIndex = $options.Label.IndexOf('&' + $Ask.Default)
+    $response = $HostUi.PromptForChoice($Ask.Caption, $Ask.Message, $options, $defaultIndex)
+
+    return $options.Label[$response] -replace '&'
+}
+

--- a/src/private/cli/ReadAwesomeHost.ps1
+++ b/src/private/cli/ReadAwesomeHost.ps1
@@ -1,3 +1,4 @@
+
 function Read-AwesomeHost {
     [CmdletBinding()]
     param (
@@ -5,28 +6,11 @@ function Read-AwesomeHost {
         [pscustomobject]
         $Ask
     )
-    ## For standard questions
-    if ($null -eq $Ask.Choice) {
-        do {
-            $response = $Host.UI.Prompt($Ask.Caption, $Ask.Message, $Ask.Prompt)
-        } while ($Ask.Default -eq 'MANDATORY' -and [string]::IsNullOrEmpty($response.Values))
 
-        if ([string]::IsNullOrEmpty($response.Values)) {
-            $result = $Ask.Default
-        } else {
-            $result = $response.Values
-        }
+    $hostUi = Get-AwesomeHostUi
+    if ($null -eq $Ask.Choice) {
+        return Read-AwesomeStandardPrompt -Ask $Ask -HostUi $hostUi
     }
-    ## For Choice based
-    if ($Ask.Choice) {
-        $Cs = @()
-        $Ask.Choice.Keys | ForEach-Object {
-            $Cs += New-Object System.Management.Automation.Host.ChoiceDescription "&$_", $($Ask.Choice.$_)
-        }
-        $options = [System.Management.Automation.Host.ChoiceDescription[]]($Cs)
-        $IndexOfDefault = $Cs.Label.IndexOf('&' + $Ask.Default)
-        $response = $Host.UI.PromptForChoice($Ask.Caption, $Ask.Message, $options, $IndexOfDefault)
-        $result = $Cs.Label[$response] -replace '&'
-    }
-    return $result
+
+    return Read-AwesomeChoicePrompt -Ask $Ask -HostUi $hostUi
 }

--- a/src/private/cli/ReadAwesomeStandardPrompt.ps1
+++ b/src/private/cli/ReadAwesomeStandardPrompt.ps1
@@ -1,0 +1,13 @@
+function Read-AwesomeStandardPrompt {
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Ask,
+        [Parameter(Mandatory)][object]$HostUi
+    )
+
+    do {
+        $response = $HostUi.Prompt($Ask.Caption, $Ask.Message, $Ask.Prompt)
+    } while (Test-AwesomePromptRequiresRetry -Ask $Ask -Response $response)
+
+    return Get-AwesomePromptResult -Ask $Ask -Response $response
+}
+

--- a/src/private/cli/TestAwesomePromptRequiresRetry.ps1
+++ b/src/private/cli/TestAwesomePromptRequiresRetry.ps1
@@ -1,0 +1,9 @@
+function Test-AwesomePromptRequiresRetry {
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Ask,
+        [Parameter(Mandatory)][object]$Response
+    )
+
+    return $Ask.Default -eq 'MANDATORY' -and [string]::IsNullOrEmpty($Response.Values)
+}
+

--- a/tests/CiCoverage.Tests.ps1
+++ b/tests/CiCoverage.Tests.ps1
@@ -1,6 +1,7 @@
 BeforeAll {
     . (Join-Path $PSScriptRoot '..' 'scripts' 'build' 'ci' 'CodeSceneCoverageMap.ps1')
     . (Join-Path $PSScriptRoot '..' 'scripts' 'build' 'ci' 'CodeSceneCoverageXml.ps1')
+    . (Join-Path $PSScriptRoot '..' 'scripts' 'build' 'ci' 'CoverageLowReport.ps1')
 }
 
 Describe 'CodeScene Cobertura remapping helpers' {
@@ -101,6 +102,96 @@ Describe 'CodeScene Cobertura remapping helpers' {
         {
             Convert-CoberturaCoverageToSourcePath -CoveragePath $coveragePath -BuiltModulePath $builtModulePath -RepoRoot $repoRoot
         } | Should -Throw "Could not find any '# Source:' markers*"
+    }
+
+    It 'ignores covered built-module preamble lines before the first source marker' {
+        $repoRoot = Join-Path $TestDrive 'repo-with-preamble'
+        $sourcePublicDir = Join-Path $repoRoot 'src/public'
+        $buildDir = Join-Path $repoRoot 'dist/NovaModuleTools'
+        $coveragePath = Join-Path $repoRoot 'artifacts/pester-coverage.cobertura.xml'
+        $builtModulePath = Join-Path $buildDir 'NovaModuleTools.psm1'
+
+        New-Item -ItemType Directory -Path $sourcePublicDir, (Split-Path -Parent $coveragePath), $buildDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $sourcePublicDir 'Invoke-Foo.ps1') -Encoding utf8 -Value @(
+            'function Invoke-Foo {'
+            "    'foo'"
+            '}'
+        )
+        Set-Content -LiteralPath $builtModulePath -Encoding utf8 -Value @(
+            'Set-StrictMode -Version Latest'
+            "`$ErrorActionPreference = 'Stop'"
+            ''
+            '# Source: src/public/Invoke-Foo.ps1'
+            'function Invoke-Foo {'
+            "    'foo'"
+            '}'
+        )
+
+        @'
+<?xml version="1.0" encoding="utf-8"?>
+<coverage lines-covered="4" lines-valid="4" line-rate="1" branches-covered="0" branches-valid="0" branch-rate="1" timestamp="1" version="1.0">
+  <packages>
+    <package name="dist/NovaModuleTools" line-rate="1" branch-rate="1">
+      <classes>
+        <class name="NovaModuleTools.psm1" filename="dist/NovaModuleTools/NovaModuleTools.psm1" line-rate="1" branch-rate="1">
+          <methods />
+          <lines>
+            <line number="1" hits="1" />
+            <line number="2" hits="1" />
+            <line number="5" hits="1" />
+            <line number="6" hits="1" />
+          </lines>
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>
+'@ | Set-Content -LiteralPath $coveragePath -Encoding utf8
+
+        Convert-CoberturaCoverageToSourcePath -CoveragePath $coveragePath -BuiltModulePath $builtModulePath -RepoRoot $repoRoot
+
+        [xml]$convertedCoverage = Get-Content -LiteralPath $coveragePath -Raw
+        $classNode = $convertedCoverage.SelectSingleNode('/coverage/packages/package/classes/class')
+
+        $classNode.filename | Should -Be 'src/public/Invoke-Foo.ps1'
+        @($classNode.lines.line | ForEach-Object number) | Should -Be @(1, 2)
+        @($classNode.lines.line | ForEach-Object hits) | Should -Be @('1', '1')
+    }
+
+    It 'writes a low-coverage report sorted by line rate from Cobertura classes' {
+        $coveragePath = Join-Path $TestDrive 'coverage.cobertura.xml'
+        $reportPath = Join-Path $TestDrive 'coverage-low.txt'
+
+        @'
+<?xml version="1.0" encoding="utf-8"?>
+<coverage lines-covered="6" lines-valid="8" line-rate="0.75" branches-covered="0" branches-valid="0" branch-rate="1" timestamp="1" version="1.0">
+  <packages>
+    <package name="src/private" line-rate="0.4375" branch-rate="1">
+      <classes>
+        <class name="Low.ps1" filename="src/private/Low.ps1" line-rate="0.125" branch-rate="1">
+          <methods />
+          <lines />
+        </class>
+        <class name="Mid.ps1" filename="src/private/Mid.ps1" line-rate="0.75" branch-rate="1">
+          <methods />
+          <lines />
+        </class>
+        <class name="High.ps1" filename="src/private/High.ps1" line-rate="1" branch-rate="1">
+          <methods />
+          <lines />
+        </class>
+      </classes>
+    </package>
+  </packages>
+</coverage>
+'@ | Set-Content -LiteralPath $coveragePath -Encoding utf8
+
+        Write-CoverageLowReport -CoveragePath $coveragePath -OutputPath $reportPath
+
+        @(Get-Content -LiteralPath $reportPath) | Should -Be @(
+            '0.125000 src/private/Low.ps1',
+            '0.750000 src/private/Mid.ps1'
+        )
     }
 }
 

--- a/tests/CoverageCompletion.TestSupport.ps1
+++ b/tests/CoverageCompletion.TestSupport.ps1
@@ -1,0 +1,40 @@
+function New-TestPromptHostUi {
+    param([Parameter(Mandatory)][scriptblock]$GetResponse)
+
+    $hostUi = [pscustomobject]@{
+        State = [ordered]@{
+            PromptCalls = 0
+            GetResponse = $GetResponse
+        }
+    }
+    $hostUi | Add-Member -MemberType ScriptMethod -Name Prompt -Value {
+        $this.State.PromptCalls += 1
+        return & $this.State.GetResponse $this.State.PromptCalls
+    }
+
+    return $hostUi
+}
+
+function New-TestChoiceHostUi {
+    param([int]$ChoiceIndex = 0)
+
+    $hostUi = [pscustomobject]@{
+        State = [ordered]@{
+            ChoiceCalls = 0
+            ChoiceLabels = @()
+            DefaultChoiceIndex = $null
+            ChoiceIndex = $ChoiceIndex
+        }
+    }
+    $hostUi | Add-Member -MemberType ScriptMethod -Name PromptForChoice -Value {
+        $this.State.ChoiceCalls += 1
+        $this.State.ChoiceLabels = @($args[2] | ForEach-Object Label)
+        $this.State.DefaultChoiceIndex = $args[3]
+        return $this.State.ChoiceIndex
+    }
+
+    return $hostUi
+}
+
+
+

--- a/tests/CoverageCompletion.Tests.ps1
+++ b/tests/CoverageCompletion.Tests.ps1
@@ -74,6 +74,33 @@ Describe 'Coverage completion for remaining low-coverage helpers' {
         }
     }
 
+    It 'Get-LocalModulePathPattern and Get-LocalModulePathErrorMessage support the opposite platform branch' {
+        $targetIsWindows = -not [bool]$IsWindows
+
+        InModuleScope $script:moduleName -Parameters @{TargetIsWindows = $targetIsWindows} {
+            param($TargetIsWindows)
+
+            try {
+                Set-Variable -Name IsWindows -Value $TargetIsWindows -Force
+
+                $pattern = Get-LocalModulePathPattern
+                $message = Get-LocalModulePathErrorMessage -MatchPattern $pattern
+
+                if ($TargetIsWindows) {
+                    $pattern | Should -Be ([regex]::Escape('\Documents\PowerShell\Modules'))
+                    $message | Should -Be "No windows module path matching $pattern found"
+                }
+                else {
+                    $pattern | Should -Be '/\.local/share/powershell/Modules$'
+                    $message | Should -Be "No macOS/Linux module path matching $pattern found in PSModulePath."
+                }
+            }
+            finally {
+                Remove-Variable -Name IsWindows -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
     It 'Get-AwesomeHostUi returns the current host UI instance type' {
         $expectedType = $Host.UI.GetType().FullName
 

--- a/tests/CoverageCompletion.Tests.ps1
+++ b/tests/CoverageCompletion.Tests.ps1
@@ -74,6 +74,19 @@ Describe 'Coverage completion for remaining low-coverage helpers' {
         }
     }
 
+    It 'Get-AwesomeHostUi returns the current host UI instance type' {
+        $expectedType = $Host.UI.GetType().FullName
+
+        InModuleScope $script:moduleName -Parameters @{ExpectedType = $expectedType} {
+            param($ExpectedType)
+
+            $result = Get-AwesomeHostUi
+
+            $result | Should -Not -BeNullOrEmpty
+            $result.GetType().FullName | Should -Be $ExpectedType
+        }
+    }
+
     It 'Read-AwesomeHost handles standard prompt case <Name>' -ForEach @(
         @{
             Name = 'entered text'

--- a/tests/CoverageCompletion.Tests.ps1
+++ b/tests/CoverageCompletion.Tests.ps1
@@ -1,11 +1,30 @@
+$script:coverageCompletionTestSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'CoverageCompletion.TestSupport.ps1')).Path
+$global:coverageCompletionTestSupportFunctionNameList = @(
+    'New-TestPromptHostUi'
+    'New-TestChoiceHostUi'
+)
+. $script:coverageCompletionTestSupportPath
+
+foreach ($functionName in $global:coverageCompletionTestSupportFunctionNameList) {
+    $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
+    Set-Item -Path "function:global:$functionName" -Value $scriptBlock
+}
+
 BeforeAll {
     $here = Split-Path -Parent $PSCommandPath
+    $coverageCompletionTestSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'CoverageCompletion.TestSupport.ps1')).Path
     $script:repoRoot = Split-Path -Parent $here
     $script:moduleName = (Get-Content -LiteralPath (Join-Path $script:repoRoot 'project.json') -Raw | ConvertFrom-Json).ProjectName
     $script:distModuleDir = Join-Path $script:repoRoot "dist/$script:moduleName"
 
     if (-not (Test-Path -LiteralPath $script:distModuleDir)) {
         throw "Expected built $script:moduleName module at: $script:distModuleDir. Run Invoke-NovaBuild in the repo root first."
+    }
+
+    . $coverageCompletionTestSupportPath
+    foreach ($functionName in $global:coverageCompletionTestSupportFunctionNameList) {
+        $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
+        Set-Item -Path "function:global:$functionName" -Value $scriptBlock
     }
 
     Remove-Module $script:moduleName -ErrorAction SilentlyContinue
@@ -53,6 +72,84 @@ Describe 'Coverage completion for remaining low-coverage helpers' {
                 $message | Should -Be "No macOS/Linux module path matching $pattern found in PSModulePath."
             }
         }
+    }
+
+    It 'Read-AwesomeHost handles standard prompt case <Name>' -ForEach @(
+        @{
+            Name = 'entered text'
+            Caption = 'Module Name'
+            Message = 'Enter module name'
+            Default = 'ignored'
+            Responses = @('NovaModuleTools')
+            Expected = 'NovaModuleTools'
+            ExpectedPromptCalls = 1
+        }
+        @{
+            Name = 'mandatory retry'
+            Caption = 'Module Name'
+            Message = 'Enter module name'
+            Default = 'MANDATORY'
+            Responses = @($null, 'NovaModuleTools')
+            Expected = 'NovaModuleTools'
+            ExpectedPromptCalls = 2
+        }
+        @{
+            Name = 'default fallback'
+            Caption = 'Semantic Version'
+            Message = 'Starting version'
+            Default = '0.0.1'
+            Responses = @('')
+            Expected = '0.0.1'
+            ExpectedPromptCalls = 1
+        }
+    ) {
+        $hostUi = New-TestPromptHostUi {
+            param($CallCount)
+
+            return [pscustomobject]@{Values = $Responses[$CallCount - 1]}
+        }
+
+        $result = InModuleScope $script:moduleName -Parameters @{HostUi = $hostUi; PromptCase = $_} {
+            param($HostUi, $PromptCase)
+
+            Mock Get-AwesomeHostUi {$HostUi}
+
+            Read-AwesomeHost -Ask ([pscustomobject]@{
+                Caption = $PromptCase.Caption
+                Message = $PromptCase.Message
+                Prompt = @{}
+                Default = $PromptCase.Default
+                Choice = $null
+            })
+        }
+
+        $result | Should -Be $Expected
+        $hostUi.State.PromptCalls | Should -Be $ExpectedPromptCalls
+    }
+
+    It 'Read-AwesomeHost returns the selected label for choice prompts' {
+        $hostUi = New-TestChoiceHostUi -ChoiceIndex 0
+
+        $result = InModuleScope $script:moduleName -Parameters @{HostUi = $hostUi} {
+            param($HostUi)
+
+            Mock Get-AwesomeHostUi {$HostUi}
+
+            Read-AwesomeHost -Ask ([pscustomobject]@{
+                Caption = 'Git Version Control'
+                Message = 'Enable git?'
+                Default = 'No'
+                Choice = [ordered]@{
+                    Yes = 'Enable Git'
+                    No = 'Skip Git initialization'
+                }
+            })
+        }
+
+        $result | Should -Be 'Yes'
+        $hostUi.State.ChoiceCalls | Should -Be 1
+        $hostUi.State.DefaultChoiceIndex | Should -Be 1
+        $hostUi.State.ChoiceLabels | Should -Be @('&Yes', '&No')
     }
 
     It 'Get-FunctionSourceIndex adds entries for indexable files' {

--- a/tests/CoverageGaps.Tests.ps1
+++ b/tests/CoverageGaps.Tests.ps1
@@ -335,8 +335,11 @@ Describe 'Coverage gaps for scaffold, CLI, release, and helper internals' {
         }
     }
 
-    It 'Get-NovaCliLauncherPath reports missing file-backed commands and missing launcher files' {
+    It 'Get-NovaCliLauncherPath reports missing commands, missing file-backed commands, and missing launcher files' {
         InModuleScope $script:moduleName {
+            Mock Get-Command {$null}
+            {Get-NovaCliLauncherPath} | Should -Throw 'Install-NovaCli command not found.'
+
             Mock Get-Command {
                 [pscustomobject]@{
                     ScriptBlock = [pscustomobject]@{File = $null}
@@ -483,12 +486,27 @@ Describe 'Coverage gaps for scaffold, CLI, release, and helper internals' {
         }
     }
 
-    It 'Build-Manifest includes resource paths and prerelease manifest metadata' {
-        InModuleScope $script:moduleName {
+    It 'Build-Manifest includes expected resource paths and prerelease manifest metadata when resources go to <ResourceLocation>' -ForEach @(
+        @{
+            ResourceLocation = 'resources/'
+            CopyResourcesToModuleRoot = $false
+            ExpectedFormatPath = 'resources/Nova.Format.ps1xml'
+            ExpectedTypePath = 'resources/Nova.Types.ps1xml'
+        }
+        @{
+            ResourceLocation = 'module root'
+            CopyResourcesToModuleRoot = $true
+            ExpectedFormatPath = 'Nova.Format.ps1xml'
+            ExpectedTypePath = 'Nova.Types.ps1xml'
+        }
+    ) {
+        InModuleScope $script:moduleName -Parameters @{ManifestCase = $_} {
+            param($ManifestCase)
+
             $projectInfo = [pscustomobject]@{
                 PublicDir = '/tmp/public'
                 ResourcesDir = '/tmp/resources'
-                CopyResourcesToModuleRoot = $false
+                CopyResourcesToModuleRoot = $ManifestCase.CopyResourcesToModuleRoot
                 Manifest = [ordered]@{Author = 'Tester'; CompanyName = 'Nova'}
                 Version = '1.2.3-preview'
                 Description = 'Example'
@@ -510,8 +528,8 @@ Describe 'Coverage gaps for scaffold, CLI, release, and helper internals' {
                 $Path -eq '/tmp/NovaModuleTools.psd1' -and
                         $FunctionsToExport -eq @('Get-Thing') -and
                         $AliasesToExport -eq @('gt') -and
-                        $FormatsToProcess -eq @('resources/Nova.Format.ps1xml') -and
-                        $TypesToProcess -eq @('resources/Nova.Types.ps1xml') -and
+                        $FormatsToProcess -eq @($ManifestCase.ExpectedFormatPath) -and
+                        $TypesToProcess -eq @($ManifestCase.ExpectedTypePath) -and
                         $Prerelease -eq 'preview' -and
                         $Author -eq 'Tester' -and
                         $CompanyName -eq 'Nova'

--- a/tests/CoverageGaps.Tests.ps1
+++ b/tests/CoverageGaps.Tests.ps1
@@ -1,5 +1,19 @@
+$script:gitTestSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'GitTestSupport.ps1')).Path
+$global:gitTestSupportFunctionNameList = @(
+    'Initialize-TestGitRepository'
+    'New-TestGitCommit'
+    'New-TestGitTag'
+)
+. $script:gitTestSupportPath
+
+foreach ($functionName in $global:gitTestSupportFunctionNameList) {
+    $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
+    Set-Item -Path "function:global:$functionName" -Value $scriptBlock
+}
+
 BeforeAll {
     $here = Split-Path -Parent $PSCommandPath
+    $gitTestSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'GitTestSupport.ps1')).Path
     $script:repoRoot = Split-Path -Parent $here
     $script:moduleName = (Get-Content -LiteralPath (Join-Path $script:repoRoot 'project.json') -Raw | ConvertFrom-Json).ProjectName
     $script:distModuleDir = Join-Path $script:repoRoot "dist/$script:moduleName"
@@ -7,6 +21,12 @@ BeforeAll {
 
     if (-not (Test-Path -LiteralPath $script:distModuleDir)) {
         throw "Expected built $script:moduleName module at: $script:distModuleDir. Run Invoke-NovaBuild in the repo root first."
+    }
+
+    . $gitTestSupportPath
+    foreach ($functionName in $global:gitTestSupportFunctionNameList) {
+        $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
+        Set-Item -Path "function:global:$functionName" -Value $scriptBlock
     }
 
     Remove-Module $script:moduleName -ErrorAction SilentlyContinue
@@ -708,6 +728,64 @@ function Second {
         InModuleScope $script:moduleName {
             $projectRoot = Join-Path $TestDrive 'no-git-project'
             New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+
+            $messages = @(Get-GitCommitMessageForVersionBump -ProjectRoot $projectRoot)
+
+            $messages.Count | Should -Be 0
+        }
+    }
+
+    It 'Get-GitCommitMessageForVersionBump returns commits since the latest tag when tags exist' {
+        if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+            Set-ItResult -Skipped -Because 'git is not available in this environment'
+            return
+        }
+
+        InModuleScope $script:moduleName {
+            $projectRoot = Join-Path $TestDrive 'tagged-git-project'
+            Initialize-TestGitRepository -Path $projectRoot
+            New-TestGitCommit -RepositoryPath $projectRoot -Message 'feat: initial release' -File @{Name = 'first.txt'; Content = 'first'}
+            New-TestGitTag -RepositoryPath $projectRoot -TagName 'v1.0.0'
+            New-TestGitCommit -RepositoryPath $projectRoot -Message 'fix: patch bug' -Body 'Detailed patch note' -File @{Name = 'second.txt'; Content = 'second'}
+            New-TestGitCommit -RepositoryPath $projectRoot -Message 'docs: update readme' -File @{Name = 'third.txt'; Content = 'third'}
+
+            $messages = @(Get-GitCommitMessageForVersionBump -ProjectRoot $projectRoot)
+
+            $messages.Count | Should -Be 2
+            $messages[0] | Should -Be 'docs: update readme'
+            $messages[1] | Should -Be "fix: patch bug$( [Environment]::NewLine )Detailed patch note"
+        }
+    }
+
+    It 'Get-GitCommitMessageForVersionBump returns all commits when no tags exist' {
+        if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+            Set-ItResult -Skipped -Because 'git is not available in this environment'
+            return
+        }
+
+        InModuleScope $script:moduleName {
+            $projectRoot = Join-Path $TestDrive 'untagged-git-project'
+            Initialize-TestGitRepository -Path $projectRoot
+            New-TestGitCommit -RepositoryPath $projectRoot -Message 'feat: add capability' -Body 'Implements the new path' -File @{Name = 'first.txt'; Content = 'first'}
+            New-TestGitCommit -RepositoryPath $projectRoot -Message 'chore: tidy metadata' -File @{Name = 'second.txt'; Content = 'second'}
+
+            $messages = @(Get-GitCommitMessageForVersionBump -ProjectRoot $projectRoot)
+
+            $messages.Count | Should -Be 2
+            $messages[0] | Should -Be 'chore: tidy metadata'
+            $messages[1] | Should -Be "feat: add capability$( [Environment]::NewLine )Implements the new path"
+        }
+    }
+
+    It 'Get-GitCommitMessageForVersionBump returns empty when the git directory exists but git log fails' {
+        if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+            Set-ItResult -Skipped -Because 'git is not available in this environment'
+            return
+        }
+
+        InModuleScope $script:moduleName {
+            $projectRoot = Join-Path $TestDrive 'broken-git-project'
+            New-Item -ItemType Directory -Path (Join-Path $projectRoot '.git') -Force | Out-Null
 
             $messages = @(Get-GitCommitMessageForVersionBump -ProjectRoot $projectRoot)
 

--- a/tests/CoverageGaps.Tests.ps1
+++ b/tests/CoverageGaps.Tests.ps1
@@ -586,6 +586,18 @@ Describe 'Coverage gaps for scaffold, CLI, release, and helper internals' {
         }
     }
 
+    It 'Get-ProjectJsonValueTypeName returns null for null input' {
+        InModuleScope $script:moduleName {
+            Get-ProjectJsonValueTypeName -Value $null | Should -Be 'null'
+        }
+    }
+
+    It 'Get-ProjectJsonValueTypeName returns the CLR type name for non-null values' {
+        InModuleScope $script:moduleName {
+            Get-ProjectJsonValueTypeName -Value 42 | Should -Be 'System.Int32'
+        }
+    }
+
     It 'Get-TopLevelFunctionAst returns only top-level functions and Get-TopLevelFunctionAstFromFile ignores parse errors' {
         InModuleScope $script:moduleName {
             $tokens = $null

--- a/tests/CoverageGaps.Tests.ps1
+++ b/tests/CoverageGaps.Tests.ps1
@@ -354,6 +354,16 @@ Describe 'Coverage gaps for scaffold, CLI, release, and helper internals' {
         }
     }
 
+    It 'Get-NovaCliInstalledVersion returns the currently loaded module version' {
+        $expectedVersion = (Get-Module $script:moduleName -ErrorAction Stop).Version.ToString()
+
+        InModuleScope $script:moduleName -Parameters @{ExpectedVersion = $expectedVersion} {
+            param($ExpectedVersion)
+
+            Get-NovaCliInstalledVersion | Should -Be $ExpectedVersion
+        }
+    }
+
     It 'Test-NovaCliDirectoryOnPath returns true when the directory is present' {
         InModuleScope $script:moduleName {
             $originalPath = $env:PATH

--- a/tests/CoverageGaps.Tests.ps1
+++ b/tests/CoverageGaps.Tests.ps1
@@ -572,6 +572,20 @@ Describe 'Coverage gaps for scaffold, CLI, release, and helper internals' {
         }
     }
 
+    It 'Format-ProjectJsonValue returns null for null input' {
+        InModuleScope $script:moduleName {
+            Format-ProjectJsonValue -Value $null | Should -Be 'null'
+        }
+    }
+
+    It 'Format-ProjectJsonValue falls back to string conversion when ConvertTo-Json fails' {
+        InModuleScope $script:moduleName {
+            Mock ConvertTo-Json {throw 'json failed'}
+
+            Format-ProjectJsonValue -Value 42 | Should -Be '42'
+        }
+    }
+
     It 'Get-TopLevelFunctionAst returns only top-level functions and Get-TopLevelFunctionAstFromFile ignores parse errors' {
         InModuleScope $script:moduleName {
             $tokens = $null

--- a/tests/GitTestSupport.ps1
+++ b/tests/GitTestSupport.ps1
@@ -1,0 +1,43 @@
+function Initialize-TestGitRepository {
+    param([Parameter(Mandatory)][string]$Path)
+
+    New-Item -ItemType Directory -Path $Path -Force | Out-Null
+    & git -C $Path init --quiet | Out-Null
+    & git -C $Path config user.name 'NovaModuleTools Tests' | Out-Null
+    & git -C $Path config user.email 'tests@example.invalid' | Out-Null
+    & git -C $Path config core.hooksPath /dev/null | Out-Null
+    & git -C $Path config commit.gpgsign false | Out-Null
+    & git -C $Path config tag.gpgSign false | Out-Null
+}
+
+function New-TestGitCommit {
+    param(
+        [Parameter(Mandatory)][string]$RepositoryPath,
+        [Parameter(Mandatory)][string]$Message,
+        [string]$Body,
+        [Parameter(Mandatory)][hashtable]$File
+    )
+
+    Set-Content -LiteralPath (Join-Path $RepositoryPath $File.Name) -Value $File.Content -Encoding utf8
+    & git -C $RepositoryPath add $File.Name | Out-Null
+
+    if ( [string]::IsNullOrWhiteSpace($Body)) {
+        & git -C $RepositoryPath -c core.hooksPath=/dev/null -c commit.gpgsign=false -c commit.template= commit --quiet -m $Message | Out-Null
+        return
+    }
+
+    & git -C $RepositoryPath -c core.hooksPath=/dev/null -c commit.gpgsign=false -c commit.template= commit --quiet -m $Message -m $Body | Out-Null
+}
+
+function New-TestGitTag {
+    param(
+        [Parameter(Mandatory)][string]$RepositoryPath,
+        [Parameter(Mandatory)][string]$TagName
+    )
+
+    & git -C $RepositoryPath -c core.hooksPath=/dev/null -c tag.gpgSign=false tag $TagName | Out-Null
+}
+
+
+
+

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -35,7 +35,16 @@ Describe 'Nova command model' {
         InModuleScope $script:moduleName {
             Mock Get-Content {'{"ProjectName":"X","Version":"9.9.9"}'}
 
-            (Get-NovaProjectInfo).Version | Should -Be '9.9.9'
+            Get-NovaProjectInfo -Version | Should -Be '9.9.9'
+        }
+    }
+
+    It 'Get-NovaProjectInfo throws when project.json is missing' {
+        InModuleScope $script:moduleName {
+            $projectRoot = Join-Path $TestDrive 'missing-project-json'
+            New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+
+            {Get-NovaProjectInfo -Path $projectRoot} | Should -Throw 'Not a project folder. project.json not found:*'
         }
     }
 

--- a/tests/OutputFiles.Tests.ps1
+++ b/tests/OutputFiles.Tests.ps1
@@ -1,5 +1,19 @@
-$script:outputFileProjectInfo = Get-NovaProjectInfo
-$script:outputFileList = @(Get-ChildItem $script:outputFileProjectInfo.OutputModuleDir -File)
+BeforeDiscovery {
+    $here = Split-Path -Parent $PSCommandPath
+    $script:repoRoot = Split-Path -Parent $here
+    $script:moduleName = (Get-Content -LiteralPath (Join-Path $script:repoRoot 'project.json') -Raw | ConvertFrom-Json).ProjectName
+    $script:distModuleDir = Join-Path $script:repoRoot "dist/$script:moduleName"
+
+    if (-not (Test-Path -LiteralPath $script:distModuleDir)) {
+        throw "Expected built $script:moduleName module at: $script:distModuleDir. Run Invoke-NovaBuild in the repo root first."
+    }
+
+    Remove-Module $script:moduleName -ErrorAction SilentlyContinue
+    Import-Module $script:distModuleDir -Force
+
+    $script:outputFileProjectInfo = Get-NovaProjectInfo
+    $script:outputFileList = @(Get-ChildItem $script:outputFileProjectInfo.OutputModuleDir -File)
+}
 
 Describe 'Module and Manifest testing' {
     Context 'Test <_.Name>' -ForEach $script:outputFileList {

--- a/tests/RemainingCommandCoverage.Tests.ps1
+++ b/tests/RemainingCommandCoverage.Tests.ps1
@@ -1,0 +1,312 @@
+BeforeAll {
+    $here = Split-Path -Parent $PSCommandPath
+    $script:repoRoot = Split-Path -Parent $here
+    $script:moduleName = (Get-Content -LiteralPath (Join-Path $script:repoRoot 'project.json') -Raw | ConvertFrom-Json).ProjectName
+    $script:distModuleDir = Join-Path $script:repoRoot "dist/$script:moduleName"
+
+    if (-not (Test-Path -LiteralPath $script:distModuleDir)) {
+        throw "Expected built $script:moduleName module at: $script:distModuleDir. Run Invoke-NovaBuild in the repo root first."
+    }
+
+    Remove-Module $script:moduleName -ErrorAction SilentlyContinue
+    Import-Module $script:distModuleDir -Force
+}
+
+Describe 'Coverage for remaining command and filesystem branches' {
+    It 'Reset-ProjectDist removes an existing output directory and recreates the dist folders' {
+        $outputDir = Join-Path $TestDrive 'dist'
+        $outputModuleDir = Join-Path $outputDir 'NovaModuleTools'
+        New-Item -ItemType Directory -Path $outputModuleDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $outputDir 'stale.txt') -Value 'stale' -Encoding utf8
+
+        InModuleScope $script:moduleName -Parameters @{OutputDir = $outputDir; OutputModuleDir = $outputModuleDir} {
+            param($OutputDir, $OutputModuleDir)
+
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    OutputDir = $OutputDir
+                    OutputModuleDir = $OutputModuleDir
+                }
+            }
+
+            Reset-ProjectDist
+        }
+
+        (Test-Path -LiteralPath $outputDir -PathType Container) | Should -BeTrue
+        (Test-Path -LiteralPath $outputModuleDir -PathType Container) | Should -BeTrue
+        (Test-Path -LiteralPath (Join-Path $outputDir 'stale.txt')) | Should -BeFalse
+    }
+
+    It 'Reset-ProjectDist wraps filesystem failures with a clear error' {
+        $outputDir = Join-Path $TestDrive 'dist-error'
+        $outputModuleDir = Join-Path $outputDir 'NovaModuleTools'
+
+        InModuleScope $script:moduleName -Parameters @{OutputDir = $outputDir; OutputModuleDir = $outputModuleDir} {
+            param($OutputDir, $OutputModuleDir)
+
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    OutputDir = $OutputDir
+                    OutputModuleDir = $OutputModuleDir
+                }
+            }
+            Mock Test-Path {$false}
+            Mock New-Item {throw 'access denied'} -ParameterFilter {$Path -eq $OutputDir}
+
+            {Reset-ProjectDist} | Should -Throw 'Failed to reset Dist folder: access denied'
+        }
+    }
+
+    It 'New-InitiateGitRepo warns when a repository already exists in the target directory' {
+        $repoPath = Join-Path $TestDrive 'existing-git-repo'
+        New-Item -ItemType Directory -Path (Join-Path $repoPath '.git') -Force | Out-Null
+
+        InModuleScope $script:moduleName -Parameters @{RepoPath = $repoPath} {
+            param($RepoPath)
+
+            Mock Get-Command {[pscustomobject]@{Name = 'git'}} -ParameterFilter {$Name -eq 'git'}
+            Mock Write-Warning {}
+
+            New-InitiateGitRepo -DirectoryPath $RepoPath -Confirm:$false
+
+            Assert-MockCalled Write-Warning -Times 1 -ParameterFilter {
+                $Message -eq 'A Git repository already exists in this directory.'
+            }
+        }
+    }
+
+    It 'New-InitiateGitRepo wraps git init failures with a clear error' {
+        $repoPath = Join-Path $TestDrive 'failing-git-repo'
+        New-Item -ItemType Directory -Path $repoPath -Force | Out-Null
+
+        function global:git {
+            throw 'init failed'
+        }
+
+        try {
+            InModuleScope $script:moduleName -Parameters @{RepoPath = $repoPath} {
+                param($RepoPath)
+
+                {New-InitiateGitRepo -DirectoryPath $RepoPath -Confirm:$false} | Should -Throw 'Failed to initialize Git repo: init failed'
+            }
+        }
+        finally {
+            Remove-Item -Path function:global:git -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'Test-NovaBuild creates the artifacts directory when it is missing' {
+        $cfg = [pscustomobject]@{
+            Run = [pscustomobject]@{
+                Path = $null
+                PassThru = $false
+                Exit = $false
+                Throw = $false
+            }
+            Filter = [pscustomobject]@{
+                Tag = @()
+                ExcludeTag = @()
+            }
+            Output = [pscustomobject]@{
+                Verbosity = 'Detailed'
+                RenderMode = 'Auto'
+            }
+            TestResult = [pscustomobject]@{
+                OutputPath = $null
+            }
+        }
+
+        InModuleScope $script:moduleName -Parameters @{Config = $cfg} {
+            param($Config)
+
+            $projectRoot = '/tmp/nova-project'
+
+            Mock Test-ProjectSchema {}
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    Pester = @{}
+                    BuildRecursiveFolders = $false
+                    TestsDir = 'tests'
+                    ProjectRoot = $projectRoot
+                }
+            }
+            Mock New-PesterConfiguration {$Config}
+            Mock Test-Path {$false}
+            Mock New-Item {}
+            Mock Invoke-Pester {[pscustomobject]@{Result = 'Passed'}}
+
+            Test-NovaBuild
+
+            $Config.Run.Path | Should -Be ([System.IO.Path]::Join('tests', '*.Tests.ps1'))
+            Assert-MockCalled New-Item -Times 1 -ParameterFilter {
+                $ItemType -eq 'Directory' -and $Path -eq ([System.IO.Path]::Join($projectRoot, 'artifacts')) -and $Force
+            }
+        }
+    }
+
+    It 'Test-NovaBuild throws when Pester reports a failing result' {
+        $cfg = [pscustomobject]@{
+            Run = [pscustomobject]@{
+                Path = $null
+                PassThru = $false
+                Exit = $false
+                Throw = $false
+            }
+            Filter = [pscustomobject]@{
+                Tag = @()
+                ExcludeTag = @()
+            }
+            Output = [pscustomobject]@{
+                Verbosity = 'Detailed'
+                RenderMode = 'Auto'
+            }
+            TestResult = [pscustomobject]@{
+                OutputPath = $null
+            }
+        }
+
+        InModuleScope $script:moduleName -Parameters @{Config = $cfg} {
+            param($Config)
+
+            Mock Test-ProjectSchema {}
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    Pester = @{}
+                    BuildRecursiveFolders = $true
+                    TestsDir = 'tests'
+                    ProjectRoot = '/tmp/nova-project'
+                }
+            }
+            Mock New-PesterConfiguration {$Config}
+            Mock Test-Path {$true}
+            Mock Invoke-Pester {[pscustomobject]@{Result = 'Failed'}}
+
+            {Test-NovaBuild} | Should -Throw 'Tests failed'
+        }
+    }
+
+    It 'Install-NovaCli rejects Windows hosts explicitly' {
+        InModuleScope $script:moduleName {
+            try {
+                Set-Variable -Name IsWindows -Value $true -Force
+
+                {Install-NovaCli} | Should -Throw 'Install-NovaCli currently supports macOS/Linux only*'
+            }
+            finally {
+                Remove-Variable -Name IsWindows -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    It 'Install-NovaCli throws when the target file exists and Force is not used' {
+        InModuleScope $script:moduleName {
+            try {
+                Set-Variable -Name IsWindows -Value $false -Force
+                Mock Get-NovaCliInstallDirectory {'/tmp/bin'}
+                Mock Get-NovaCliLauncherPath {'/tmp/source/nova'}
+                Mock Test-Path {$true}
+
+                {Install-NovaCli} | Should -Throw 'Target file already exists: /tmp/bin/nova*'
+            }
+            finally {
+                Remove-Variable -Name IsWindows -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    It 'Install-NovaCli returns without copying when WhatIf declines the install action' {
+        InModuleScope $script:moduleName {
+            try {
+                Set-Variable -Name IsWindows -Value $false -Force
+                Mock Get-NovaCliInstallDirectory {'/tmp/bin'}
+                Mock Get-NovaCliLauncherPath {'/tmp/source/nova'}
+                Mock Test-Path {$false}
+                Mock Copy-NovaCliLauncher {throw 'should not copy'}
+
+                $result = Install-NovaCli -WhatIf
+
+                $result | Should -BeNullOrEmpty
+                Assert-MockCalled Copy-NovaCliLauncher -Times 0
+            }
+            finally {
+                Remove-Variable -Name IsWindows -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    It 'Install-NovaCli warns when the install directory is not on PATH' {
+        InModuleScope $script:moduleName {
+            try {
+                Set-Variable -Name IsWindows -Value $false -Force
+                Mock Get-NovaCliInstallDirectory {'/tmp/bin'}
+                Mock Get-NovaCliLauncherPath {'/tmp/source/nova'}
+                Mock Test-Path {$false}
+                Mock Copy-NovaCliLauncher {'/tmp/bin/nova'}
+                Mock Test-NovaCliDirectoryOnPath {$false}
+                Mock Write-Warning {}
+
+                $result = Install-NovaCli -Force -Confirm:$false
+
+                $result.InstalledPath | Should -Be '/tmp/bin/nova'
+                $result.DirectoryOnPath | Should -BeFalse
+                Assert-MockCalled Write-Warning -Times 1 -ParameterFilter {
+                    $Message -like 'Installed nova to /tmp/bin, but that directory is not currently in PATH*'
+                }
+            }
+            finally {
+                Remove-Variable -Name IsWindows -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    It 'Publish-NovaBuiltModule uses an explicit local module directory without resolving the default path' {
+        InModuleScope $script:moduleName {
+            $projectInfo = [pscustomobject]@{
+                OutputModuleDir = '/tmp/dist/NovaModuleTools'
+                ProjectName = 'NovaModuleTools'
+            }
+
+            Mock Test-Path {$true}
+            Mock Resolve-NovaLocalPublishPath {throw 'should not resolve default path'}
+            Mock Publish-NovaBuiltModuleToDirectory {}
+
+            Publish-NovaBuiltModule -ProjectInfo $projectInfo -ModuleDirectoryPath '/tmp/custom-modules'
+
+            Assert-MockCalled Resolve-NovaLocalPublishPath -Times 0
+            Assert-MockCalled Publish-NovaBuiltModuleToDirectory -Times 1 -ParameterFilter {
+                $ModuleDirectoryPath -eq '/tmp/custom-modules'
+            }
+        }
+    }
+
+    It 'Publish-NovaBuiltModule resolves the default ProjectInfo when none is supplied' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    OutputModuleDir = '/tmp/dist/NovaModuleTools'
+                    ProjectName = 'NovaModuleTools'
+                }
+            }
+            Mock Test-Path {$true}
+            Mock Resolve-NovaLocalPublishPath {'/tmp/default-modules'}
+            Mock Publish-NovaBuiltModuleToDirectory {}
+
+            Publish-NovaBuiltModule
+
+            Assert-MockCalled Get-NovaProjectInfo -Times 1
+            Assert-MockCalled Resolve-NovaLocalPublishPath -Times 1 -ParameterFilter {
+                $ModuleDirectoryPath -eq ''
+            }
+            Assert-MockCalled Publish-NovaBuiltModuleToDirectory -Times 1 -ParameterFilter {
+                $ModuleDirectoryPath -eq '/tmp/default-modules'
+            }
+        }
+    }
+}
+
+
+
+
+
+
+

--- a/tests/RemainingHelperCoverage.Tests.ps1
+++ b/tests/RemainingHelperCoverage.Tests.ps1
@@ -1,0 +1,173 @@
+BeforeAll {
+    $here = Split-Path -Parent $PSCommandPath
+    $script:repoRoot = Split-Path -Parent $here
+    $script:moduleName = (Get-Content -LiteralPath (Join-Path $script:repoRoot 'project.json') -Raw | ConvertFrom-Json).ProjectName
+    $script:distModuleDir = Join-Path $script:repoRoot "dist/$script:moduleName"
+
+    if (-not (Test-Path -LiteralPath $script:distModuleDir)) {
+        throw "Expected built $script:moduleName module at: $script:distModuleDir. Run Invoke-NovaBuild in the repo root first."
+    }
+
+    Remove-Module $script:moduleName -ErrorAction SilentlyContinue
+    Import-Module $script:distModuleDir -Force
+}
+
+Describe 'Coverage for remaining manifest, JSON, and help-locale helpers' {
+    It 'Test-ProjectSchema validates the Build schema' {
+        InModuleScope $script:moduleName {
+            Mock Get-ResourceFilePath {
+                if ($FileName -eq 'Schema-Build.json') {
+                    return '/tmp/build-schema.json'
+                }
+
+                return '/tmp/pester-schema.json'
+            }
+            Mock Get-Content {
+                if ($Path -eq '/tmp/build-schema.json') {
+                    return '{"title":"build"}'
+                }
+
+                return '{"title":"pester"}'
+            }
+            Mock Test-Json {$true}
+
+            Test-ProjectSchema -Schema Build | Should -BeTrue
+
+            Assert-MockCalled Test-Json -Times 1 -ParameterFilter {
+                $Path -eq 'project.json' -and $Schema -eq '{"title":"build"}'
+            }
+        }
+    }
+
+    It 'Get-AliasInFunctionFromFile returns aliases declared on the function' {
+        $filePath = Join-Path $script:repoRoot 'src/public/InvokeNovaCli.ps1'
+
+        InModuleScope $script:moduleName -Parameters @{FilePath = $filePath} {
+            param($FilePath)
+
+            @(Get-AliasInFunctionFromFile -filePath $FilePath) | Should -Be @('nova')
+        }
+    }
+
+    It 'Get-AliasInFunctionFromFile returns nothing when the file cannot be parsed' {
+        InModuleScope $script:moduleName {
+            $result = Get-AliasInFunctionFromFile -filePath (Join-Path $TestDrive 'missing.ps1')
+
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'Get-FunctionNameFromFile returns every function name in the file' {
+        $filePath = Join-Path $TestDrive 'Functions.ps1'
+        @'
+function Get-First {
+}
+
+function Get-Second {
+}
+'@ | Set-Content -LiteralPath $filePath -Encoding utf8
+
+        InModuleScope $script:moduleName -Parameters @{FilePath = $filePath} {
+            param($FilePath)
+
+            @(Get-FunctionNameFromFile -filePath $FilePath) | Should -Be @('Get-First', 'Get-Second')
+        }
+    }
+
+    It 'Get-FunctionNameFromFile returns an empty string when the file cannot be read' {
+        InModuleScope $script:moduleName {
+            Get-FunctionNameFromFile -filePath (Join-Path $TestDrive 'missing.ps1') | Should -Be ''
+        }
+    }
+
+    It 'Read-ProjectJsonData returns a hashtable for a valid project object' {
+        $projectJsonPath = Join-Path $TestDrive 'project.json'
+        '{"ProjectName":"NovaModuleTools","Version":"1.2.3"}' | Set-Content -LiteralPath $projectJsonPath -Encoding utf8
+
+        InModuleScope $script:moduleName -Parameters @{ProjectJsonPath = $projectJsonPath} {
+            param($ProjectJsonPath)
+
+            $result = Read-ProjectJsonData -ProjectJsonPath $ProjectJsonPath
+
+            $result | Should -BeOfType 'hashtable'
+            $result.ProjectName | Should -Be 'NovaModuleTools'
+            $result.Version | Should -Be '1.2.3'
+        }
+    }
+
+    It 'Read-ProjectJsonData throws when project.json is <Name>' -ForEach @(
+        @{
+            Name = 'empty'
+            FileName = 'empty-project.json'
+            Content = ''
+            ExpectedMessage = 'project.json is empty*'
+        }
+        @{
+            Name = 'not valid JSON'
+            FileName = 'invalid-project.json'
+            Content = '{ invalid json }'
+            ExpectedMessage = 'project.json is not valid JSON*'
+        }
+        @{
+            Name = 'not a top-level object'
+            FileName = 'array-project.json'
+            Content = '[1,2,3]'
+            ExpectedMessage = 'project.json must contain a top-level JSON object*'
+        }
+    ) {
+        $projectJsonPath = Join-Path $TestDrive $_.FileName
+        $_.Content | Set-Content -LiteralPath $projectJsonPath -Encoding utf8
+
+        InModuleScope $script:moduleName -Parameters @{ProjectJsonPath = $projectJsonPath; ExpectedMessage = $_.ExpectedMessage} {
+            param($ProjectJsonPath, $ExpectedMessage)
+
+            {Read-ProjectJsonData -ProjectJsonPath $ProjectJsonPath} | Should -Throw $ExpectedMessage
+        }
+    }
+
+    It 'Get-NovaHelpLocale defaults to en-US when docs metadata has no locale' {
+        $docPath = Join-Path $TestDrive 'No-Locale.md'
+        @'
+---
+title: Test-Help
+---
+'@ | Set-Content -LiteralPath $docPath -Encoding utf8
+
+        InModuleScope $script:moduleName -Parameters @{HelpFile = (Get-Item -LiteralPath $docPath)} {
+            param($HelpFile)
+
+            Get-NovaHelpLocale -HelpMarkdownFiles $HelpFile | Should -Be 'en-US'
+        }
+    }
+
+    It 'Get-NovaHelpLocale throws when docs metadata contains conflicting locales' {
+        $firstDocPath = Join-Path $TestDrive 'First.md'
+        $secondDocPath = Join-Path $TestDrive 'Second.md'
+        @'
+---
+Locale: da-DK
+---
+'@ | Set-Content -LiteralPath $firstDocPath -Encoding utf8
+        @'
+---
+Locale: en-US
+---
+'@ | Set-Content -LiteralPath $secondDocPath -Encoding utf8
+
+        InModuleScope $script:moduleName -Parameters @{FirstDocPath = $firstDocPath; SecondDocPath = $secondDocPath} {
+            param($FirstDocPath, $SecondDocPath)
+
+            $helpFiles = @(
+                Get-Item -LiteralPath $FirstDocPath
+                Get-Item -LiteralPath $SecondDocPath
+            )
+
+            {Get-NovaHelpLocale -HelpMarkdownFiles $helpFiles} | Should -Throw 'Multiple help locales found in docs metadata*'
+        }
+    }
+}
+
+
+
+
+

--- a/tests/RemainingHelperCoverage.Tests.ps1
+++ b/tests/RemainingHelperCoverage.Tests.ps1
@@ -57,6 +57,12 @@ Describe 'Coverage for remaining manifest, JSON, and help-locale helpers' {
         }
     }
 
+    It 'Get-OrderedScriptFileForDirectory returns an empty list when the directory is missing' {
+        InModuleScope $script:moduleName {
+            @(Get-OrderedScriptFileForDirectory -Directory (Join-Path $TestDrive 'missing-dir') -ProjectRoot $TestDrive -Recurse $false) | Should -Be @()
+        }
+    }
+
     It 'Get-FunctionNameFromFile returns every function name in the file' {
         $filePath = Join-Path $TestDrive 'Functions.ps1'
         @'


### PR DESCRIPTION
  - `Read-AwesomeHost` standard, mandatory, default, and choice prompt flows
    - `Get-GitCommitMessageForVersionBump` tagged, untagged, and git-failure flows
    - remaining low-coverage manifest, project-json, help-locale, dist-reset, publish, and CLI install branches

- Added `artifacts/coverage-low.txt` generation in the CI helper flow so low-coverage files are refreshed from the
  latest Cobertura report.

- `Test-ProjectSchema` no longer carries an unreachable default branch now that `Schema` is constrained by
  `ValidateSet('Build', 'Pester')`.

- Fixed the CI helper flow so its second Pester pass now reloads the freshly built `dist/` module instead of relying on
  an installed `NovaModuleTools` copy during test discovery.

- Documented the generated `artifacts/coverage-low.txt` summary in the README artifact list.