### PR TITLE
Improve version output format in nova CLI and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ The format follows the principles from Keep a Changelog and the project aims to 
   `10.0`.
 - README and command documentation were refreshed to consistently use the Nova command names and describe the
   CLI/release workflow more clearly.
+- `nova version` and `nova --version` now include the component name alongside the version so CLI output clearly
+  distinguishes project versions from the installed NovaModuleTools version.
 - Release and test automation files were updated to better support the new Nova workflow.
 - `Test-ProjectSchema` no longer carries an unreachable default branch now that `Schema` is constrained by
   `ValidateSet('Build', 'Pester')`.

--- a/README.md
+++ b/README.md
@@ -407,9 +407,11 @@ nova build
 ### Get-NovaProjectInfo (`nova info` / `nova version`)
 
 This function provides complete info about the project, which can be used in Pester tests or for general
-troubleshooting. Use `nova info` for the full project object or `nova version` for just the project version.
+troubleshooting. Use `nova info` for the full project object or `nova version` for a concise
+`<ProjectName> <ProjectVersion>` string.
 
-Use `nova --version` when you want to see the installed `NovaModuleTools` module version on the current machine.
+Use `nova --version` when you want to see the installed `NovaModuleTools` module name and version on the current
+machine as `NovaModuleTools <ModuleVersion>`.
 
 ### Test-NovaBuild (`nova test`)
 

--- a/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
@@ -47,6 +47,7 @@ nova --version
 ```
 
 Returns the installed `NovaModuleTools` module version.
+The output format is `NovaModuleTools <Version>`.
 
 ### EXAMPLE 2
 
@@ -55,6 +56,7 @@ nova version
 ```
 
 Returns the current project version from `project.json`.
+The output format is `<ProjectName> <Version>`.
 
 ### EXAMPLE 3
 

--- a/src/private/cli/FormatNovaCliVersionString.ps1
+++ b/src/private/cli/FormatNovaCliVersionString.ps1
@@ -1,0 +1,10 @@
+function Format-NovaCliVersionString {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Version
+    )
+
+    return "$Name $Version"
+}
+

--- a/src/private/cli/GetNovaCliHelp.ps1
+++ b/src/private/cli/GetNovaCliHelp.ps1
@@ -9,7 +9,7 @@ start a new module project
 
 work with the current project
    info       Show project information
-   version    Show the current project version from project.json
+   version    Show the current project name and version from project.json
    build      Build the module into the dist folder
    test       Run Pester tests for the project
    bump       Update the module version in project.json
@@ -20,7 +20,7 @@ publish and release
 
 global options
    --help     Show this help message
-   --version  Show the installed NovaModuleTools module version
+   --version  Show the installed NovaModuleTools module name and version
 
 Examples:
    nova init ~/Work

