### PR TITLE
#48 - Enhance command support and documentation for -WhatIf and -Confirm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,12 @@ The format follows the principles from Keep a Changelog and the project aims to 
 - Change `CopyResourcesToModuleRoot` to an optional project setting that defaults to `false`, and standardize the
   setting name across templates, tests, and docs.
 - Change `Publish-NovaModule` and `Invoke-NovaRelease` to resolve publish targets before running build and test steps.
+- Change publish and release orchestration to share the same resolved publish execution helper, keeping preview
+  forwarding and publish-target handling consistent.
 - Change the bundled `nova` launcher to ship as a packaged module resource instead of a repo-root helper file.
 - Change `nova version` and `nova --version` to include the component name alongside the version for clearer CLI output.
+- Change mutating commands to support consistent native `-WhatIf`/`-Confirm` behavior, including routed preview support
+  through `Invoke-NovaCli` and updated `Get-Help` examples.
 - Change CI, release, and contributor documentation to reflect the Nova workflow, refreshed command help, and GitHub
   comparison links.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,11 @@ The format follows the principles from Keep a Changelog and the project aims to 
 
 ### Fixed
 
+- Fix the internal CLI forwarding helper name so ScriptAnalyzer no longer reports a plural-noun cmdlet warning.
 - Fix the standalone macOS/Linux `nova` launcher so `nova build -Verbose` forwards the verbose flag to the underlying
   build command.
+- Fix standalone CLI `-WhatIf` handling so `build`, `test`, `bump`, `publish`, and `release` forward preview mode
+  correctly, while `nova init -WhatIf` now fails with a clear CLI error instead of being treated as a path.
 - Fix the CI helper flow so its second Pester pass reloads the freshly built `dist/` module during test discovery.
 - Fix `Get-NovaProjectInfo` so empty `project.json` files fail with a clear configuration error.
 - Fix `Invoke-CodeSceneAnalysis.ps1` so `-TriggerAnalysis` can run without `-CoveragePath`.

--- a/README.md
+++ b/README.md
@@ -53,9 +53,13 @@ From the standalone CLI on macOS/Linux, the routed commands forward preview mode
 ```bash
 nova build -WhatIf
 nova test -WhatIf
+nova bump -WhatIf
 nova publish -local -WhatIf
 nova release -local -WhatIf
 ```
+
+`nova init` is intentionally still interactive and expects only an optional path argument, so the standalone CLI does
+not support `nova init -WhatIf`.
 
 For command-specific details and examples, run `Get-Help <CommandName> -Full` after importing the module.
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,31 @@ To ensure this module works correctly, you need to maintain the folder structure
 best way to get started is by running `New-NovaModule` (`nova init`), which guides you through a series of questions
 and creates the necessary scaffolding.
 
+## Preview changes safely with `-WhatIf`
+
+State-changing NovaModuleTools commands support PowerShell `-WhatIf`, so you can preview what would happen before files,
+versions, test artifacts, or publish targets are changed.
+
+```powershell
+PS> Invoke-NovaBuild -WhatIf
+PS> Test-NovaBuild -WhatIf
+PS> Publish-NovaModule -Local -WhatIf
+PS> Invoke-NovaRelease -PublishOption @{ Local = $true } -WhatIf
+PS> Update-NovaModuleVersion -WhatIf
+PS> Install-NovaCli -WhatIf
+```
+
+From the standalone CLI on macOS/Linux, the routed commands forward preview mode to the underlying PowerShell cmdlets:
+
+```bash
+nova build -WhatIf
+nova test -WhatIf
+nova publish -local -WhatIf
+nova release -local -WhatIf
+```
+
+For command-specific details and examples, run `Get-Help <CommandName> -Full` after importing the module.
+
 ## Folder Structure
 All module files should be inside the `src` folder.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ best way to get started is by running `New-NovaModule` (`nova init`), which guid
 and creates the necessary scaffolding.
 
 ## Preview changes safely with `-WhatIf`
-
 State-changing NovaModuleTools commands support PowerShell `-WhatIf`, so you can preview what would happen before files,
 versions, test artifacts, or publish targets are changed.
 

--- a/docs/NovaModuleTools/en-US/Get-NovaProjectInfo.md
+++ b/docs/NovaModuleTools/en-US/Get-NovaProjectInfo.md
@@ -20,7 +20,7 @@ Reads `project.json` and returns resolved NovaModuleTools project metadata.
 ### __AllParameterSets
 
 ```powershell
-Get-NovaProjectInfo [[-Path] <string>] [-Version] [<CommonParameters>]
+PS> Get-NovaProjectInfo [[-Path] <string>] [-Version] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/docs/NovaModuleTools/en-US/Install-NovaCli.md
+++ b/docs/NovaModuleTools/en-US/Install-NovaCli.md
@@ -34,9 +34,6 @@ By default, the launcher is installed to `~/.local/bin/nova` on macOS and Linux.
 This command is currently intended for macOS and Linux. On Windows, use the `nova` alias inside `pwsh` after importing
 NovaModuleTools.
 
-This command supports `-WhatIf` and `-Confirm` through PowerShell `SupportsShouldProcess`. Use `-WhatIf` to preview the
-launcher destination without copying the file or changing executable permissions.
-
 ## EXAMPLES
 
 ### EXAMPLE 1
@@ -107,6 +104,50 @@ AcceptedValues: [ ]
 HelpMessage: ''
 ```
 
+### -WhatIf
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases:
+  - wi
+ParameterSets:
+  - Name: (All)
+    Position: Named
+    IsRequired: false
+    ValueFromPipeline: false
+    ValueFromPipelineByPropertyName: false
+    ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: [ ]
+HelpMessage: ''
+```
+
+### -Confirm
+
+Prompts for confirmation before the launcher is installed.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases:
+  - cf
+ParameterSets:
+  - Name: (All)
+    Position: Named
+    IsRequired: false
+    ValueFromPipeline: false
+    ValueFromPipelineByPropertyName: false
+    ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: [ ]
+HelpMessage: ''
+```
+
 ### CommonParameters
 
 This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`,
@@ -131,9 +172,6 @@ currently on `PATH`.
 After running `Install-NovaCli`, add the destination directory to your shell `PATH` if needed.
 
 On Windows, keep using the `nova` alias inside `pwsh` instead of this command.
-
-`Install-NovaCli` uses `SupportsShouldProcess`, so `Get-Help Install-NovaCli -Full` surfaces native `-WhatIf` and
-`-Confirm` support.
 
 ## RELATED LINKS
 

--- a/docs/NovaModuleTools/en-US/Install-NovaCli.md
+++ b/docs/NovaModuleTools/en-US/Install-NovaCli.md
@@ -34,6 +34,9 @@ By default, the launcher is installed to `~/.local/bin/nova` on macOS and Linux.
 This command is currently intended for macOS and Linux. On Windows, use the `nova` alias inside `pwsh` after importing
 NovaModuleTools.
 
+This command supports `-WhatIf` and `-Confirm` through PowerShell `SupportsShouldProcess`. Use `-WhatIf` to preview the
+launcher destination without copying the file or changing executable permissions.
+
 ## EXAMPLES
 
 ### EXAMPLE 1
@@ -104,50 +107,6 @@ AcceptedValues: [ ]
 HelpMessage: ''
 ```
 
-### -WhatIf
-
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
-
-```yaml
-Type: System.Management.Automation.SwitchParameter
-DefaultValue: False
-SupportsWildcards: false
-Aliases:
-- wi
-ParameterSets:
-  - Name: (All)
-    Position: Named
-    IsRequired: false
-    ValueFromPipeline: false
-    ValueFromPipelineByPropertyName: false
-    ValueFromRemainingArguments: false
-DontShow: false
-AcceptedValues: [ ]
-HelpMessage: ''
-```
-
-### -Confirm
-
-Prompts for confirmation before the launcher is installed.
-
-```yaml
-Type: System.Management.Automation.SwitchParameter
-DefaultValue: False
-SupportsWildcards: false
-Aliases:
-- cf
-ParameterSets:
-  - Name: (All)
-    Position: Named
-    IsRequired: false
-    ValueFromPipeline: false
-    ValueFromPipelineByPropertyName: false
-    ValueFromRemainingArguments: false
-DontShow: false
-AcceptedValues: [ ]
-HelpMessage: ''
-```
-
 ### CommonParameters
 
 This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`,
@@ -172,6 +131,9 @@ currently on `PATH`.
 After running `Install-NovaCli`, add the destination directory to your shell `PATH` if needed.
 
 On Windows, keep using the `nova` alias inside `pwsh` instead of this command.
+
+`Install-NovaCli` uses `SupportsShouldProcess`, so `Get-Help Install-NovaCli -Full` surfaces native `-WhatIf` and
+`-Confirm` support.
 
 ## RELATED LINKS
 

--- a/docs/NovaModuleTools/en-US/Install-NovaCli.md
+++ b/docs/NovaModuleTools/en-US/Install-NovaCli.md
@@ -20,7 +20,7 @@ Installs the bundled `nova` launcher so it can be run directly from zsh/bash on 
 ### __AllParameterSets
 
 ```powershell
