### PR TITLE
#54: fix(#54): improve -Confirm functionality and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ The format follows the principles from Keep a Changelog and the project aims to 
 - Fix the standalone macOS/Linux `nova` launcher so `nova build -Verbose` forwards the verbose flag to the underlying
   build command.
 - Fix `nova bump -WhatIf` so it previews the actual calculated next version instead of echoing the current version.
+- Fix `nova bump -Confirm` so cancelled or suspended CLI confirmations return cleanly without opening an interactive
+  PowerShell prompt or printing a misleading version result.
 - Fix standalone CLI `-WhatIf` handling so `build`, `test`, `bump`, `publish`, and `release` forward preview mode
   correctly, while `nova init -WhatIf` now fails with a clear CLI error instead of being treated as a path.
 - Fix the CI helper flow so its second Pester pass reloads the freshly built `dist/` module during test discovery.

--- a/README.md
+++ b/README.md
@@ -499,6 +499,10 @@ Use `nova bump -WhatIf` when you want to preview the exact next version before w
 `PreviousVersion`, `NewVersion`, `Label`, and `CommitCount` information as a real bump, but it leaves `project.json`
 unchanged.
 
+Use `nova bump -Confirm` when you want an interactive CLI confirmation before applying the version bump. If you decline
+or suspend that confirmation, NovaModuleTools returns to your shell without changing `project.json` and without printing
+the version result table.
+
 ## Advanced - Use it in Github Actions
 > [!TIP]
 > This repository uses Github actions to run tests and publish to PowerShell Gallery, use it as reference.

--- a/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
@@ -39,6 +39,9 @@ Mutating routed commands (`build`, `test`, `bump`, `publish`, and `release`) for
 `-WhatIf`/`-Confirm` to the underlying cmdlet. That means `nova build -WhatIf` and
 `Invoke-NovaCli -Command build -WhatIf` both preview the build instead of running it.
 
+For the standalone launcher, `nova bump -Confirm` uses a CLI-friendly confirmation prompt. Declined or suspended choices
+cancel the bump cleanly and return control to the shell without printing a version result.
+
 `nova init` remains interactive and expects only an optional path argument. For that reason, the CLI rejects
 `nova init -WhatIf` with a clear error instead of treating `-WhatIf` as a path.
 

--- a/docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md
+++ b/docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md
@@ -41,6 +41,11 @@ command falls back to a patch bump.
 This command supports `-WhatIf` and `-Confirm` through PowerShell `SupportsShouldProcess`. Use `-WhatIf` to preview the
 calculated release label and the exact next version without changing the stored version.
 
+From the standalone `nova` launcher on macOS/Linux, `nova bump -Confirm` uses a CLI-friendly confirmation prompt. If you
+choose `No`, `No to All`, or `Suspend`, the command exits without changing `project.json` and without returning a
+version
+result object.
+
 ## EXAMPLES
 
 ### EXAMPLE 1