--- a/src/public/InvokeNovaCli.ps1
+++ b/src/public/InvokeNovaCli.ps1
@@ -21,7 +21,8 @@ function Invoke-NovaCli {
             return Get-NovaProjectInfo @commonParameters
         }
         'version' {
-            return Get-NovaProjectInfo -Version
+            $projectInfo = Get-NovaProjectInfo @commonParameters
+            return Format-NovaCliVersionString -Name $projectInfo.ProjectName -Version $projectInfo.Version
         }
         'build' {
             return Invoke-NovaBuild @commonParameters
@@ -48,7 +49,9 @@ function Invoke-NovaCli {
             return Invoke-NovaRelease -PublishOption $options @commonParameters
         }
         '--version' {
-            return Get-NovaCliInstalledVersion
+            $moduleName = $ExecutionContext.SessionState.Module.Name
+            $moduleVersion = Get-NovaCliInstalledVersion
+            return Format-NovaCliVersionString -Name $moduleName -Version $moduleVersion
         }
         '--help' {
             return Get-NovaCliHelp

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -423,6 +423,7 @@ title: Invoke-NovaBuild
         $targetDirectory = Join-Path $TestDrive 'bin'
         $installedPath = Join-Path $targetDirectory 'nova'
         $installedModuleVersion = (Get-Module $script:moduleName).Version.ToString()
+        $expectedProjectVersionText = "$( $script:projectInfo.ProjectName ) $( $script:projectInfo.Version )"
         $originalModulePath = $env:PSModulePath
         $modulePathSeparator = [string][System.IO.Path]::PathSeparator
         $distParent = Split-Path -Parent $distModuleDir
@@ -437,6 +438,15 @@ title: Invoke-NovaBuild
             $versionOutput = & $installedPath --version 2>&1
             $versionText = @($versionOutput) -join [Environment]::NewLine
             $versionExitCode = $LASTEXITCODE
+            Push-Location $script:projectInfo.ProjectRoot
+            try {
+                $projectVersionOutput = & $installedPath version 2>&1
+                $projectVersionText = @($projectVersionOutput) -join [Environment]::NewLine
+                $projectVersionExitCode = $LASTEXITCODE
+            }
+            finally {
+                Pop-Location
+            }
 
             $result.CommandName | Should -Be 'nova'
             $result.InstalledPath | Should -Be $installedPath
@@ -444,9 +454,11 @@ title: Invoke-NovaBuild
             (Test-Path -LiteralPath $installedPath) | Should -BeTrue
             $helpExitCode | Should -Be 0
             $versionExitCode | Should -Be 0
+            $projectVersionExitCode | Should -Be 0
             $helpText | Should -Match 'usage: nova \[--version\] \[--help\] <command> \[<args>\]'
-            $helpText | Should -Match 'version\s+Show the current project version from project.json'
-            $versionText | Should -Match ([regex]::Escape($installedModuleVersion))
+            $helpText | Should -Match 'version\s+Show the current project name and version from project.json'
+            $versionText | Should -Be "$script:moduleName $installedModuleVersion"
+            $projectVersionText | Should -Be $expectedProjectVersionText
         }
         finally {
             $env:PSModulePath = $originalModulePath
@@ -522,20 +534,22 @@ function Invoke-TestCliVerbose {
         }
     }
 
-    It 'Invoke-NovaCli version maps to Get-NovaProjectInfo -Version' {
+    It 'Invoke-NovaCli version returns the project name and version' {
         InModuleScope $script:moduleName {
-            Mock Get-NovaProjectInfo {'1.2.3'} -ParameterFilter {$Version}
+            Mock Get-NovaProjectInfo {[pscustomobject]@{ProjectName = 'AzureDevOpsAgentInstaller'; Version = '1.2.3'}}
 
-            Invoke-NovaCli version | Should -Be '1.2.3'
-            Assert-MockCalled Get-NovaProjectInfo -Times 1 -ParameterFilter {$Version}
+            Invoke-NovaCli version | Should -Be 'AzureDevOpsAgentInstaller 1.2.3'
+            Assert-MockCalled Get-NovaProjectInfo -Times 1 -ParameterFilter {-not $Version}
         }
     }
 
-    It 'Invoke-NovaCli --version returns the installed NovaModuleTools version' {
-        InModuleScope $script:moduleName {
+    It 'Invoke-NovaCli --version returns the installed NovaModuleTools name and version' {
+        InModuleScope $script:moduleName -Parameters @{ModuleName = $script:moduleName} {
+            param($ModuleName)
+
             Mock Get-NovaCliInstalledVersion {'9.9.9'}
 
-            Invoke-NovaCli --version | Should -Be '9.9.9'
+            Invoke-NovaCli --version | Should -Be "$ModuleName 9.9.9"
             Assert-MockCalled Get-NovaCliInstalledVersion -Times 1
         }
     }
@@ -546,8 +560,8 @@ function Invoke-TestCliVerbose {
 
             $result | Should -Match 'usage: nova \[--version\] \[--help\] <command> \[<args>\]'
             $result | Should -Match 'init\s+Create a new Nova module scaffold'
-            $result | Should -Match 'version\s+Show the current project version from project.json'
-            $result | Should -Match '--version\s+Show the installed NovaModuleTools module version'
+            $result | Should -Match 'version\s+Show the current project name and version from project.json'
+            $result | Should -Match '--version\s+Show the installed NovaModuleTools module name and version'
             $result | Should -Match 'publish\s+Build, test, and publish the module locally or to a repository'
         }
     }

--- a/tests/RemainingHelperCoverage.Tests.ps1
+++ b/tests/RemainingHelperCoverage.Tests.ps1
@@ -13,6 +13,12 @@ BeforeAll {
 }
 
 Describe 'Coverage for remaining manifest, JSON, and help-locale helpers' {
+    It 'Format-NovaCliVersionString combines the component name and version' {
+        InModuleScope $script:moduleName {
+            Format-NovaCliVersionString -Name 'NovaModuleTools' -Version '1.9.10' | Should -Be 'NovaModuleTools 1.9.10'
+        }
+    }
+
     It 'Test-ProjectSchema validates the Build schema' {
         InModuleScope $script:moduleName {
             Mock Get-ResourceFilePath {


### PR DESCRIPTION
- Include component name alongside version in `nova version` and `nova --version` commands
- Update documentation to reflect changes in version output format