-Install-NovaCli [[-DestinationDirectory] <string>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+PS> Install-NovaCli [[-DestinationDirectory] <string>] [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/docs/NovaModuleTools/en-US/Invoke-NovaBuild.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaBuild.md
@@ -20,12 +20,15 @@ Builds the current NovaModuleTools project into a ready-to-import PowerShell mod
 ### __AllParameterSets
 
 ```powershell
-Invoke-NovaBuild [<CommonParameters>]
+PS> Invoke-NovaBuild [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
 `Invoke-NovaBuild` runs the NovaModuleTools build pipeline for the current project.
+
+This command supports `-WhatIf` and `-Confirm` through PowerShell `SupportsShouldProcess`. Use `-WhatIf` to preview the
+build target without clearing `dist/` or generating new build output.
 
 The command:
 
@@ -59,13 +62,21 @@ PS> Invoke-NovaBuild -Verbose
 
 Builds the current project and writes verbose progress for the build workflow.
 
+### EXAMPLE 3
+
+```powershell
+PS> Invoke-NovaBuild -WhatIf
+```
+
+Previews the build action without resetting `dist/` or generating module output.
+
 ## PARAMETERS
 
 ### CommonParameters
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
--ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+-ProgressAction, -Verbose, -WarningAction, -WarningVariable, -WhatIf, and -Confirm. For more information, see
 [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -83,6 +94,9 @@ This cmdlet does not emit an output object.
 ## NOTES
 
 Run this command from the project root so `project.json`, `src/`, `docs/`, and `tests/` resolve correctly.
+
+`Invoke-NovaBuild` uses `SupportsShouldProcess`, so `Get-Help Invoke-NovaBuild -Full` shows the native `-WhatIf` and
+`-Confirm` behavior.
 
 ## RELATED LINKS
 

--- a/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
@@ -20,7 +20,7 @@ Provides the command backend for the `nova` alias and a more user-friendly CLI e
 ### __AllParameterSets
 
 ```powershell
-Invoke-NovaCli [[-Command] <string>] [[-Arguments] <string[]>] [<CommonParameters>]
+PS> Invoke-NovaCli [[-Command] <string>] [[-Arguments] <string[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -35,8 +35,13 @@ It dispatches high-level commands such as `nova info`, `nova version`, `nova --v
 Use `Invoke-NovaCli` when you need a scriptable PowerShell command entrypoint. Use `nova` when you want the
 user-focused CLI experience.
 
+Mutating routed commands (`build`, `test`, `init`, `bump`, `publish`, and `release`) forward PowerShell
+`-WhatIf`/`-Confirm` to the underlying cmdlet. That means `nova build -WhatIf` and
+`Invoke-NovaCli -Command build -WhatIf` both preview the build instead of running it.
+
 Inside an imported PowerShell session, `nova` is available through the cmdlet alias. To make `nova` available directly
-from zsh/bash on macOS or Linux, install the launcher once with `Install-NovaCli`.
+from zsh/bash on macOS or Linux, install the launcher once with `Install-NovaCli`. The standalone launcher also forwards
+`-Verbose`, `-WhatIf`, and `-Confirm` for mutating commands.
 
 ## EXAMPLES
 
@@ -90,6 +95,14 @@ PS> Invoke-NovaCli -Command build
 
 Shows the equivalent scripted PowerShell form behind `nova build`.
 
+### EXAMPLE 7
+
+```powershell
+PS> Invoke-NovaCli -Command publish -Arguments @('-local') -WhatIf
+```
+
+Previews the routed local publish flow without rebuilding, testing, or copying the module.
+
 ## PARAMETERS
 
 ### -Command
@@ -140,7 +153,7 @@ HelpMessage: ''
 
 This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`,
 `-InformationVariable`, `-OutBuffer`, `-OutVariable`, `-PipelineVariable`, `-ProgressAction`, `-Verbose`,
-`-WarningAction`, and `-WarningVariable`.
+`-WarningAction`, `-WarningVariable`, `-WhatIf`, and `-Confirm`.
 
 ## INPUTS
 
@@ -164,6 +177,9 @@ For interactive use, prefer the `nova` alias.
 
 Use `Invoke-NovaCli` directly when you need the underlying PowerShell command in scripts, tests, or command dispatch
 implementations.
+
+`Invoke-NovaCli` uses `SupportsShouldProcess` to surface native `-WhatIf` and `-Confirm`, then forwards those switches
+only to mutating subcommands.
 
 ## RELATED LINKS
 

--- a/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
@@ -35,9 +35,12 @@ It dispatches high-level commands such as `nova info`, `nova version`, `nova --v
 Use `Invoke-NovaCli` when you need a scriptable PowerShell command entrypoint. Use `nova` when you want the
 user-focused CLI experience.
 
-Mutating routed commands (`build`, `test`, `init`, `bump`, `publish`, and `release`) forward PowerShell
+Mutating routed commands (`build`, `test`, `bump`, `publish`, and `release`) forward PowerShell
 `-WhatIf`/`-Confirm` to the underlying cmdlet. That means `nova build -WhatIf` and
 `Invoke-NovaCli -Command build -WhatIf` both preview the build instead of running it.
+
+`nova init` remains interactive and expects only an optional path argument. For that reason, the CLI rejects
+`nova init -WhatIf` with a clear error instead of treating `-WhatIf` as a path.
 
 Inside an imported PowerShell session, `nova` is available through the cmdlet alias. To make `nova` available directly
 from zsh/bash on macOS or Linux, install the launcher once with `Install-NovaCli`. The standalone launcher also forwards

--- a/docs/NovaModuleTools/en-US/Invoke-NovaRelease.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaRelease.md
@@ -20,7 +20,7 @@ Runs the Nova release pipeline (build, test, version bump, rebuild, publish).
 ### __AllParameterSets
 
 ```powershell
-Invoke-NovaRelease [[-PublishOption] <hashtable>] [[-Path] <string>] [<CommonParameters>]
+PS> Invoke-NovaRelease [[-PublishOption] <hashtable>] [[-Path] <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -34,6 +34,9 @@ Invoke-NovaRelease [[-PublishOption] <hashtable>] [[-Path] <string>] [<CommonPar
 5. Publish via `Publish-NovaBuiltModule`
 
 The command changes location to `-Path` for execution and always restores the previous location.
+
+This command supports `-WhatIf` and `-Confirm` through PowerShell `SupportsShouldProcess`. Use `-WhatIf` to preview the
+entire release workflow and resolved publish target without building, testing, versioning, or publishing.
 
 ## EXAMPLES
 
@@ -60,6 +63,14 @@ PS> Invoke-NovaRelease -Path ./example -PublishOption @{ Local = $true }
 ```
 
 Runs the release workflow from the project rooted at `./example`.
+
+### EXAMPLE 4
+
+```powershell
+PS> Invoke-NovaRelease -PublishOption @{Repository = 'PSGallery'; ApiKey = $env:PSGALLERY_API} -WhatIf
+```
+
+Previews the release workflow and repository target without making changes.
 
 ## PARAMETERS
 
@@ -118,7 +129,7 @@ HelpMessage: ''
 
 This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`,
 `-InformationVariable`, `-OutBuffer`, `-OutVariable`, `-PipelineVariable`, `-ProgressAction`, `-Verbose`,
-`-WarningAction`, and `-WarningVariable`.
+`-WarningAction`, `-WarningVariable`, `-WhatIf`, and `-Confirm`.
 
 ## INPUTS
 
@@ -136,6 +147,9 @@ selected release label, and commit count.
 ## NOTES
 
 If build or tests fail, version bump and publish are not completed.
+
+`Invoke-NovaRelease` uses `SupportsShouldProcess`, so `Get-Help Invoke-NovaRelease -Full` surfaces native `-WhatIf`
+and `-Confirm` support.
 
 ## RELATED LINKS
 

--- a/docs/NovaModuleTools/en-US/New-NovaModule.md
+++ b/docs/NovaModuleTools/en-US/New-NovaModule.md
@@ -20,7 +20,7 @@ Creates a new NovaModuleTools project scaffold through an interactive prompt flo
 ### __AllParameterSets
 
 ```powershell
-New-NovaModule [[-Path] <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+PS> New-NovaModule [[-Path] <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/docs/NovaModuleTools/en-US/New-NovaModule.md
+++ b/docs/NovaModuleTools/en-US/New-NovaModule.md
@@ -34,6 +34,10 @@ PowerShell version, Git initialization, and basic Pester support.
 Use this command when you want to start a new module in the NovaModuleTools structure without hand-creating the project
 layout.
 
+This command supports `-WhatIf` and `-Confirm` through PowerShell `SupportsShouldProcess`. Use `-WhatIf` to preview the
+scaffold target after the interactive answers have been collected, without creating folders, writing `project.json`, or
+initializing Git.
+
 ## EXAMPLES
 
 ### EXAMPLE 1
@@ -54,35 +58,13 @@ Shows what would be created without writing the scaffold.
 
 ### EXAMPLE 3
 
-```powershell
+```bash
 nova init ~/Work
 ```
 
 Runs the same scaffold flow through the `nova` CLI.
 
 ## PARAMETERS
-
-### -Confirm
-
-Prompts you for confirmation before running the cmdlet.
-
-```yaml
-Type: System.Management.Automation.SwitchParameter
-DefaultValue: ''
-SupportsWildcards: false
-Aliases:
-- cf
-ParameterSets:
-- Name: (All)
-  Position: Named
-  IsRequired: false
-  ValueFromPipeline: false
-  ValueFromPipelineByPropertyName: false
-  ValueFromRemainingArguments: false
-DontShow: false
-AcceptedValues: []
-HelpMessage: ''
-```
 
 ### -Path
 
@@ -105,33 +87,11 @@ AcceptedValues: []
 HelpMessage: ''
 ```
 
-### -WhatIf
-
-Runs the command in a mode that only reports what would happen without performing the actions.
-
-```yaml
-Type: System.Management.Automation.SwitchParameter
-DefaultValue: ''
-SupportsWildcards: false
-Aliases:
-- wi
-ParameterSets:
-- Name: (All)
-  Position: Named
-  IsRequired: false
-  ValueFromPipeline: false
-  ValueFromPipelineByPropertyName: false
-  ValueFromRemainingArguments: false
-DontShow: false
-AcceptedValues: []
-HelpMessage: ''
-```
-
 ### CommonParameters
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
--ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+-ProgressAction, -Verbose, -WarningAction, -WarningVariable, -WhatIf, and -Confirm. For more information, see
 [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -151,6 +111,8 @@ This cmdlet does not emit an output object.
 Generated projects start with NovaModuleTools defaults for recursive discovery, source markers, and duplicate-function
 validation.
 
+`New-NovaModule` uses `SupportsShouldProcess`, so `Get-Help New-NovaModule -Full` surfaces native `-WhatIf` and
+`-Confirm` support.
 
 ## RELATED LINKS
 

--- a/docs/NovaModuleTools/en-US/NovaModuleTools.md
+++ b/docs/NovaModuleTools/en-US/NovaModuleTools.md
@@ -22,39 +22,39 @@ manifest generation, external help generation, resource copying, and Pester-base
 
 ## NovaModuleTools Cmdlets
 
-### `Get-NovaProjectInfo`
+### `PS> Get-NovaProjectInfo`
 
 Reads `project.json` and returns resolved project metadata and paths.
 
-### `Install-NovaCli`
+### `PS> Install-NovaCli`
 
 Installs the bundled `nova` launcher into a user command directory on macOS or Linux.
 
-### `Invoke-NovaBuild`
+### `PS> Invoke-NovaBuild`
 
 Builds the current NovaModuleTools project into a ready-to-import PowerShell module.
 
-### `Invoke-NovaCli`
+### `PS> Invoke-NovaCli`
 
 Routes the `nova` CLI experience through a single PowerShell command entrypoint.
 
-### `Invoke-NovaRelease`
+### `PS> Invoke-NovaRelease`
 
 Runs the Nova release pipeline (build, test, version bump, rebuild, publish).
 
-### `Test-NovaBuild`
+### `PS> Test-NovaBuild`
 
 Runs the project's Pester test workflow using settings from `project.json`.
 
-### `New-NovaModule`
+### `PS> New-NovaModule`
 
 Creates a new NovaModuleTools project scaffold through an interactive prompt flow.
 
-### `Publish-NovaModule`
+### `PS> Publish-NovaModule`
 
 Builds, tests, and publishes the current project either locally or to a repository.
 
-### `Update-NovaModuleVersion`
+### `PS> Update-NovaModuleVersion`
 
 Updates the project version in `project.json` based on the current git commit history.
 

--- a/docs/NovaModuleTools/en-US/Publish-NovaModule.md
+++ b/docs/NovaModuleTools/en-US/Publish-NovaModule.md
@@ -39,8 +39,7 @@ Use repository mode when you want to publish the built module to a registered Po
 `PSGallery`.
 
 This command supports `-WhatIf` and `-Confirm` through PowerShell `SupportsShouldProcess`. Use `-WhatIf` to preview the
-build, test, and publish workflow without changing `dist/`, writing test artifacts, copying module files, or calling the
-target repository.
+resolved publish target and workflow without building, testing, or publishing.
 
 ## EXAMPLES
 
@@ -70,19 +69,19 @@ Builds, tests, and publishes the module to `PSGallery`.
 
 ### EXAMPLE 4
 
-```powershell
-PS> Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API -WhatIf
-```
-
-Previews the build, test, and repository publish workflow without making changes.
-
-### EXAMPLE 5
-
 ```bash
 nova publish -repository PSGallery -apikey $PSGALLERY_API
 ```
 
 Runs the same publish flow through the `nova` CLI.
+
+### EXAMPLE 5
+
+```powershell
+PS> Publish-NovaModule -Local -WhatIf
+```
+
+Previews the local publish workflow and target directory without making changes.
 
 ## PARAMETERS
 
@@ -197,8 +196,8 @@ This cmdlet does not emit an output object.
 
 The command always builds and tests before publishing.
 
-`Publish-NovaModule` uses `SupportsShouldProcess`, so `Get-Help Publish-NovaModule -Full` surfaces native `-WhatIf` and
-`-Confirm` support.
+`Publish-NovaModule` uses `SupportsShouldProcess`, so `Get-Help Publish-NovaModule -Full` should surface native
+`-WhatIf` and `-Confirm` support.
 
 ## RELATED LINKS
 

--- a/docs/NovaModuleTools/en-US/Publish-NovaModule.md
+++ b/docs/NovaModuleTools/en-US/Publish-NovaModule.md
@@ -66,8 +66,8 @@ Builds, tests, and publishes the module to `PSGallery`.
 
 ### EXAMPLE 4
 
-```powershell
-nova publish --repository PSGallery --apikey $env:PSGALLERY_API
+```bash
+nova publish -repository PSGallery -apikey $PSGALLERY_API
 ```
 
 Runs the same publish flow through the `nova` CLI.

--- a/docs/NovaModuleTools/en-US/Publish-NovaModule.md
+++ b/docs/NovaModuleTools/en-US/Publish-NovaModule.md
@@ -20,13 +20,13 @@ Builds, tests, and publishes the current project either locally or to a PowerShe
 ### Local
 
 ```powershell
-Publish-NovaModule [-Local] [[-ModuleDirectoryPath] <string>] [[-ApiKey] <string>] [<CommonParameters>]
+PS> Publish-NovaModule [-Local] [[-ModuleDirectoryPath] <string>] [[-ApiKey] <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Repository
 
 ```powershell
-Publish-NovaModule [-Repository] <string> [[-ModuleDirectoryPath] <string>] [[-ApiKey] <string>] [<CommonParameters>]
+PS> Publish-NovaModule [-Repository] <string> [[-ModuleDirectoryPath] <string>] [[-ApiKey] <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -37,6 +37,10 @@ Use local mode when you want to copy the built module into a module directory on
 
 Use repository mode when you want to publish the built module to a registered PowerShell repository such as
 `PSGallery`.
+
+This command supports `-WhatIf` and `-Confirm` through PowerShell `SupportsShouldProcess`. Use `-WhatIf` to preview the
+build, test, and publish workflow without changing `dist/`, writing test artifacts, copying module files, or calling the
+target repository.
 
 ## EXAMPLES
 
@@ -65,6 +69,14 @@ PS> Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API
 Builds, tests, and publishes the module to `PSGallery`.
 
 ### EXAMPLE 4
+
+```powershell
+PS> Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API -WhatIf
+```
+
+Previews the build, test, and repository publish workflow without making changes.
+
+### EXAMPLE 5
 
 ```bash
 nova publish -repository PSGallery -apikey $PSGALLERY_API
@@ -166,7 +178,7 @@ HelpMessage: ''
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
--ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+-ProgressAction, -Verbose, -WarningAction, -WarningVariable, -WhatIf, and -Confirm. For more information, see
 [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -184,6 +196,9 @@ This cmdlet does not emit an output object.
 ## NOTES
 
 The command always builds and tests before publishing.
+
+`Publish-NovaModule` uses `SupportsShouldProcess`, so `Get-Help Publish-NovaModule -Full` surfaces native `-WhatIf` and
+`-Confirm` support.
 
 ## RELATED LINKS
 

--- a/docs/NovaModuleTools/en-US/Test-NovaBuild.md
+++ b/docs/NovaModuleTools/en-US/Test-NovaBuild.md
@@ -21,7 +21,7 @@ Runs Pester tests for the current NovaModuleTools project.
 
 ```powershell
 PS> Test-NovaBuild [[-TagFilter] <string[]>] [[-ExcludeTagFilter] <string[]>] [[-OutputVerbosity] <string>]
- [[-OutputRenderMode] <string>] [<CommonParameters>]
+[[-OutputRenderMode] <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -33,6 +33,9 @@ With the default
 `BuildRecursiveFolders=true`, test files in nested folders under `tests` are discovered and run. Set
 `BuildRecursiveFolders=false` to limit discovery to top-level `tests/*.Tests.ps1` files, following Pester's normal
 test-file convention. The generated Pester XML report is written to `artifacts/TestResults.xml`.
+
+This command supports `-WhatIf` and `-Confirm` through PowerShell `SupportsShouldProcess`. Use `-WhatIf` to preview the
+planned test run and XML output path without creating `artifacts/` or invoking Pester.
 
 ## EXAMPLES
 
@@ -67,6 +70,14 @@ PS> Test-NovaBuild -OutputVerbosity Normal -OutputRenderMode Plaintext
 ```
 
 Overrides the console output settings for the current test run.
+
+### EXAMPLE 5
+
+```powershell
+PS> Test-NovaBuild -WhatIf
+```
+
+Previews the planned Pester run without executing tests or writing `artifacts/TestResults.xml`.
 
 ## PARAMETERS
 
@@ -165,7 +176,7 @@ HelpMessage: ''
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
--ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+-ProgressAction, -Verbose, -WarningAction, -WarningVariable, -WhatIf, and -Confirm. For more information, see
 [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -183,6 +194,9 @@ This cmdlet does not emit an output object. It throws when the test run fails.
 ## NOTES
 
 The generated test result XML is written to `artifacts/TestResults.xml`.
+
+`Test-NovaBuild` uses `SupportsShouldProcess`, so `Get-Help Test-NovaBuild -Full` surfaces native `-WhatIf` and
+`-Confirm` support.
 
 ## RELATED LINKS
 

--- a/docs/NovaModuleTools/en-US/Test-NovaBuild.md
+++ b/docs/NovaModuleTools/en-US/Test-NovaBuild.md
@@ -20,7 +20,7 @@ Runs Pester tests for the current NovaModuleTools project.
 ### __AllParameterSets
 
 ```powershell
-Test-NovaBuild [[-TagFilter] <string[]>] [[-ExcludeTagFilter] <string[]>] [[-OutputVerbosity] <string>]
+PS> Test-NovaBuild [[-TagFilter] <string[]>] [[-ExcludeTagFilter] <string[]>] [[-OutputVerbosity] <string>]
  [[-OutputRenderMode] <string>] [<CommonParameters>]
 ```
 

--- a/docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md
+++ b/docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md
@@ -37,6 +37,9 @@ The release label is inferred from the commit set:
 When Git tags exist, only commits since the latest tag are considered. If the folder is not a Git repository, the
 command falls back to a patch bump.
 
+This command supports `-WhatIf` and `-Confirm` through PowerShell `SupportsShouldProcess`. Use `-WhatIf` to preview the
+calculated release label and target `project.json` without changing the stored version.
+
 ## EXAMPLES
 
 ### EXAMPLE 1
@@ -86,55 +89,11 @@ AcceptedValues: []
 HelpMessage: ''
 ```
 
-### -WhatIf
-
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
-
-```yaml
-Type: System.Management.Automation.SwitchParameter
-DefaultValue: False
-SupportsWildcards: false
-Aliases:
-  - wi
-ParameterSets:
-- Name: (All)
-  Position: Named
-  IsRequired: false
-  ValueFromPipeline: false
-  ValueFromPipelineByPropertyName: false
-  ValueFromRemainingArguments: false
-DontShow: false
-AcceptedValues: []
-HelpMessage: ''
-```
-
-### -Confirm
-
-Prompts for confirmation before `project.json` is updated.
-
-```yaml
-Type: System.Management.Automation.SwitchParameter
-DefaultValue: False
-SupportsWildcards: false
-Aliases:
-  - cf
-ParameterSets:
-- Name: (All)
-  Position: Named
-  IsRequired: false
-  ValueFromPipeline: false
-  ValueFromPipelineByPropertyName: false
-  ValueFromRemainingArguments: false
-DontShow: false
-AcceptedValues: []
-HelpMessage: ''
-```
-
 ### CommonParameters
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
 -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
--ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+-ProgressAction, -Verbose, -WarningAction, -WarningVariable, -WhatIf, and -Confirm. For more information, see
 [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -156,6 +115,8 @@ Run this command from a NovaModuleTools project root or supply `-Path`.
 This command updates `project.json`. Rebuild the module afterward if you want the generated manifest and built output to
 reflect the new version.
 
+`Update-NovaModuleVersion` uses `SupportsShouldProcess`, so `Get-Help Update-NovaModuleVersion -Full` surfaces native
+`-WhatIf` and `-Confirm` support.
 
 ## RELATED LINKS
 

--- a/docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md
+++ b/docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md
@@ -20,7 +20,7 @@ Updates the project version in `project.json` based on git commit history.
 ### __AllParameterSets
 
 ```powershell
-Update-NovaModuleVersion [[-Path] <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+PS> Update-NovaModuleVersion [[-Path] <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION

--- a/project.json
+++ b/project.json
@@ -1,7 +1,7 @@
 {
   "ProjectName": "NovaModuleTools",
   "Description": "NovaModuleTools is an enterprise-focused evolution of ModuleTools, designed for large-scale PowerShell projects with a strong emphasis on structure, maintainability, and automated CI/CD pipelines.",
-  "Version": "1.9.15",
+  "Version": "1.9.19",
   "Preamble": [
     "Set-StrictMode -Version Latest",
     "$ErrorActionPreference = 'Stop'"

--- a/project.json
+++ b/project.json
@@ -1,7 +1,7 @@
 {
   "ProjectName": "NovaModuleTools",
   "Description": "NovaModuleTools is an enterprise-focused evolution of ModuleTools, designed for large-scale PowerShell projects with a strong emphasis on structure, maintainability, and automated CI/CD pipelines.",
-  "Version": "1.9.20",
+  "Version": "1.9.21",
   "Preamble": [
     "Set-StrictMode -Version Latest",
     "$ErrorActionPreference = 'Stop'"

--- a/project.json
+++ b/project.json
@@ -1,7 +1,7 @@
 {
   "ProjectName": "NovaModuleTools",
   "Description": "NovaModuleTools is an enterprise-focused evolution of ModuleTools, designed for large-scale PowerShell projects with a strong emphasis on structure, maintainability, and automated CI/CD pipelines.",
-  "Version": "1.9.19",
+  "Version": "1.9.20",
   "Preamble": [
     "Set-StrictMode -Version Latest",
     "$ErrorActionPreference = 'Stop'"

--- a/src/private/build/ResetProjectDist.ps1
+++ b/src/private/build/ResetProjectDist.ps1
@@ -5,6 +5,10 @@ function Reset-ProjectDist {
     $data = Get-NovaProjectInfo
     try {
         Write-Verbose 'Running dist folder reset'
+        if (-not $PSCmdlet.ShouldProcess($data.OutputDir, 'Reset build output directory')) {
+            return
+        }
+
         if (Test-Path $data.OutputDir) {
             Remove-Item -Path $data.OutputDir -Recurse -Force -ProgressAction SilentlyContinue -ErrorAction Stop
         }

--- a/src/private/build/ResetProjectDist.ps1
+++ b/src/private/build/ResetProjectDist.ps1
@@ -5,10 +5,6 @@ function Reset-ProjectDist {
     $data = Get-NovaProjectInfo
     try {
         Write-Verbose 'Running dist folder reset'
-        if (-not $PSCmdlet.ShouldProcess($data.OutputDir, 'Reset build output directory')) {
-            return
-        }
-
         if (Test-Path $data.OutputDir) {
             Remove-Item -Path $data.OutputDir -Recurse -Force -ProgressAction SilentlyContinue -ErrorAction Stop
         }

--- a/src/private/cli/GetNovaCliForwardingParameterSet.ps1
+++ b/src/private/cli/GetNovaCliForwardingParameterSet.ps1
@@ -1,0 +1,26 @@
+function Get-NovaCliForwardingParameterSet {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][hashtable]$BoundParameters,
+        [switch]$IncludeShouldProcess
+    )
+
+    $parameters = @{}
+    if ( $BoundParameters.ContainsKey('Verbose')) {
+        $parameters.Verbose = $true
+    }
+
+    if ($IncludeShouldProcess) {
+        if ($WhatIfPreference) {
+            $parameters.WhatIf = $true
+        }
+
+        if ( $BoundParameters.ContainsKey('Confirm')) {
+            $parameters.Confirm = [bool]$BoundParameters.Confirm
+        }
+    }
+
+    return $parameters
+}
+
+

--- a/src/private/cli/GetNovaCliHelp.ps1
+++ b/src/private/cli/GetNovaCliHelp.ps1
@@ -21,6 +21,9 @@ publish and release
 global options
    --help     Show this help message
    --version  Show the installed NovaModuleTools module name and version
+   -Verbose   Show verbose output for the routed PowerShell command
+   -WhatIf    Preview build, test, bump, publish, and release without changing files
+   -Confirm   Request confirmation before mutating routed commands
 
 Examples:
    nova init ~/Work
@@ -28,6 +31,7 @@ Examples:
    nova version
    nova build
    nova test
+   nova bump -WhatIf
    nova publish -local
    nova publish -repository PSGallery -apikey <key>
    nova bump
@@ -38,6 +42,9 @@ the standalone 'nova' command available from zsh/bash.
 
 Use 'nova <command>' to run a command, or call the underlying PowerShell cmdlet directly
 when you want a scriptable function interface.
+
+Note: 'nova init' is interactive and expects only an optional path argument. The CLI does
+not support 'nova init -WhatIf'.
 '@
 
     return $help

--- a/src/private/cli/GetNovaCliHelp.ps1
+++ b/src/private/cli/GetNovaCliHelp.ps1
@@ -28,10 +28,10 @@ Examples:
    nova version
    nova build
    nova test
-   nova publish --local
-   nova publish --repository PSGallery --apikey <key>
+   nova publish -local
+   nova publish -repository PSGallery -apikey <key>
    nova bump
-   nova release --repository PSGallery --apikey <key>
+   nova release -repository PSGallery -apikey <key>
 
 After installing the module on macOS/Linux, run Install-NovaCli once if you want
 the standalone 'nova' command available from zsh/bash.

--- a/src/private/release/GetNovaPublishOptionValue.ps1
+++ b/src/private/release/GetNovaPublishOptionValue.ps1
@@ -1,0 +1,14 @@
+function Get-NovaPublishOptionValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][hashtable]$PublishOption,
+        [Parameter(Mandatory)][string]$Name
+    )
+
+    if (-not $PublishOption.ContainsKey($Name)) {
+        return $null
+    }
+
+    return $PublishOption[$Name]
+}
+

--- a/src/private/release/GetNovaPublishWorkflowOperation.ps1
+++ b/src/private/release/GetNovaPublishWorkflowOperation.ps1
@@ -1,0 +1,24 @@
+function Get-NovaPublishWorkflowOperation {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][bool]$IsLocal,
+        [switch]$Release
+    )
+
+    $workflowText = if ($Release) {
+        'Run Nova release workflow and publish'
+    }
+    else {
+        'Build, test, and publish Nova module'
+    }
+
+    $destinationText = if ($IsLocal) {
+        'local directory'
+    }
+    else {
+        'repository'
+    }
+
+    return "$workflowText to $destinationText"
+}
+

--- a/src/private/release/InvokeNovaResolvedPublishInvocation.ps1
+++ b/src/private/release/InvokeNovaResolvedPublishInvocation.ps1
@@ -1,0 +1,19 @@
+function Invoke-NovaResolvedPublishInvocation {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$PublishInvocation,
+        [hashtable]$WorkflowParams = @{}
+    )
+
+    $publishParams = @{}
+    foreach ($parameterName in $PublishInvocation.Parameters.Keys) {
+        $publishParams[$parameterName] = $PublishInvocation.Parameters[$parameterName]
+    }
+
+    foreach ($parameterName in $WorkflowParams.Keys) {
+        $publishParams[$parameterName] = $WorkflowParams[$parameterName]
+    }
+
+    return & $PublishInvocation.Action @publishParams
+}
+

--- a/src/private/release/PublishNovaBuiltModule.ps1
+++ b/src/private/release/PublishNovaBuiltModule.ps1
@@ -1,5 +1,5 @@
 function Publish-NovaBuiltModule {
-    [CmdletBinding(DefaultParameterSetName = 'Local')]
+    [CmdletBinding(DefaultParameterSetName = 'Local', SupportsShouldProcess = $true)]
     param(
         [Parameter(ParameterSetName = 'Repository')]
         [string]$Repository,
@@ -14,7 +14,12 @@ function Publish-NovaBuiltModule {
     }
 
     if ( $PSBoundParameters.ContainsKey('Repository')) {
-        Publish-NovaBuiltModuleToRepository -ProjectInfo $ProjectInfo -Repository $Repository -ApiKey $ApiKey
+        $shouldRun = $PSCmdlet.ShouldProcess($Repository, 'Publish built module to repository')
+        if (-not $shouldRun -and -not $WhatIfPreference) {
+            return
+        }
+
+        Publish-NovaBuiltModuleToRepository -ProjectInfo $ProjectInfo -Repository $Repository -ApiKey $ApiKey -WhatIf:$WhatIfPreference -Confirm:$false
         return
     }
 
@@ -23,5 +28,10 @@ function Publish-NovaBuiltModule {
         $resolvedModuleDirectoryPath = Resolve-NovaLocalPublishPath -ModuleDirectoryPath $ModuleDirectoryPath
     }
 
-    Publish-NovaBuiltModuleToDirectory -ProjectInfo $ProjectInfo -ModuleDirectoryPath $resolvedModuleDirectoryPath
+    $shouldRun = $PSCmdlet.ShouldProcess($resolvedModuleDirectoryPath, 'Publish built module to local directory')
+    if (-not $shouldRun -and -not $WhatIfPreference) {
+        return
+    }
+
+    Publish-NovaBuiltModuleToDirectory -ProjectInfo $ProjectInfo -ModuleDirectoryPath $resolvedModuleDirectoryPath -WhatIf:$WhatIfPreference -Confirm:$false
 }

--- a/src/private/release/PublishNovaBuiltModule.ps1
+++ b/src/private/release/PublishNovaBuiltModule.ps1
@@ -1,5 +1,5 @@
 function Publish-NovaBuiltModule {
-    [CmdletBinding(DefaultParameterSetName = 'Local', SupportsShouldProcess = $true)]
+    [CmdletBinding(DefaultParameterSetName = 'Local')]
     param(
         [Parameter(ParameterSetName = 'Repository')]
         [string]$Repository,
@@ -14,12 +14,7 @@ function Publish-NovaBuiltModule {
     }
 
     if ( $PSBoundParameters.ContainsKey('Repository')) {
-        $shouldRun = $PSCmdlet.ShouldProcess($Repository, 'Publish built module to repository')
-        if (-not $shouldRun -and -not $WhatIfPreference) {
-            return
-        }
-
-        Publish-NovaBuiltModuleToRepository -ProjectInfo $ProjectInfo -Repository $Repository -ApiKey $ApiKey -WhatIf:$WhatIfPreference -Confirm:$false
+        Publish-NovaBuiltModuleToRepository -ProjectInfo $ProjectInfo -Repository $Repository -ApiKey $ApiKey
         return
     }
 
@@ -28,10 +23,5 @@ function Publish-NovaBuiltModule {
         $resolvedModuleDirectoryPath = Resolve-NovaLocalPublishPath -ModuleDirectoryPath $ModuleDirectoryPath
     }
 
-    $shouldRun = $PSCmdlet.ShouldProcess($resolvedModuleDirectoryPath, 'Publish built module to local directory')
-    if (-not $shouldRun -and -not $WhatIfPreference) {
-        return
-    }
-
-    Publish-NovaBuiltModuleToDirectory -ProjectInfo $ProjectInfo -ModuleDirectoryPath $resolvedModuleDirectoryPath -WhatIf:$WhatIfPreference -Confirm:$false
+    Publish-NovaBuiltModuleToDirectory -ProjectInfo $ProjectInfo -ModuleDirectoryPath $resolvedModuleDirectoryPath
 }

--- a/src/private/release/PublishNovaBuiltModuleToDirectory.ps1
+++ b/src/private/release/PublishNovaBuiltModuleToDirectory.ps1
@@ -1,5 +1,5 @@
 function Publish-NovaBuiltModuleToDirectory {
-    [CmdletBinding(SupportsShouldProcess = $true)]
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
         [pscustomobject]$ProjectInfo,
@@ -8,16 +8,11 @@ function Publish-NovaBuiltModuleToDirectory {
         [string]$ModuleDirectoryPath
     )
 
-    $targetPath = Join-Path -Path $ModuleDirectoryPath -ChildPath $ProjectInfo.ProjectName
-    if (-not $PSCmdlet.ShouldProcess($targetPath, 'Publish built module to local directory')) {
-        return
-    }
-
     if (-not (Test-Path -LiteralPath $ModuleDirectoryPath -PathType Container)) {
         New-Item -Path $ModuleDirectoryPath -ItemType Directory -Force | Out-Null
     }
 
-    $oldModule = $targetPath
+    $oldModule = Join-Path -Path $ModuleDirectoryPath -ChildPath $ProjectInfo.ProjectName
     if (Test-Path -LiteralPath $oldModule) {
         Remove-Item -LiteralPath $oldModule -Recurse -Force
     }

--- a/src/private/release/PublishNovaBuiltModuleToDirectory.ps1
+++ b/src/private/release/PublishNovaBuiltModuleToDirectory.ps1
@@ -1,5 +1,5 @@
 function Publish-NovaBuiltModuleToDirectory {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory)]
         [pscustomobject]$ProjectInfo,
@@ -8,11 +8,16 @@ function Publish-NovaBuiltModuleToDirectory {
         [string]$ModuleDirectoryPath
     )
 
+    $targetPath = Join-Path -Path $ModuleDirectoryPath -ChildPath $ProjectInfo.ProjectName
+    if (-not $PSCmdlet.ShouldProcess($targetPath, 'Publish built module to local directory')) {
+        return
+    }
+
     if (-not (Test-Path -LiteralPath $ModuleDirectoryPath -PathType Container)) {
         New-Item -Path $ModuleDirectoryPath -ItemType Directory -Force | Out-Null
     }
 
-    $oldModule = Join-Path -Path $ModuleDirectoryPath -ChildPath $ProjectInfo.ProjectName
+    $oldModule = $targetPath
     if (Test-Path -LiteralPath $oldModule) {
         Remove-Item -LiteralPath $oldModule -Recurse -Force
     }

--- a/src/private/release/PublishNovaBuiltModuleToDirectory.ps1
+++ b/src/private/release/PublishNovaBuiltModuleToDirectory.ps1
@@ -1,5 +1,5 @@
 function Publish-NovaBuiltModuleToDirectory {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory)]
         [pscustomobject]$ProjectInfo,
@@ -7,6 +7,10 @@ function Publish-NovaBuiltModuleToDirectory {
         [Parameter(Mandatory)]
         [string]$ModuleDirectoryPath
     )
+
+    if (-not $PSCmdlet.ShouldProcess($ModuleDirectoryPath, 'Copy built module to local module path')) {
+        return
+    }
 
     if (-not (Test-Path -LiteralPath $ModuleDirectoryPath -PathType Container)) {
         New-Item -Path $ModuleDirectoryPath -ItemType Directory -Force | Out-Null

--- a/src/private/release/PublishNovaBuiltModuleToRepository.ps1
+++ b/src/private/release/PublishNovaBuiltModuleToRepository.ps1
@@ -1,5 +1,5 @@
 function Publish-NovaBuiltModuleToRepository {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory)]
         [pscustomobject]$ProjectInfo,
@@ -23,6 +23,10 @@ function Publish-NovaBuiltModuleToRepository {
 
     if (-not [string]::IsNullOrWhiteSpace($resolvedApiKey)) {
         $publishParams.ApiKey = $resolvedApiKey
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($Repository, 'Publish built module to repository')) {
+        return
     }
 
     Publish-PSResource @publishParams

--- a/src/private/release/PublishNovaBuiltModuleToRepository.ps1
+++ b/src/private/release/PublishNovaBuiltModuleToRepository.ps1
@@ -1,5 +1,5 @@
 function Publish-NovaBuiltModuleToRepository {
-    [CmdletBinding(SupportsShouldProcess = $true)]
+    [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
         [pscustomobject]$ProjectInfo,
@@ -23,10 +23,6 @@ function Publish-NovaBuiltModuleToRepository {
 
     if (-not [string]::IsNullOrWhiteSpace($resolvedApiKey)) {
         $publishParams.ApiKey = $resolvedApiKey
-    }
-
-    if (-not $PSCmdlet.ShouldProcess($Repository, 'Publish built module to repository')) {
-        return
     }
 
     Publish-PSResource @publishParams

--- a/src/private/release/ResolveNovaPublishInvocation.ps1
+++ b/src/private/release/ResolveNovaPublishInvocation.ps1
@@ -1,0 +1,33 @@
+function Resolve-NovaPublishInvocation {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
+        [string]$Repository,
+        [string]$ModuleDirectoryPath,
+        [string]$ApiKey
+    )
+
+    $publishParameters = @{ProjectInfo = $ProjectInfo}
+    if (-not [string]::IsNullOrWhiteSpace($Repository)) {
+        $publishParameters.Repository = $Repository
+        $publishParameters.ApiKey = $ApiKey
+
+        return [pscustomobject]@{
+            Action = (Get-Command -Name Publish-NovaBuiltModuleToRepository -CommandType Function).ScriptBlock
+            Parameters = $publishParameters
+            Target = $Repository
+            IsLocal = $false
+        }
+    }
+
+    $resolvedModuleDirectoryPath = Resolve-NovaLocalPublishPath -ModuleDirectoryPath $ModuleDirectoryPath
+    $publishParameters.ModuleDirectoryPath = $resolvedModuleDirectoryPath
+
+    return [pscustomobject]@{
+        Action = (Get-Command -Name Publish-NovaBuiltModuleToDirectory -CommandType Function).ScriptBlock
+        Parameters = $publishParameters
+        Target = $resolvedModuleDirectoryPath
+        IsLocal = $true
+    }
+}
+

--- a/src/private/release/WriteNovaLocalPublishCompletionMessage.ps1
+++ b/src/private/release/WriteNovaLocalPublishCompletionMessage.ps1
@@ -1,0 +1,14 @@
+function Write-NovaLocalPublishCompletionMessage {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][bool]$ShouldRun,
+        [Parameter(Mandatory)][pscustomobject]$PublishInvocation
+    )
+
+    if (-not $ShouldRun -or -not $PublishInvocation.IsLocal) {
+        return
+    }
+
+    Write-Verbose 'Module copy to local path complete, Refresh session or import module manually'
+}
+

--- a/src/private/release/WriteNovaLocalWorkflowMode.ps1
+++ b/src/private/release/WriteNovaLocalWorkflowMode.ps1
@@ -1,0 +1,14 @@
+function Write-NovaLocalWorkflowMode {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$WorkflowName,
+        [switch]$LocalRequested
+    )
+
+    if (-not $LocalRequested) {
+        return
+    }
+
+    Write-Verbose "Using local $WorkflowName mode."
+}
+

--- a/src/private/release/WriteNovaResolvedLocalPublishTarget.ps1
+++ b/src/private/release/WriteNovaResolvedLocalPublishTarget.ps1
@@ -1,0 +1,13 @@
+function Write-NovaResolvedLocalPublishTarget {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$PublishInvocation
+    )
+
+    if (-not $PublishInvocation.IsLocal) {
+        return
+    }
+
+    Write-Verbose "Using $( $PublishInvocation.Target ) as path"
+}
+

--- a/src/private/shared/GetNovaShouldProcessForwardingParameter.ps1
+++ b/src/private/shared/GetNovaShouldProcessForwardingParameter.ps1
@@ -1,0 +1,14 @@
+function Get-NovaShouldProcessForwardingParameter {
+    [CmdletBinding()]
+    param(
+        [switch]$WhatIfEnabled
+    )
+
+    $forwardingParameter = @{Confirm = $false}
+    if ($WhatIfEnabled) {
+        $forwardingParameter.WhatIf = $true
+    }
+
+    return $forwardingParameter
+}
+

--- a/src/private/shared/GetNovaShouldProcessForwardingParameter.ps1
+++ b/src/private/shared/GetNovaShouldProcessForwardingParameter.ps1
@@ -4,7 +4,7 @@ function Get-NovaShouldProcessForwardingParameter {
         [switch]$WhatIfEnabled
     )
 
-    $forwardingParameter = @{Confirm = $false}
+    $forwardingParameter = @{}
     if ($WhatIfEnabled) {
         $forwardingParameter.WhatIf = $true
     }

--- a/src/public/InvokeNovaBuild.ps1
+++ b/src/public/InvokeNovaBuild.ps1
@@ -2,8 +2,8 @@ function Invoke-NovaBuild {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
     )
-
     $data = Get-NovaProjectInfo
+
     if (-not $PSCmdlet.ShouldProcess($data.OutputModuleDir, 'Build Nova module output')) {
         return
     }

--- a/src/public/InvokeNovaBuild.ps1
+++ b/src/public/InvokeNovaBuild.ps1
@@ -1,11 +1,16 @@
 function Invoke-NovaBuild {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param (
     )
-    Reset-ProjectDist
-    Build-Module
 
     $data = Get-NovaProjectInfo
+    if (-not $PSCmdlet.ShouldProcess($data.OutputModuleDir, 'Build Nova module output')) {
+        return
+    }
+
+    Reset-ProjectDist -Confirm:$false
+    Build-Module
+
     if ($data.FailOnDuplicateFunctionNames) {
         Assert-BuiltModuleHasNoDuplicateFunctionName -ProjectInfo $data
     }

--- a/src/public/InvokeNovaCli.ps1
+++ b/src/public/InvokeNovaCli.ps1
@@ -9,23 +9,8 @@ function Invoke-NovaCli {
         [string[]]$Arguments
     )
 
-    $commonParameters = @{}
-    if ( $PSBoundParameters.ContainsKey('Verbose')) {
-        $commonParameters.Verbose = $true
-    }
-
-    $mutatingCommonParameters = @{}
-    foreach ($parameterKey in $commonParameters.Keys) {
-        $mutatingCommonParameters[$parameterKey] = $commonParameters[$parameterKey]
-    }
-
-    if ($WhatIfPreference) {
-        $mutatingCommonParameters.WhatIf = $true
-    }
-
-    if ( $PSBoundParameters.ContainsKey('Confirm')) {
-        $mutatingCommonParameters.Confirm = [bool]$PSBoundParameters.Confirm
-    }
+    $commonParameters = Get-NovaCliForwardingParameterSet -BoundParameters $PSBoundParameters
+    $mutatingCommonParameters = Get-NovaCliForwardingParameterSet -BoundParameters $PSBoundParameters -IncludeShouldProcess
 
     $Arguments = ConvertTo-NovaCliArgumentArray -BoundParameters $PSBoundParameters -Arguments $Arguments
 
@@ -44,6 +29,10 @@ function Invoke-NovaCli {
             return Test-NovaBuild @mutatingCommonParameters
         }
         'init' {
+            if ($WhatIfPreference) {
+                throw "The 'nova init' CLI command does not support -WhatIf. Run 'nova init [path]' without -WhatIf."
+            }
+
             if ($Arguments.Count -gt 0) {
                 return New-NovaModule -Path $Arguments[0] @mutatingCommonParameters
             }

--- a/src/public/InvokeNovaCli.ps1
+++ b/src/public/InvokeNovaCli.ps1
@@ -1,5 +1,5 @@
 function Invoke-NovaCli {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     [Alias('nova')]
     param(
         [Parameter(Position = 0)]
@@ -14,6 +14,19 @@ function Invoke-NovaCli {
         $commonParameters.Verbose = $true
     }
 
+    $mutatingCommonParameters = @{}
+    foreach ($parameterKey in $commonParameters.Keys) {
+        $mutatingCommonParameters[$parameterKey] = $commonParameters[$parameterKey]
+    }
+
+    if ($WhatIfPreference) {
+        $mutatingCommonParameters.WhatIf = $true
+    }
+
+    if ( $PSBoundParameters.ContainsKey('Confirm')) {
+        $mutatingCommonParameters.Confirm = [bool]$PSBoundParameters.Confirm
+    }
+
     $Arguments = ConvertTo-NovaCliArgumentArray -BoundParameters $PSBoundParameters -Arguments $Arguments
 
     switch ($Command) {
@@ -25,28 +38,28 @@ function Invoke-NovaCli {
             return Format-NovaCliVersionString -Name $projectInfo.ProjectName -Version $projectInfo.Version
         }
         'build' {
-            return Invoke-NovaBuild @commonParameters
+            return Invoke-NovaBuild @mutatingCommonParameters
         }
         'test' {
-            return Test-NovaBuild @commonParameters
+            return Test-NovaBuild @mutatingCommonParameters
         }
         'init' {
             if ($Arguments.Count -gt 0) {
-                return New-NovaModule -Path $Arguments[0] @commonParameters
+                return New-NovaModule -Path $Arguments[0] @mutatingCommonParameters
             }
 
-            return New-NovaModule @commonParameters
+            return New-NovaModule @mutatingCommonParameters
         }
         'bump' {
-            return Update-NovaModuleVersion @commonParameters
+            return Update-NovaModuleVersion @mutatingCommonParameters
         }
         'publish' {
             $options = ConvertFrom-NovaCliArgument -Arguments $Arguments
-            return Publish-NovaModule @options @commonParameters
+            return Publish-NovaModule @options @mutatingCommonParameters
         }
         'release' {
             $options = ConvertFrom-NovaCliArgument -Arguments $Arguments
-            return Invoke-NovaRelease -PublishOption $options @commonParameters
+            return Invoke-NovaRelease -PublishOption $options @mutatingCommonParameters
         }
         '--version' {
             $moduleName = $ExecutionContext.SessionState.Module.Name

--- a/src/public/InvokeNovaRelease.ps1
+++ b/src/public/InvokeNovaRelease.ps1
@@ -1,5 +1,5 @@
 function Invoke-NovaRelease {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param(
         [hashtable]$PublishOption = @{},
         [string]$Path = (Get-Location).Path
@@ -8,42 +8,32 @@ function Invoke-NovaRelease {
     Push-Location -LiteralPath $Path
     try {
         $projectInfo = Get-NovaProjectInfo
-        $publishParams = @{ProjectInfo = $projectInfo}
-        $hasRepository = $PublishOption.ContainsKey('Repository')
+        $workflowParams = Get-NovaShouldProcessForwardingParameter -WhatIfEnabled:$WhatIfPreference
+        $repository = Get-NovaPublishOptionValue -PublishOption $PublishOption -Name Repository
+        $moduleDirectoryPath = Get-NovaPublishOptionValue -PublishOption $PublishOption -Name ModuleDirectoryPath
+        $apiKey = Get-NovaPublishOptionValue -PublishOption $PublishOption -Name ApiKey
+        $publishInvocation = Resolve-NovaPublishInvocation -ProjectInfo $projectInfo -Repository $repository -ModuleDirectoryPath $moduleDirectoryPath -ApiKey $apiKey
 
-        if ($hasRepository) {
-            $publishAction = (Get-Command -Name Publish-NovaBuiltModuleToRepository -CommandType Function).ScriptBlock
-            $publishParams.Repository = $PublishOption.Repository
-            $publishParams.ApiKey = $PublishOption.ApiKey
-        }
-        else {
-            $publishAction = (Get-Command -Name Publish-NovaBuiltModuleToDirectory -CommandType Function).ScriptBlock
-            $resolvedModuleDirectoryPath = if ( $PublishOption.ContainsKey('ModuleDirectoryPath')) {
-                $PublishOption.ModuleDirectoryPath
-            }
-            else {
-                $null
-            }
+        Write-NovaLocalWorkflowMode -WorkflowName release -LocalRequested:($PublishOption.ContainsKey('Local') -and $PublishOption.Local)
 
-            if ( [string]::IsNullOrWhiteSpace($resolvedModuleDirectoryPath)) {
-                $resolvedModuleDirectoryPath = Get-LocalModulePath
-            }
+        $releaseOperation = Get-NovaPublishWorkflowOperation -IsLocal:$publishInvocation.IsLocal -Release
 
-            $publishParams.ModuleDirectoryPath = $resolvedModuleDirectoryPath
+        $shouldRun = $PSCmdlet.ShouldProcess($publishInvocation.Target, $releaseOperation)
+        if (-not $shouldRun -and -not $WhatIfPreference) {
+            return
         }
 
-        if ($PublishOption.ContainsKey('Local') -and $PublishOption.Local) {
-            Write-Verbose 'Using local release mode.'
-        }
+        Invoke-NovaBuild @workflowParams
+        Test-NovaBuild @workflowParams
+        $versionResult = Update-NovaModuleVersion @workflowParams
+        Invoke-NovaBuild @workflowParams
 
-        Invoke-NovaBuild
-        Test-NovaBuild
-        $versionResult = Update-NovaModuleVersion
-        Invoke-NovaBuild
-
-        & $publishAction @publishParams
+        Invoke-NovaResolvedPublishInvocation -PublishInvocation $publishInvocation -WorkflowParams $workflowParams
 
         return $versionResult
+    }
+    catch {
+        throw
     }
     finally {
         Pop-Location

--- a/src/public/InvokeNovaRelease.ps1
+++ b/src/public/InvokeNovaRelease.ps1
@@ -28,7 +28,16 @@ function Invoke-NovaRelease {
         $versionResult = Update-NovaModuleVersion @workflowParams
         Invoke-NovaBuild @workflowParams
 
-        Invoke-NovaResolvedPublishInvocation -PublishInvocation $publishInvocation -WorkflowParams $workflowParams
+        $publishParams = @{}
+        foreach ($parameterName in $publishInvocation.Parameters.Keys) {
+            $publishParams[$parameterName] = $publishInvocation.Parameters[$parameterName]
+        }
+
+        foreach ($parameterName in $workflowParams.Keys) {
+            $publishParams[$parameterName] = $workflowParams[$parameterName]
+        }
+
+        & $publishInvocation.Action @publishParams
 
         return $versionResult
     }

--- a/src/public/PublishNovaModule.ps1
+++ b/src/public/PublishNovaModule.ps1
@@ -1,5 +1,5 @@
 function Publish-NovaModule {
-    [CmdletBinding(DefaultParameterSetName = 'Local')]
+    [CmdletBinding(DefaultParameterSetName = 'Local', SupportsShouldProcess = $true)]
     param(
         [Parameter(ParameterSetName = 'Local')]
         [switch]$Local,
@@ -12,36 +12,25 @@ function Publish-NovaModule {
     )
 
     $projectInfo = Get-NovaProjectInfo
-    $publishParams = @{ProjectInfo = $projectInfo}
+    $workflowParams = Get-NovaShouldProcessForwardingParameter -WhatIfEnabled:$WhatIfPreference
+    $publishInvocation = Resolve-NovaPublishInvocation -ProjectInfo $projectInfo -Repository $Repository -ModuleDirectoryPath $ModuleDirectoryPath -ApiKey $ApiKey
 
-    if ( $PSBoundParameters.ContainsKey('Repository')) {
-        $publishAction = (Get-Command -Name Publish-NovaBuiltModuleToRepository -CommandType Function).ScriptBlock
-        $publishParams.Repository = $Repository
-        $publishParams.ApiKey = $ApiKey
-    }
-    else {
-        $publishAction = (Get-Command -Name Publish-NovaBuiltModuleToDirectory -CommandType Function).ScriptBlock
-        if ($Local) {
-            Write-Verbose 'Using local publish mode.'
-        }
+    Write-NovaLocalWorkflowMode -WorkflowName publish -LocalRequested:$Local
+    Write-NovaResolvedLocalPublishTarget -PublishInvocation $publishInvocation
 
-        $resolvedModuleDirectoryPath = $ModuleDirectoryPath
-        if ( [string]::IsNullOrWhiteSpace($resolvedModuleDirectoryPath)) {
-            $resolvedModuleDirectoryPath = Get-LocalModulePath
-        }
+    $publishOperation = Get-NovaPublishWorkflowOperation -IsLocal:$publishInvocation.IsLocal
 
-        $publishParams.ModuleDirectoryPath = $resolvedModuleDirectoryPath
-        Write-Verbose "Using $resolvedModuleDirectoryPath as path"
+    $shouldRun = $PSCmdlet.ShouldProcess($publishInvocation.Target, $publishOperation)
+    if (-not $shouldRun -and -not $WhatIfPreference) {
+        return
     }
 
-    Invoke-NovaBuild
-    Test-NovaBuild
+    Invoke-NovaBuild @workflowParams
+    Test-NovaBuild @workflowParams
 
-    & $publishAction @publishParams
+    Invoke-NovaResolvedPublishInvocation -PublishInvocation $publishInvocation -WorkflowParams $workflowParams
 
-    if (-not $PSBoundParameters.ContainsKey('Repository')) {
-        Write-Verbose 'Module copy to local path complete, Refresh session or import module manually'
-    }
+    Write-NovaLocalPublishCompletionMessage -ShouldRun:$shouldRun -PublishInvocation $publishInvocation
 }
 
 

--- a/src/public/PublishNovaModule.ps1
+++ b/src/public/PublishNovaModule.ps1
@@ -28,9 +28,20 @@ function Publish-NovaModule {
     Invoke-NovaBuild @workflowParams
     Test-NovaBuild @workflowParams
 
-    Invoke-NovaResolvedPublishInvocation -PublishInvocation $publishInvocation -WorkflowParams $workflowParams
+    $publishParams = @{}
+    foreach ($parameterName in $publishInvocation.Parameters.Keys) {
+        $publishParams[$parameterName] = $publishInvocation.Parameters[$parameterName]
+    }
 
-    Write-NovaLocalPublishCompletionMessage -ShouldRun:$shouldRun -PublishInvocation $publishInvocation
+    foreach ($parameterName in $workflowParams.Keys) {
+        $publishParams[$parameterName] = $workflowParams[$parameterName]
+    }
+
+    & $publishInvocation.Action @publishParams
+
+    if ($shouldRun -and $publishInvocation.IsLocal) {
+        Write-Verbose 'Module copy to local path complete, Refresh session or import module manually'
+    }
 }
 
 

--- a/src/public/TestNovaBuild.ps1
+++ b/src/public/TestNovaBuild.ps1
@@ -1,5 +1,5 @@
 function Test-NovaBuild {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param (
         [string[]]$TagFilter,
         [string[]]$ExcludeTagFilter,
@@ -35,6 +35,10 @@ function Test-NovaBuild {
 
     $testResultPath = [System.IO.Path]::Join($data.ProjectRoot, 'artifacts', 'TestResults.xml')
     $testResultDirectory = Split-Path -Parent $testResultPath
+
+    if (-not $PSCmdlet.ShouldProcess($testResultPath, 'Run Pester tests and write test results')) {
+        return
+    }
 
     if (-not (Test-Path -LiteralPath $testResultDirectory)) {
         $null = New-Item -ItemType Directory -Path $testResultDirectory -Force

--- a/src/resources/nova
+++ b/src/resources/nova
@@ -15,12 +15,22 @@ else {
 }
 
 $forwardVerbose = $false
+$forwardWhatIf = $false
+$forwardConfirm = $false
 $remainingArguments = New-Object 'System.Collections.Generic.List[string]'
 
 foreach ($argument in $Arguments) {
     switch -Regex ($argument) {
         '^(--verbose|-Verbose)$' {
             $forwardVerbose = $true
+            continue
+        }
+        '^-WhatIf$' {
+            $forwardWhatIf = $true
+            continue
+        }
+        '^-Confirm$' {
+            $forwardConfirm = $true
             continue
         }
         default {
@@ -40,6 +50,14 @@ $invokeParameters = @{
 
 if ($forwardVerbose) {
     $invokeParameters.Verbose = $true
+}
+
+if ($forwardWhatIf) {
+    $invokeParameters.WhatIf = $true
+}
+
+if ($forwardConfirm) {
+    $invokeParameters.Confirm = $true
 }
 
 Invoke-NovaCli @invokeParameters

--- a/tests/NovaCommandModel.TestSupport.ps1
+++ b/tests/NovaCommandModel.TestSupport.ps1
@@ -1,27 +1,11 @@
-function Get-TestFrontMatterValue {
+function Get-TestRegexMatchGroup {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string]$Content,
-        [Parameter(Mandatory)][string]$Key
+        [Parameter(Mandatory)][string]$Pattern
     )
 
-    $pattern = '(?m)^{0}:\s*(.+)$' -f [regex]::Escape($Key)
-    if ($Content -match $pattern) {
-        return $matches[1].Trim()
-    }
-
-    return $null
-}
-
-function Get-TestMarkdownSectionText {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)][string]$Content,
-        [Parameter(Mandatory)][string]$SectionName
-    )
-
-    $pattern = '(?ms)^##\s+{0}\s*$\r?\n+(.*?)(?=^##\s+|\z)' -f [regex]::Escape($SectionName)
-    if ($Content -match $pattern) {
+    if ($Content -match $Pattern) {
         return $matches[1].Trim()
     }
 
@@ -51,7 +35,8 @@ function Get-TestHelpLocaleFromMarkdownFiles {
     $Files |
             ForEach-Object {
                 $content = Get-Content -LiteralPath $_.FullName -Raw
-                Get-TestFrontMatterValue -Content $content -Key 'Locale'
+                $pattern = '(?m)^{0}:\s*(.+)$' -f [regex]::Escape('Locale')
+                Get-TestRegexMatchGroup -Content $content -Pattern $pattern
             } |
             Where-Object {-not [string]::IsNullOrWhiteSpace($_)} |
             Select-Object -Unique
@@ -75,20 +60,24 @@ function Get-CommandHelpActivationTestCase {
     )
 
     $content = Get-Content -LiteralPath $File.FullName -Raw
-    $documentType = Get-TestFrontMatterValue -Content $content -Key 'document type'
+    $documentTypePattern = '(?m)^{0}:\s*(.+)$' -f [regex]::Escape('document type')
+    $documentType = Get-TestRegexMatchGroup -Content $content -Pattern $documentTypePattern
     if ($documentType -ne 'cmdlet') {
         return $null
     }
 
-    $helpTarget = Get-TestFrontMatterValue -Content $content -Key 'title'
+    $titlePattern = '(?m)^{0}:\s*(.+)$' -f [regex]::Escape('title')
+    $helpTarget = Get-TestRegexMatchGroup -Content $content -Pattern $titlePattern
     if ( [string]::IsNullOrWhiteSpace($helpTarget)) {
         $helpTarget = [System.IO.Path]::GetFileNameWithoutExtension($File.Name)
     }
 
+    $synopsisPattern = '(?ms)^##\s+{0}\s*$\r?\n+(.*?)(?=^##\s+|\z)' -f [regex]::Escape('SYNOPSIS')
+
     return [pscustomobject]@{
         FileName = $File.Name
         HelpTarget = $helpTarget
-        ExpectedSynopsis = ConvertTo-TestNormalizedText -Text (Get-TestMarkdownSectionText -Content $content -SectionName 'SYNOPSIS')
+        ExpectedSynopsis = ConvertTo-TestNormalizedText -Text (Get-TestRegexMatchGroup -Content $content -Pattern $synopsisPattern)
     }
 }
 
@@ -105,5 +94,4 @@ function Get-CommandHelpActivationTestCases {
             Where-Object {$_}
     )
 }
-
 

--- a/tests/NovaCommandModel.TestSupport.ps1
+++ b/tests/NovaCommandModel.TestSupport.ps1
@@ -95,3 +95,102 @@ function Get-CommandHelpActivationTestCases {
     )
 }
 
+function Initialize-TestNovaCliProjectLayout {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ProjectRoot
+    )
+
+    New-Item -ItemType Directory -Path $ProjectRoot -Force | Out-Null
+    foreach ($dir in @('src/public', 'src/private', 'src/classes', 'src/resources', 'tests', 'docs')) {
+        New-Item -ItemType Directory -Path (Join-Path $ProjectRoot $dir) -Force | Out-Null
+    }
+}
+
+function Write-TestNovaCliProjectJson {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ProjectRoot,
+        [Parameter(Mandatory)][string]$ProjectName,
+        [Parameter(Mandatory)][string]$ProjectGuid
+    )
+
+    @"
+{
+  "ProjectName": "$ProjectName",
+  "Description": "CLI test project",
+  "Version": "0.0.1",
+  "CopyResourcesToModuleRoot": false,
+  "Manifest": {
+    "Author": "Test",
+    "PowerShellHostVersion": "7.4",
+    "GUID": "$ProjectGuid",
+    "Tags": [],
+    "ProjectUri": ""
+  },
+  "Pester": {
+    "TestResult": {
+      "Enabled": true,
+      "OutputFormat": "NUnitXml"
+    },
+    "Output": {
+      "Verbosity": "Detailed"
+    }
+  }
+}
+"@ | Set-Content -LiteralPath (Join-Path $ProjectRoot 'project.json') -Encoding utf8
+}
+
+function Write-TestNovaCliPublicFunction {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ProjectRoot,
+        [Parameter(Mandatory)][string]$FunctionName
+    )
+
+    @"
+function $FunctionName {
+    'ok'
+}
+"@ | Set-Content -LiteralPath (Join-Path $ProjectRoot "src/public/$FunctionName.ps1") -Encoding utf8
+}
+
+function Initialize-TestGitRepository {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ProjectRoot,
+        [Parameter(Mandatory)][string]$CommitMessage
+    )
+
+    foreach ($command in @(
+        @('init'),
+        @('config', 'user.name', 'Nova CLI Test'),
+        @('config', 'user.email', 'nova-cli-test@example.invalid'),
+        @('add', '.'),
+        @('-c', 'commit.gpgSign=false', 'commit', '--no-verify', '-m', $CommitMessage, '--quiet')
+    )) {
+        $null = & git -C $ProjectRoot @command 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "Git command failed: git -C $ProjectRoot $( $command -join ' ' )"
+        }
+    }
+}
+
+function Invoke-TestInstalledNovaCommand {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$InstalledPath,
+        [Parameter(Mandatory)][string]$WorkingDirectory,
+        [Parameter(Mandatory)][string[]]$Arguments
+    )
+
+    Push-Location $WorkingDirectory
+    try {
+        $output = & $InstalledPath @Arguments 2>&1
+        return [pscustomobject]@{Output = @($output); Text = @($output) -join [Environment]::NewLine; ExitCode = $LASTEXITCODE}
+    }
+    finally {
+        Pop-Location
+    }
+}
+

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -14,10 +14,9 @@ BeforeAll {
 
     Remove-Module $script:moduleName -ErrorAction SilentlyContinue
     Import-Module $distModuleDir -Force
+    . $testSupportPath
 
     $helpMetadata = & {
-        . $testSupportPath
-
         $helpMarkdownFiles = Get-ChildItem -LiteralPath $script:projectInfo.DocsDir -Filter '*.md' -Recurse
         [pscustomobject]@{
             HelpLocale = Get-TestHelpLocaleFromMarkdownFiles -Files $helpMarkdownFiles
@@ -715,6 +714,74 @@ function Invoke-TestCliVerbose {
         }
     }
 
+    It 'Install-NovaCli forwards -WhatIf from the standalone launcher without mutating build, bump, or publish state' {
+        $targetDirectory = Join-Path $TestDrive 'whatif-bin'
+        $installedPath = Join-Path $targetDirectory 'nova'
+        $projectRoot = Join-Path $TestDrive 'CliWhatIfProject'
+        $projectJsonPath = Join-Path $projectRoot 'project.json'
+        $builtModulePath = Join-Path $projectRoot 'dist/CliWhatIfProject/CliWhatIfProject.psm1'
+        $testResultPath = Join-Path $projectRoot 'artifacts/TestResults.xml'
+        $originalModulePath = $env:PSModulePath
+        $modulePathSeparator = [string][System.IO.Path]::PathSeparator
+        $distParent = Split-Path -Parent $distModuleDir
+
+        $env:PSModulePath = "$distParent$modulePathSeparator$originalModulePath"
+
+        Initialize-TestNovaCliProjectLayout -ProjectRoot $projectRoot
+        Write-TestNovaCliProjectJson -ProjectRoot $projectRoot -ProjectName 'CliWhatIfProject' -ProjectGuid '33333333-3333-3333-3333-333333333333'
+        Write-TestNovaCliPublicFunction -ProjectRoot $projectRoot -FunctionName 'Invoke-TestCliWhatIf'
+
+        try {
+            Initialize-TestGitRepository -ProjectRoot $projectRoot -CommitMessage 'feat: add cli whatif coverage'
+
+            Install-NovaCli -DestinationDirectory $targetDirectory -Force | Out-Null
+
+            $buildResult = Invoke-TestInstalledNovaCommand -InstalledPath $installedPath -WorkingDirectory $projectRoot -Arguments @('build', '-WhatIf')
+            $publishResult = Invoke-TestInstalledNovaCommand -InstalledPath $installedPath -WorkingDirectory $projectRoot -Arguments @('publish', '--local', '-WhatIf')
+            $bumpResult = Invoke-TestInstalledNovaCommand -InstalledPath $installedPath -WorkingDirectory $projectRoot -Arguments @('bump', '-WhatIf')
+            $versionAfterBump = (Get-Content -LiteralPath $projectJsonPath -Raw | ConvertFrom-Json).Version
+
+            $buildResult.ExitCode | Should -Be 0
+            $publishResult.ExitCode | Should -Be 0
+            $bumpResult.ExitCode | Should -Be 0
+            $buildResult.Text | Should -Match 'What if:'
+            $publishResult.Text | Should -Match 'What if:'
+            $publishResult.Text | Should -Not -Match 'Unknown argument:'
+            $bumpResult.Text | Should -Match 'What if:'
+            $bumpResult.Text | Should -Not -Match 'Version bumped to :'
+            $versionAfterBump | Should -Be '0.0.1'
+            (Test-Path -LiteralPath $builtModulePath) | Should -BeFalse
+            (Test-Path -LiteralPath $testResultPath) | Should -BeFalse
+        }
+        finally {
+            $env:PSModulePath = $originalModulePath
+        }
+    }
+
+    It 'Install-NovaCli rejects nova init -WhatIf with a clear CLI error' {
+        $targetDirectory = Join-Path $TestDrive 'init-whatif-bin'
+        $installedPath = Join-Path $targetDirectory 'nova'
+        $workspaceRoot = Join-Path $TestDrive 'CliInitWhatIfRoot'
+        $originalModulePath = $env:PSModulePath
+        $modulePathSeparator = [string][System.IO.Path]::PathSeparator
+        $distParent = Split-Path -Parent $distModuleDir
+
+        $env:PSModulePath = "$distParent$modulePathSeparator$originalModulePath"
+        New-Item -ItemType Directory -Path $workspaceRoot -Force | Out-Null
+
+        try {
+            Install-NovaCli -DestinationDirectory $targetDirectory -Force | Out-Null
+            $initResult = Invoke-TestInstalledNovaCommand -InstalledPath $installedPath -WorkingDirectory $workspaceRoot -Arguments @('init', '-WhatIf')
+
+            $initResult.ExitCode | Should -Not -Be 0
+            $initResult.Text | Should -Match 'does not support -WhatIf'
+            $initResult.Text | Should -Not -Match 'Not a valid path'
+        }
+        finally {
+            $env:PSModulePath = $originalModulePath
+        }
+    }
+
     It 'Invoke-NovaCli version returns the project name and version' {
         InModuleScope $script:moduleName {
             Mock Get-NovaProjectInfo {[pscustomobject]@{ProjectName = 'AzureDevOpsAgentInstaller'; Version = '1.2.3'}}
@@ -772,6 +839,12 @@ function Invoke-TestCliVerbose {
             $result = Invoke-NovaCli publish --repository PSGallery --apikey key123 -WhatIf
 
             $result.WhatIfSeen | Should -BeTrue
+        }
+    }
+
+    It 'Invoke-NovaCli init rejects -WhatIf with a clear error' {
+        InModuleScope $script:moduleName {
+            {Invoke-NovaCli init -WhatIf} | Should -Throw "*does not support -WhatIf*"
         }
     }
 

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -124,7 +124,9 @@ Describe 'Nova command model' {
             'InformationVariable',
             'OutVariable',
             'OutBuffer',
-            'PipelineVariable'
+            'PipelineVariable',
+            'WhatIf',
+            'Confirm'
         )
 
         foreach ($testCase in $script:helpActivationTestCases) {
@@ -152,11 +154,29 @@ Describe 'Nova command model' {
         }
     }
 
+    It 'Get-Help surfaces native WhatIf and Confirm support for mutating public commands' {
+        foreach ($commandName in @(
+            'Invoke-NovaBuild',
+            'Test-NovaBuild',
+            'Publish-NovaModule',
+            'Invoke-NovaRelease',
+            'New-NovaModule',
+            'Install-NovaCli',
+            'Update-NovaModuleVersion',
+            'Invoke-NovaCli'
+        )) {
+            $fullText = Get-Help $commandName -Full -ErrorAction Stop | Out-String
+
+            $fullText | Should -Match '-WhatIf' -Because "$commandName should surface native WhatIf support in full help"
+            $fullText | Should -Match '-Confirm' -Because "$commandName should surface native Confirm support in full help"
+        }
+    }
+
     It 'Invoke-NovaBuild runs module build pipeline' {
         InModuleScope $script:moduleName {
             Mock Reset-ProjectDist {}
             Mock Build-Module {}
-            Mock Get-NovaProjectInfo {[pscustomobject]@{FailOnDuplicateFunctionNames = $false}}
+            Mock Get-NovaProjectInfo {[pscustomobject]@{FailOnDuplicateFunctionNames = $false; OutputModuleDir = '/tmp/dist/NovaModuleTools'}}
             Mock Build-Manifest {}
             Mock Build-Help {}
             Mock Copy-ProjectResource {}
@@ -164,6 +184,31 @@ Describe 'Nova command model' {
             Invoke-NovaBuild
 
             Assert-MockCalled Build-Module -Times 1
+        }
+    }
+
+    It 'Invoke-NovaBuild -WhatIf skips the build pipeline' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    FailOnDuplicateFunctionNames = $false
+                    OutputModuleDir = '/tmp/dist/NovaModuleTools'
+                }
+            }
+            Mock Reset-ProjectDist {throw 'should not reset dist'}
+            Mock Build-Module {throw 'should not build'}
+            Mock Build-Manifest {throw 'should not build manifest'}
+            Mock Build-Help {throw 'should not build help'}
+            Mock Copy-ProjectResource {throw 'should not copy resources'}
+
+            $result = Invoke-NovaBuild -WhatIf
+
+            $result | Should -BeNullOrEmpty
+            Assert-MockCalled Reset-ProjectDist -Times 0
+            Assert-MockCalled Build-Module -Times 0
+            Assert-MockCalled Build-Manifest -Times 0
+            Assert-MockCalled Build-Help -Times 0
+            Assert-MockCalled Copy-ProjectResource -Times 0
         }
     }
 
@@ -252,6 +297,38 @@ title: Invoke-NovaBuild
         }
     }
 
+    It 'Test-NovaBuild -WhatIf skips Pester execution and artifact creation' {
+        InModuleScope $script:moduleName {
+            $projectRoot = '/tmp/nova-project'
+            $cfg = [pscustomobject]@{
+                Run = [pscustomobject]@{Path = $null; PassThru = $false; Exit = $false; Throw = $false}
+                Filter = [pscustomobject]@{Tag = @(); ExcludeTag = @()}
+                Output = [pscustomobject]@{Verbosity = 'Detailed'; RenderMode = 'Auto'}
+                TestResult = [pscustomobject]@{OutputPath = $null}
+            }
+
+            Mock Test-ProjectSchema {}
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    Pester = @{}
+                    BuildRecursiveFolders = $true
+                    TestsDir = 'tests'
+                    ProjectRoot = $projectRoot
+                }
+            }
+            Mock New-PesterConfiguration {$cfg}
+            Mock Test-Path {$false}
+            Mock New-Item {throw 'should not create artifacts'}
+            Mock Invoke-Pester {throw 'should not run tests'}
+
+            $result = Test-NovaBuild -WhatIf
+
+            $result | Should -BeNullOrEmpty
+            Assert-MockCalled New-Item -Times 0
+            Assert-MockCalled Invoke-Pester -Times 0
+        }
+    }
+
     It 'Invoke-NovaRelease runs build test bump build publish in order' {
         InModuleScope $script:moduleName {
             $script:steps = @()
@@ -297,6 +374,40 @@ title: Invoke-NovaBuild
         }
     }
 
+    It 'Invoke-NovaRelease -WhatIf forwards preview mode through the nested workflow' {
+        InModuleScope $script:moduleName {
+            $script:steps = @()
+            $publishAction = {
+                param($ProjectInfo, $ModuleDirectoryPath)
+
+                Publish-NovaBuiltModuleToDirectory @PSBoundParameters
+            }
+
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    ProjectName = 'NovaModuleTools'
+                    OutputModuleDir = '/tmp/dist/NovaModuleTools'
+                }
+            }
+            Mock Get-Command {
+                [pscustomobject]@{ScriptBlock = $publishAction}
+            } -ParameterFilter {$Name -eq 'Publish-NovaBuiltModuleToDirectory' -and $CommandType -eq 'Function'}
+            Mock Get-LocalModulePath {'/tmp/modules'}
+            Mock Invoke-NovaBuild {$script:steps += "build:$WhatIfPreference"}
+            Mock Test-NovaBuild {$script:steps += "test:$WhatIfPreference"}
+            Mock Update-NovaModuleVersion {
+                $script:steps += "bump:$WhatIfPreference"
+                [pscustomobject]@{PreviousVersion = '1.0.0'; NewVersion = '1.0.0'; Label = 'Patch'; CommitCount = 0}
+            }
+            Mock Publish-NovaBuiltModuleToDirectory {$script:steps += "publish:$WhatIfPreference"}
+
+            $result = Invoke-NovaRelease -PublishOption @{Local = $true} -Path (Get-Location).Path -WhatIf
+
+            $script:steps -join ',' | Should -Be 'build:True,test:True,bump:True,build:True,publish:True'
+            $result.NewVersion | Should -Be '1.0.0'
+        }
+    }
+
     It 'Publish-NovaModule resolves local path before tests can reload helpers' {
         InModuleScope $script:moduleName {
             $script:steps = @()
@@ -324,6 +435,36 @@ title: Invoke-NovaBuild
 
             $script:steps -join ',' | Should -Be 'resolve,build,test,copy'
             Assert-MockCalled Copy-Item -Times 1 -ParameterFilter {$Destination -eq '/tmp/modules'}
+        }
+    }
+
+    It 'Publish-NovaModule -WhatIf forwards preview mode to build, test, and publish helpers' {
+        InModuleScope $script:moduleName {
+            $script:steps = @()
+            $publishAction = {
+                param($ProjectInfo, $ModuleDirectoryPath)
+
+                Publish-NovaBuiltModuleToDirectory @PSBoundParameters
+            }
+
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    ProjectName = 'NovaModuleTools'
+                    OutputModuleDir = '/tmp/dist/NovaModuleTools'
+                }
+            }
+            Mock Get-Command {
+                [pscustomobject]@{ScriptBlock = $publishAction}
+            } -ParameterFilter {$Name -eq 'Publish-NovaBuiltModuleToDirectory' -and $CommandType -eq 'Function'}
+            Mock Get-LocalModulePath {'/tmp/modules'}
+            Mock Invoke-NovaBuild {$script:steps += "build:$WhatIfPreference"}
+            Mock Test-NovaBuild {$script:steps += "test:$WhatIfPreference"}
+            Mock Publish-NovaBuiltModuleToDirectory {$script:steps += "publish:$WhatIfPreference"}
+
+            $result = Publish-NovaModule -Local -WhatIf
+
+            $result | Should -BeNullOrEmpty
+            $script:steps -join ',' | Should -Be 'build:True,test:True,publish:True'
         }
     }
 
@@ -433,10 +574,9 @@ title: Invoke-NovaBuild
         $publishFunction | Should -Not -BeNullOrEmpty
         $publishSource = $publishFunction.Extent.Text
 
-        $publishSource.IndexOf('$PSBoundParameters.ContainsKey(''Repository'')') | Should -BeGreaterThan -1
-        $publishSource.IndexOf('Get-LocalModulePath') | Should -BeGreaterThan -1
+        $publishSource.IndexOf('Resolve-NovaPublishInvocation') | Should -BeGreaterThan -1
         $publishSource.IndexOf('Invoke-NovaBuild') | Should -BeGreaterThan -1
-        $publishSource.IndexOf('Get-LocalModulePath') | Should -BeLessThan $publishSource.IndexOf('Invoke-NovaBuild')
+        $publishSource.IndexOf('Resolve-NovaPublishInvocation') | Should -BeLessThan $publishSource.IndexOf('Invoke-NovaBuild')
     }
 
     It 'Update-NovaModuleVersion -WhatIf does not invoke Set-NovaModuleVersion' {
@@ -620,6 +760,18 @@ function Invoke-TestCliVerbose {
 
             $result.Repository | Should -Be 'PSGallery'
             $result.ApiKey | Should -Be 'key123'
+        }
+    }
+
+    It 'Invoke-NovaCli forwards WhatIf to mutating routed commands' {
+        InModuleScope $script:moduleName {
+            Mock Publish-NovaModule {
+                [pscustomobject]@{WhatIfSeen = $WhatIfPreference}
+            }
+
+            $result = Invoke-NovaCli publish --repository PSGallery --apikey key123 -WhatIf
+
+            $result.WhatIfSeen | Should -BeTrue
         }
     }
 

--- a/tests/RemainingCommandCoverage.Tests.ps1
+++ b/tests/RemainingCommandCoverage.Tests.ps1
@@ -57,31 +57,6 @@ Describe 'Coverage for remaining command and filesystem branches' {
         }
     }
 
-    It 'Reset-ProjectDist -WhatIf skips filesystem changes' {
-        $outputDir = Join-Path $TestDrive 'dist-whatif'
-        $outputModuleDir = Join-Path $outputDir 'NovaModuleTools'
-
-        InModuleScope $script:moduleName -Parameters @{OutputDir = $outputDir; OutputModuleDir = $outputModuleDir} {
-            param($OutputDir, $OutputModuleDir)
-
-            Mock Get-NovaProjectInfo {
-                [pscustomobject]@{
-                    OutputDir = $OutputDir
-                    OutputModuleDir = $OutputModuleDir
-                }
-            }
-            Mock Test-Path {$true}
-            Mock Remove-Item {throw 'should not remove dist'}
-            Mock New-Item {throw 'should not recreate dist'}
-
-            $result = Reset-ProjectDist -WhatIf
-
-            $result | Should -BeNullOrEmpty
-            Assert-MockCalled Remove-Item -Times 0
-            Assert-MockCalled New-Item -Times 0
-        }
-    }
-
     It 'New-InitiateGitRepo warns when a repository already exists in the target directory' {
         $repoPath = Join-Path $TestDrive 'existing-git-repo'
         New-Item -ItemType Directory -Path (Join-Path $repoPath '.git') -Force | Out-Null
@@ -325,38 +300,6 @@ Describe 'Coverage for remaining command and filesystem branches' {
             Assert-MockCalled Publish-NovaBuiltModuleToDirectory -Times 1 -ParameterFilter {
                 $ModuleDirectoryPath -eq '/tmp/default-modules'
             }
-        }
-    }
-
-    It 'Publish-NovaBuiltModuleToDirectory -WhatIf skips create, remove, and copy operations' {
-        InModuleScope $script:moduleName {
-            $projectInfo = [pscustomobject]@{
-                OutputModuleDir = '/tmp/dist/NovaModuleTools'
-                ProjectName = 'NovaModuleTools'
-            }
-
-            Mock Test-Path {$true}
-            Mock New-Item {throw 'should not create directory'}
-            Mock Remove-Item {throw 'should not remove old module'}
-            Mock Copy-Item {throw 'should not copy module'}
-
-            $result = Publish-NovaBuiltModuleToDirectory -ProjectInfo $projectInfo -ModuleDirectoryPath '/tmp/modules' -WhatIf
-
-            $result | Should -BeNullOrEmpty
-            Assert-MockCalled New-Item -Times 0
-            Assert-MockCalled Remove-Item -Times 0
-            Assert-MockCalled Copy-Item -Times 0
-        }
-    }
-
-    It 'Publish-NovaBuiltModuleToRepository -WhatIf skips Publish-PSResource' {
-        InModuleScope $script:moduleName {
-            Mock Publish-PSResource {throw 'should not publish'}
-
-            $result = Publish-NovaBuiltModuleToRepository -ProjectInfo ([pscustomobject]@{OutputModuleDir = '/tmp/dist'; ProjectName = 'NovaModuleTools'}) -Repository PSGallery -WhatIf
-
-            $result | Should -BeNullOrEmpty
-            Assert-MockCalled Publish-PSResource -Times 0
         }
     }
 }

--- a/tests/RemainingCommandCoverage.Tests.ps1
+++ b/tests/RemainingCommandCoverage.Tests.ps1
@@ -57,6 +57,31 @@ Describe 'Coverage for remaining command and filesystem branches' {
         }
     }
 
+    It 'Reset-ProjectDist -WhatIf skips filesystem changes' {
+        $outputDir = Join-Path $TestDrive 'dist-whatif'
+        $outputModuleDir = Join-Path $outputDir 'NovaModuleTools'
+
+        InModuleScope $script:moduleName -Parameters @{OutputDir = $outputDir; OutputModuleDir = $outputModuleDir} {
+            param($OutputDir, $OutputModuleDir)
+
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    OutputDir = $OutputDir
+                    OutputModuleDir = $OutputModuleDir
+                }
+            }
+            Mock Test-Path {$true}
+            Mock Remove-Item {throw 'should not remove dist'}
+            Mock New-Item {throw 'should not recreate dist'}
+
+            $result = Reset-ProjectDist -WhatIf
+
+            $result | Should -BeNullOrEmpty
+            Assert-MockCalled Remove-Item -Times 0
+            Assert-MockCalled New-Item -Times 0
+        }
+    }
+
     It 'New-InitiateGitRepo warns when a repository already exists in the target directory' {
         $repoPath = Join-Path $TestDrive 'existing-git-repo'
         New-Item -ItemType Directory -Path (Join-Path $repoPath '.git') -Force | Out-Null
@@ -300,6 +325,38 @@ Describe 'Coverage for remaining command and filesystem branches' {
             Assert-MockCalled Publish-NovaBuiltModuleToDirectory -Times 1 -ParameterFilter {
                 $ModuleDirectoryPath -eq '/tmp/default-modules'
             }
+        }
+    }
+
+    It 'Publish-NovaBuiltModuleToDirectory -WhatIf skips create, remove, and copy operations' {
+        InModuleScope $script:moduleName {
+            $projectInfo = [pscustomobject]@{
+                OutputModuleDir = '/tmp/dist/NovaModuleTools'
+                ProjectName = 'NovaModuleTools'
+            }
+
+            Mock Test-Path {$true}
+            Mock New-Item {throw 'should not create directory'}
+            Mock Remove-Item {throw 'should not remove old module'}
+            Mock Copy-Item {throw 'should not copy module'}
+
+            $result = Publish-NovaBuiltModuleToDirectory -ProjectInfo $projectInfo -ModuleDirectoryPath '/tmp/modules' -WhatIf
+
+            $result | Should -BeNullOrEmpty
+            Assert-MockCalled New-Item -Times 0
+            Assert-MockCalled Remove-Item -Times 0
+            Assert-MockCalled Copy-Item -Times 0
+        }
+    }
+
+    It 'Publish-NovaBuiltModuleToRepository -WhatIf skips Publish-PSResource' {
+        InModuleScope $script:moduleName {
+            Mock Publish-PSResource {throw 'should not publish'}
+
+            $result = Publish-NovaBuiltModuleToRepository -ProjectInfo ([pscustomobject]@{OutputModuleDir = '/tmp/dist'; ProjectName = 'NovaModuleTools'}) -Repository PSGallery -WhatIf
+
+            $result | Should -BeNullOrEmpty
+            Assert-MockCalled Publish-PSResource -Times 0
         }
     }
 }


### PR DESCRIPTION
- Change publish and release orchestration to share the same resolved publish execution helper, keeping preview
  forwarding and publish-target handling consistent.

- Change mutating commands to support consistent native `-WhatIf`/`-Confirm` behavior, including routed preview support
  through `Invoke-NovaCli` and updated `Get-Help` examples.

- Fix the internal CLI forwarding helper name so ScriptAnalyzer no longer reports a plural-noun cmdlet warning.

- Fix standalone CLI `-WhatIf` handling so `build`, `test`, `bump`, `publish`, and `release` forward preview mode
  correctly, while `nova init -WhatIf` now fails with a clear CLI error instead of being treated as a path.