--- a/project.json
+++ b/project.json
@@ -1,7 +1,7 @@
 {
   "ProjectName": "NovaModuleTools",
   "Description": "NovaModuleTools is an enterprise-focused evolution of ModuleTools, designed for large-scale PowerShell projects with a strong emphasis on structure, maintainability, and automated CI/CD pipelines.",
-  "Version": "1.9.22",
+  "Version": "1.9.23",
   "Preamble": [
     "Set-StrictMode -Version Latest",
     "$ErrorActionPreference = 'Stop'"

--- a/src/private/cli/ConfirmNovaCliBumpAction.ps1
+++ b/src/private/cli/ConfirmNovaCliBumpAction.ps1
@@ -1,0 +1,74 @@
+function Get-NovaCliConfirmDecision {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][char]$KeyChar
+    )
+
+    switch ( ($KeyChar.ToString()).ToUpperInvariant()) {
+        'Y' {
+            return $true
+        }
+        'A' {
+            return $true
+        }
+        'N' {
+            return $false
+        }
+        'L' {
+            return $false
+        }
+        'S' {
+            return $false
+        }
+        default {
+            return $null
+        }
+    }
+}
+
+function Read-NovaCliPromptKey {
+    [CmdletBinding()]
+    param()
+
+    try {
+        return [Console]::ReadKey($true).KeyChar
+    }
+    catch {
+        return [char]0
+    }
+}
+
+function Confirm-NovaCliBumpAction {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Target,
+        [Parameter(Mandatory)][string]$Action
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($env:NOVA_CLI_CONFIRM_RESPONSE)) {
+        return Get-NovaCliConfirmDecision -KeyChar ([char]$env:NOVA_CLI_CONFIRM_RESPONSE[0])
+    }
+
+    $message = "Performing the operation `"$Action`" on target `"$Target`"."
+    do {
+        Write-Host 'Confirm'
+        Write-Host $message
+        Write-Host -NoNewline '[Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  (default is "Y"): '
+        $keyChar = Read-NovaCliPromptKey
+        if ($keyChar -eq [char]13 -or $keyChar -eq [char]10) {
+            Write-Host
+            return $true
+        }
+
+        $decision = Get-NovaCliConfirmDecision -KeyChar $keyChar
+        if ($null -ne $decision) {
+            Write-Host $keyChar
+            return $decision
+        }
+
+        Write-Host
+    } while ($true)
+}
+
+
+

--- a/src/private/cli/GetNovaCliHelp.ps1
+++ b/src/private/cli/GetNovaCliHelp.ps1
@@ -23,7 +23,7 @@ global options
    --version  Show the installed NovaModuleTools module name and version
    -Verbose   Show verbose output for the routed PowerShell command
    -WhatIf    Preview build, test, bump, publish, and release without changing files
-   -Confirm   Request confirmation before mutating routed commands
+   -Confirm   Request confirmation before mutating routed commands; nova bump cancels cleanly on No/No to All/Suspend
 
 Examples:
    nova init ~/Work

--- a/src/public/UpdateNovaModuleVersion.ps1
+++ b/src/public/UpdateNovaModuleVersion.ps1
@@ -9,6 +9,7 @@ function Update-NovaModuleVersion {
     $commitMessages = @(Get-GitCommitMessageForVersionBump -ProjectRoot $projectRoot)
     $label = Get-VersionLabelFromCommitSet -Messages $commitMessages
     $nextVersion = $null
+    $shouldReturnResult = $WhatIfPreference
 
     Push-Location -LiteralPath $projectRoot
     try {
@@ -17,12 +18,24 @@ function Update-NovaModuleVersion {
         $action = "Update module version using $label release label"
         $nextVersion = $versionUpdatePlan.NewVersion.ToString()
 
+        if ($env:NOVA_CLI_CONFIRM_BUMP -eq '1' -and -not $WhatIfPreference) {
+            $confirmedFromCli = Confirm-NovaCliBumpAction -Target $target -Action $action
+            if (-not $confirmedFromCli) {
+                return
+            }
+        }
+
         if ( $PSCmdlet.ShouldProcess($target, $action)) {
             Set-NovaModuleVersion -Label $label -Confirm:$false
+            $shouldReturnResult = $true
         }
     }
     finally {
         Pop-Location
+    }
+
+    if (-not $shouldReturnResult) {
+        return
     }
 
     return [pscustomobject]@{

--- a/src/resources/nova
+++ b/src/resources/nova
@@ -48,6 +48,8 @@ $invokeParameters = @{
     Arguments = @($Arguments)
 }
 
+$originalCliConfirmSetting = $env:NOVA_CLI_CONFIRM_BUMP
+
 if ($forwardVerbose) {
     $invokeParameters.Verbose = $true
 }
@@ -56,8 +58,21 @@ if ($forwardWhatIf) {
     $invokeParameters.WhatIf = $true
 }
 
-if ($forwardConfirm) {
+if ($forwardConfirm -and $Command -eq 'bump') {
+    $env:NOVA_CLI_CONFIRM_BUMP = '1'
+}
+elseif ($forwardConfirm) {
     $invokeParameters.Confirm = $true
 }
 
-Invoke-NovaCli @invokeParameters
+try {
+    Invoke-NovaCli @invokeParameters
+}
+finally {
+    if ($null -eq $originalCliConfirmSetting) {
+        Remove-Item Env:NOVA_CLI_CONFIRM_BUMP -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:NOVA_CLI_CONFIRM_BUMP = $originalCliConfirmSetting
+    }
+}

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -578,6 +578,25 @@ title: Invoke-NovaBuild
         $publishSource.IndexOf('Resolve-NovaPublishInvocation') | Should -BeLessThan $publishSource.IndexOf('Invoke-NovaBuild')
     }
 
+    It 'Get-NovaCliConfirmDecision approves Yes and Yes to All, and cancels No, No to All, and Suspend' {
+        InModuleScope $script:moduleName {
+            foreach ($testCase in @(
+                @{Key = 'Y'; Expected = $true},
+                @{Key = 'A'; Expected = $true},
+                @{Key = 'N'; Expected = $false},
+                @{Key = 'L'; Expected = $false},
+                @{Key = 'S'; Expected = $false},
+                @{Key = 'y'; Expected = $true},
+                @{Key = 'n'; Expected = $false}
+            )) {
+                $result = Get-NovaCliConfirmDecision -KeyChar ([char]$testCase.Key)
+                $result | Should -Be $testCase.Expected
+            }
+
+            Get-NovaCliConfirmDecision -KeyChar ([char]'?') | Should -BeNullOrEmpty
+        }
+    }
+
     It 'Update-NovaModuleVersion -WhatIf previews the calculated next version without persisting it' {
         InModuleScope $script:moduleName {
             Mock Get-NovaProjectInfo {
@@ -602,6 +621,47 @@ title: Invoke-NovaBuild
             $result.PreviousVersion | Should -Be '1.0.0'
             $result.NewVersion | Should -Be '1.1.0'
             $result.Label | Should -Be 'Minor'
+            Assert-MockCalled Set-NovaModuleVersion -Times 0
+        }
+    }
+
+    It 'Update-NovaModuleVersion returns no output when the CLI confirm prompt declines the bump' {
+        InModuleScope $script:moduleName {
+            $originalCliConfirm = $env:NOVA_CLI_CONFIRM_BUMP
+            $env:NOVA_CLI_CONFIRM_BUMP = '1'
+
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    Version = '1.0.0'
+                    ProjectJSON = '/tmp/project.json'
+                }
+            }
+            Mock Get-GitCommitMessageForVersionBump {@('feat: add change')}
+            Mock Get-VersionLabelFromCommitSet {'Minor'}
+            Mock Get-NovaVersionUpdatePlan {
+                [pscustomobject]@{
+                    ProjectFile = '/tmp/project.json'
+                    CurrentVersion = [semver]'1.0.0'
+                    NewVersion = [semver]'1.1.0'
+                }
+            }
+            Mock Confirm-NovaCliBumpAction {$false}
+            Mock Set-NovaModuleVersion {}
+
+            try {
+                $result = Update-NovaModuleVersion -Path (Get-Location).Path
+            }
+            finally {
+                if ($null -eq $originalCliConfirm) {
+                    Remove-Item Env:NOVA_CLI_CONFIRM_BUMP -ErrorAction SilentlyContinue
+                }
+                else {
+                    $env:NOVA_CLI_CONFIRM_BUMP = $originalCliConfirm
+                }
+            }
+
+            $result | Should -BeNullOrEmpty
+            Assert-MockCalled Confirm-NovaCliBumpAction -Times 1
             Assert-MockCalled Set-NovaModuleVersion -Times 0
         }
     }


### PR DESCRIPTION
- Fix `nova bump -Confirm` to handle cancellations without opening an interactive prompt
- Update documentation to clarify behavior of `-Confirm` in CLI