### PR TITLE
Restructure documentation for clarity and improve navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The format follows the principles from Keep a Changelog and the project aims to 
 ### Changed
 
 - Change the project to a Nova-first command model, replacing the previous mixed MT/Nova workflow.
+- Change documentation ownership so GitHub repository docs focus on contributors, while GitHub Pages now provides the
+  task-oriented end-user guide experience.
 - Change `CopyResourcesToModuleRoot` to an optional project setting that defaults to `false`, and standardize the
   setting name across templates, tests, and docs.
 - Change `Publish-NovaModule` and `Invoke-NovaRelease` to resolve publish targets before running build and test steps.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,11 +23,11 @@ If you want to contribute, please work in the same style as the project:
 
 Before making larger changes, read the contributor docs in:
 
-- [`README.md`](./README.md)
-- [`developer-docs/README.md`](./developer-docs/README.md)
-- [`developer-docs/development-workflow.md`](./developer-docs/development-workflow.md)
-- [`developer-docs/repository-structure.md`](./developer-docs/repository-structure.md)
-- [`developer-docs/ci-cd-and-release.md`](./developer-docs/ci-cd-and-release.md)
+- [README.md](./README.md)
+- [developer-docs/README.md](./developer-docs/README.md)
+- [developer-docs/development-workflow.md](./developer-docs/development-workflow.md)
+- [developer-docs/repository-structure.md](./developer-docs/repository-structure.md)
+- [developer-docs/ci-cd-and-release.md](./developer-docs/ci-cd-and-release.md)
 
 **Before opening a pull request, please run the local quality flow from the repository root:**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,14 @@ If you want to contribute, please work in the same style as the project:
     - no dead code left behind
 - Follow the Boy Scout Rule: leave the codebase a little cleaner than you found it.
 
+Before making larger changes, read the contributor docs in:
+
+- `README.md`
+- `developer-docs/README.md`
+- `developer-docs/development-workflow.md`
+- `developer-docs/repository-structure.md`
+- `developer-docs/ci-cd-and-release.md`
+
 **Before opening a pull request, please run the local quality flow from the repository root:**
 
 ```powershell title="run.ps1"
@@ -42,9 +50,15 @@ Please also make sure your contribution includes the right kind of follow-up wor
 
 - add or update tests when behavior changes
 - update help files in `docs/` when a command changes
-- update `README.md` when usage, workflow, examples, or contributor expectations change
+- update `README.md` and `developer-docs/` when repository workflow, architecture, or contributor expectations change
 - update `CHANGELOG.md` when the change is relevant to users, maintainers, or future contributors
 - keep `src/resources/example/` useful if your change affects the real-world project layout or workflow
+
+Documentation ownership is intentionally split:
+
+- GitHub repository docs are for contributors and maintainers
+- GitHub Pages content under `docs/*.html` is for end users
+- command-help markdown under `docs/NovaModuleTools/en-US/` is build input, not general prose documentation
 
 When updating documentation, write it for humans first. A reader should quickly understand:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,11 +23,11 @@ If you want to contribute, please work in the same style as the project:
 
 Before making larger changes, read the contributor docs in:
 
-- `README.md`
-- `developer-docs/README.md`
-- `developer-docs/development-workflow.md`
-- `developer-docs/repository-structure.md`
-- `developer-docs/ci-cd-and-release.md`
+- [`README.md`](./README.md)
+- [`developer-docs/README.md`](./developer-docs/README.md)
+- [`developer-docs/development-workflow.md`](./developer-docs/development-workflow.md)
+- [`developer-docs/repository-structure.md`](./developer-docs/repository-structure.md)
+- [`developer-docs/ci-cd-and-release.md`](./developer-docs/ci-cd-and-release.md)
 
 **Before opening a pull request, please run the local quality flow from the repository root:**
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ strong emphasis on structure, maintainability, and automated CI/CD pipelines tha
 This `README.md` is intentionally a **short contributor entry page**. Detailed developer guidance lives under
 `developer-docs/` and should not be duplicated here.
 
-If you are looking for **user guides** to NovaModuleTools, proceed to https://www.novamoduletools.com for more
-information.
+If you are looking for **user guides** to NovaModuleTools, proceed
+to [novamoduletools.com](https://www.novamoduletools.com/)
+for more information.
 
 ## Documentation split
 
@@ -18,11 +19,14 @@ information.
 
 ## Contributor docs in this repository
 
-- `CONTRIBUTING.md` — contribution expectations and review checklist
-- `developer-docs/README.md` — developer documentation hub
-- `developer-docs/development-workflow.md` — local setup, build, test, reload, and quality loop
-- `developer-docs/repository-structure.md` — repository architecture and ownership
-- `developer-docs/ci-cd-and-release.md` — CI, semantic-release, and publish pipeline responsibilities
+- [`CONTRIBUTING.md`](./CONTRIBUTING.md) — contribution expectations and review checklist
+- [`developer-docs/README.md`](./developer-docs/README.md) — developer documentation hub
+- [`developer-docs/development-workflow.md`](./developer-docs/development-workflow.md) — local setup, build, test,
+  reload, and quality loop
+- [`developer-docs/repository-structure.md`](./developer-docs/repository-structure.md) — repository architecture and
+  ownership
+- [`developer-docs/ci-cd-and-release.md`](./developer-docs/ci-cd-and-release.md) — CI, semantic-release, and publish
+  pipeline responsibilities
 
 ## End-user docs on GitHub Pages
 
@@ -44,14 +48,17 @@ High-level responsibilities:
 - `scripts/` — build, CI, and release automation
 - `docs/NovaModuleTools/en-US/` — PlatyPS command-help source
 
-For structure and ownership details, use `developer-docs/repository-structure.md`.
+For structure and ownership details, use [
+`developer-docs/repository-structure.md`](./developer-docs/repository-structure.md).
 
 ## Start here as a contributor
 
-1. Read `CONTRIBUTING.md`
-2. Use `developer-docs/README.md` as the developer docs hub
-3. Follow `developer-docs/development-workflow.md` for local build, test, reload, and quality flows
-4. Use `developer-docs/ci-cd-and-release.md` when your change touches workflows, release automation, or publishing
+1. Read [`CONTRIBUTING.md`](./CONTRIBUTING.md)
+2. Use [`developer-docs/README.md`](./developer-docs/README.md) as the developer docs hub
+3. Follow [`developer-docs/development-workflow.md`](./developer-docs/development-workflow.md) for local build, test,
+   reload, and quality flows
+4. Use [`developer-docs/ci-cd-and-release.md`](./developer-docs/ci-cd-and-release.md) when your change touches
+   workflows, release automation, or publishing
 
 ## Documentation ownership rules
 

--- a/README.md
+++ b/README.md
@@ -72,4 +72,7 @@ For structure and ownership details, use
 
 This project is licensed under the MIT License. See LICENSE for details.
 
+[BadgeIOCount]: https://img.shields.io/powershellgallery/dt/NovaModuleTools?label=NovaModuleTools%40PowerShell%20Gallery
+
+[PSGalleryLink]: https://www.powershellgallery.com/packages/NovaModuleTools/
 [WorkFlowStatus]: https://img.shields.io/github/actions/workflow/status/stiwicourage/NovaModuleTools/Tests.yml

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ High-level layout:
 
 ```text
 .
-├── .github/                     # workflows
+├── .github/                    # workflows
 ├── developer-docs/             # contributor-focused documentation
 ├── docs/                       # GitHub Pages HTML and PlatyPS command-help markdown
 ├── scripts/                    # build, CI, and release automation
@@ -104,6 +104,7 @@ For a deeper breakdown of repository responsibilities and architectural boundari
 Recommended contributor loop from the repository root:
 
 ```powershell
+#run.ps1
 Set-Location $PSScriptRoot
 
 $projectName = (Get-Content -LiteralPath (Join-Path $PSScriptRoot 'project.json') -Raw | ConvertFrom-Json).ProjectName

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ strong emphasis on structure, maintainability, and automated CI/CD pipelines tha
 This `README.md` is intentionally a **short contributor entry page**. Detailed developer guidance lives under
 `developer-docs/` and should not be duplicated here.
 
-If you are looking for **user guides** to NovaModuleTools, proceed to https://www.novamoduletools.com/ for more
+If you are looking for **user guides** to NovaModuleTools, proceed to https://www.novamoduletools.com for more
 information.
 
 ## Documentation split

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# NovaModuleTools | [![CodeScene general](https://codescene.io/images/analyzed-by-codescene-badge.svg)](https://codescene.io/projects/78904) ![WorkFlow Status][WorkFlowStatus]
+# NovaModuleTools | [![CodeScene general](https://codescene.io/images/analyzed-by-codescene-badge.svg)](https://codescene.io/projects/78904) ![WorkFlow Status][WorkFlowStatus] [![NovaModuleTools@PowerShell Gallery][BadgeIOCount]][PSGalleryLink]
 
 NovaModuleTools is an enterprise-focused evolution of ModuleTools, designed for large-scale PowerShell projects with a
 strong emphasis on structure, maintainability, and automated CI/CD pipelines that make up the Nova workflow.
 
-This `README.md` is intentionally a **short contributor entry page**. Detailed developer guidance lives under
-`developer-docs/` and should not be duplicated here.
+This README is intentionally a **short contributor entry page**. Detailed developer guidance lives under
+developer-docs/ and should not be duplicated here.
 
 If you are looking for **user guides** to NovaModuleTools, proceed
 to [novamoduletools.com](https://www.novamoduletools.com/)
@@ -19,13 +19,13 @@ for more information.
 
 ## Contributor docs in this repository
 
-- [`CONTRIBUTING.md`](./CONTRIBUTING.md) — contribution expectations and review checklist
-- [`developer-docs/README.md`](./developer-docs/README.md) — developer documentation hub
-- [`developer-docs/development-workflow.md`](./developer-docs/development-workflow.md) — local setup, build, test,
+- [CONTRIBUTING.md](./CONTRIBUTING.md) — contribution expectations and review checklist
+- [developer-docs/README.md](./developer-docs/README.md) — developer documentation hub
+- [developer-docs/development-workflow.md](./developer-docs/development-workflow.md) — local setup, build, test,
   reload, and quality loop
-- [`developer-docs/repository-structure.md`](./developer-docs/repository-structure.md) — repository architecture and
+- [developer-docs/repository-structure.md](./developer-docs/repository-structure.md) — repository architecture and
   ownership
-- [`developer-docs/ci-cd-and-release.md`](./developer-docs/ci-cd-and-release.md) — CI, semantic-release, and publish
+- [developer-docs/ci-cd-and-release.md](./developer-docs/ci-cd-and-release.md) — CI, semantic-release, and publish
   pipeline responsibilities
 
 ## End-user docs on GitHub Pages
@@ -48,28 +48,28 @@ High-level responsibilities:
 - `scripts/` — build, CI, and release automation
 - `docs/NovaModuleTools/en-US/` — PlatyPS command-help source
 
-For structure and ownership details, use [
-`developer-docs/repository-structure.md`](./developer-docs/repository-structure.md).
+For structure and ownership details, use
+[developer-docs/repository-structure.md](./developer-docs/repository-structure.md).
 
 ## Start here as a contributor
 
-1. Read [`CONTRIBUTING.md`](./CONTRIBUTING.md)
-2. Use [`developer-docs/README.md`](./developer-docs/README.md) as the developer docs hub
-3. Follow [`developer-docs/development-workflow.md`](./developer-docs/development-workflow.md) for local build, test,
+1. Read [CONTRIBUTING.md](./CONTRIBUTING.md)
+2. Use [developer-docs/README.md](./developer-docs/README.md) as the developer docs hub
+3. Follow [developer-docs/development-workflow.md](./developer-docs/development-workflow.md) for local build, test,
    reload, and quality flows
-4. Use [`developer-docs/ci-cd-and-release.md`](./developer-docs/ci-cd-and-release.md) when your change touches
+4. Use [developer-docs/ci-cd-and-release.md](./developer-docs/ci-cd-and-release.md) when your change touches
    workflows, release automation, or publishing
 
 ## Documentation ownership rules
 
-- Keep detailed contributor workflow documentation under `developer-docs/`
-- Keep `README.md` short and navigation-focused
-- Keep `docs/NovaModuleTools/en-US/*.md` focused on command-help source material
-- Keep `docs/*.html` focused on end-user guides
-- Do not duplicate the same workflow or setup prose across `README.md` and `developer-docs/`
+- Keep detailed contributor workflow documentation under developer-docs/
+- Keep README.md short and navigation-focused
+- Keep docs/NovaModuleTools/en-US/*.md focused on command-help source material
+- Keep docs/*.html focused on end-user guides
+- Do not duplicate the same workflow or setup prose across README.md and developer-docs/
 
 ## License
 
-This project is licensed under the MIT License. See `LICENSE` for details.
+This project is licensed under the MIT License. See LICENSE for details.
 
 [WorkFlowStatus]: https://img.shields.io/github/actions/workflow/status/stiwicourage/NovaModuleTools/Tests.yml

--- a/README.md
+++ b/README.md
@@ -1,210 +1,68 @@
 # NovaModuleTools | [![CodeScene general](https://codescene.io/images/analyzed-by-codescene-badge.svg)](https://codescene.io/projects/78904) ![WorkFlow Status][WorkFlowStatus]
 
-NovaModuleTools is the source repository for the PowerShell module builder, scaffold, test workflow, CLI launcher, and
-release automation that make up the Nova workflow.
+NovaModuleTools is an enterprise-focused evolution of ModuleTools, designed for large-scale PowerShell projects with a
+strong emphasis on structure, maintainability, and automated CI/CD pipelines that make up the Nova workflow.
 
-This `README.md` is intentionally **developer-focused**. It explains how to work on the repository, validate changes,
-and understand the internal structure of the project.
+This `README.md` is intentionally a **short contributor entry page**. Detailed developer guidance lives under
+`developer-docs/` and should not be duplicated here.
 
-If you want to **use** NovaModuleTools rather than contribute to it, start with the public user guides on GitHub Pages:
-
-- https://www.novamoduletools.com/
+If you are looking for **user guides** to NovaModuleTools, proceed to https://www.novamoduletools.com/ for more
+information.
 
 ## Documentation split
-
-This repository now keeps documentation on two separate tracks:
 
 | Audience                     | Location          | Purpose                                                   |
 |------------------------------|-------------------|-----------------------------------------------------------|
 | Contributors and maintainers | GitHub repository | Build, test, debug, document, and release NovaModuleTools |
 | End users                    | GitHub Pages      | Install NovaModuleTools and follow guided usage workflows |
 
-Repository-side developer docs:
+## Contributor docs in this repository
 
-- `README.md` — contributor entry point
 - `CONTRIBUTING.md` — contribution expectations and review checklist
 - `developer-docs/README.md` — developer documentation hub
-- `developer-docs/development-workflow.md` — local development, build, test, and reload workflows
-- `developer-docs/repository-structure.md` — architecture and repository layout
-- `developer-docs/ci-cd-and-release.md` — CI, release automation, and publish expectations
+- `developer-docs/development-workflow.md` — local setup, build, test, reload, and quality loop
+- `developer-docs/repository-structure.md` — repository architecture and ownership
+- `developer-docs/ci-cd-and-release.md` — CI, semantic-release, and publish pipeline responsibilities
 
-User-facing guides are intentionally kept out of the repository `README.md` and live under GitHub Pages in
-`docs/*.html`.
+## End-user docs on GitHub Pages
 
-## Technical overview
+- `docs/index.html` — landing page
+- `docs/getting-started.html` — install and first project setup
+- `docs/core-workflows.html` — scaffold, build, test, bump, and release flows
+- `docs/working-with-modules.html` — import and reload usage
+- `docs/troubleshooting.html` — common issues and fixes
+- `docs/advanced.html` — advanced usage and CI/CD-oriented user guidance
 
-NovaModuleTools provides:
+## Repository overview
 
-- project scaffolding through `New-NovaModule` / `nova init`
-- module building through `Invoke-NovaBuild` / `nova build`
-- test execution through `Test-NovaBuild` / `nova test`
-- version bumping through `Update-NovaModuleVersion` / `nova bump`
-- publish and release orchestration through `Publish-NovaModule` and `Invoke-NovaRelease`
-- a packaged macOS/Linux launcher installed through `Install-NovaCli`
-- generated PowerShell help from PlatyPS markdown under `docs/NovaModuleTools/en-US/`
+High-level responsibilities:
 
-The repository is intentionally organized around maintainability:
+- `src/public/` — public cmdlets
+- `src/private/` — internal helpers
+- `src/resources/` — packaged resources
+- `tests/` — Pester coverage and test helpers
+- `scripts/` — build, CI, and release automation
+- `docs/NovaModuleTools/en-US/` — PlatyPS command-help source
 
-- public entrypoints under `src/public/`
-- internal helpers under `src/private/`
-- packaged module resources under `src/resources/`
-- Pester coverage under `tests/`
-- CI and release scripts under `scripts/`
+For structure and ownership details, use `developer-docs/repository-structure.md`.
 
-## Development setup
+## Start here as a contributor
 
-### Required tools
+1. Read `CONTRIBUTING.md`
+2. Use `developer-docs/README.md` as the developer docs hub
+3. Follow `developer-docs/development-workflow.md` for local build, test, reload, and quality flows
+4. Use `developer-docs/ci-cd-and-release.md` when your change touches workflows, release automation, or publishing
 
-- PowerShell 7.4 or newer for repository development
-- Git
-- PowerShell modules used by the local quality flow:
-    - `Pester`
-    - `PSScriptAnalyzer`
-    - `Microsoft.PowerShell.PlatyPS`
-- Node.js is only required when you work on the current semantic-release based publish pipeline
+## Documentation ownership rules
 
-### Local bootstrap
-
-From the repository root, build the module and load the freshly built output:
-
-```powershell
-Set-Location $PSScriptRoot
-Invoke-NovaBuild
-Import-Module ./dist/NovaModuleTools -Force
-```
-
-If you need the reusable CI bootstrap behavior locally, review:
-
-- `scripts/build/ci/Install-CiPowerShellModules.ps1`
-- `scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
-
-## Repository structure
-
-High-level layout:
-
-```text
-.
-├── .github/                    # workflows
-├── developer-docs/             # contributor-focused documentation
-├── docs/                       # GitHub Pages HTML and PlatyPS command-help markdown
-├── scripts/                    # build, CI, and release automation
-├── src/public/                 # public cmdlets
-├── src/private/                # internal helpers
-├── src/resources/              # packaged resources, launcher, schemas, example project
-├── tests/                      # Pester suites and test support helpers
-├── project.json                # NovaModuleTools project definition
-└── package.json                # semantic-release tooling for the current release pipeline
-```
-
-For a deeper breakdown of repository responsibilities and architectural boundaries, see
-`developer-docs/repository-structure.md`.
-
-## Local development workflow
-
-Recommended contributor loop from the repository root:
-
-```powershell
-#run.ps1
-Set-Location $PSScriptRoot
-
-$projectName = (Get-Content -LiteralPath (Join-Path $PSScriptRoot 'project.json') -Raw | ConvertFrom-Json).ProjectName
-$distModuleDir = Join-Path $PSScriptRoot "dist/$projectName"
-
-Invoke-NovaBuild
-& (Join-Path $PSScriptRoot 'scripts/build/Invoke-ScriptAnalyzerCI.ps1')
-Remove-Module $projectName -ErrorAction SilentlyContinue
-Import-Module $distModuleDir -Force
-Test-NovaBuild
-```
-
-This produces the normal local artifacts under `artifacts/`, including:
-
-- `artifacts/TestResults.xml`
-- `artifacts/scriptanalyzer.txt`
-- CI-compatible reports created by the CI helper flow
-
-For the full development guide, including reload tips and CI parity helpers, see
-`developer-docs/development-workflow.md`.
-
-## Build and test expectations
-
-Core developer commands:
-
-```powershell
-Invoke-NovaBuild
-Test-NovaBuild
-Update-NovaModuleVersion -WhatIf
-Publish-NovaModule -Local -WhatIf
-Invoke-NovaRelease -PublishOption @{ Local = $true } -WhatIf
-```
-
-Notes for contributors:
-
-- `Test-NovaBuild` validates the built module and writes NUnit XML to `artifacts/TestResults.xml`
-- `scripts/build/Invoke-ScriptAnalyzerCI.ps1` is the repository ScriptAnalyzer entrypoint
-- `scripts/build/ci/Invoke-NovaModuleToolsCI.ps1` is the CI-parity flow for coverage and report generation
-- PlatyPS markdown under `docs/NovaModuleTools/en-US/` is used to build MAML help during `Invoke-NovaBuild`
-
-## Reloading during development
-
-When you are iterating on the module, prefer reloading the built output instead of relying on an older installed copy:
-
-```powershell
-Remove-Module NovaModuleTools -ErrorAction SilentlyContinue
-Invoke-NovaBuild
-Import-Module ./dist/NovaModuleTools -Force
-```
-
-If you are testing local publish behavior, reload after publishing as well:
-
-```powershell
-Remove-Module NovaModuleTools -ErrorAction SilentlyContinue
-Publish-NovaModule -Local
-Import-Module ./dist/NovaModuleTools -Force
-```
-
-## CI/CD and release expectations
-
-The repository currently uses:
-
-- GitHub Actions under `.github/workflows/`
-- PowerShell CI helper scripts under `scripts/build/ci/`
-- semantic-release orchestration for the publish workflow
-
-The current release pipeline does more than version bumping. It coordinates:
-
-- release version selection
-- `project.json` updates
-- changelog release preparation
-- rebuild after version changes
-- tagging and GitHub release automation
-- PowerShell Gallery publish steps
-
-For the release flow details and the role of `package.json`, see `developer-docs/ci-cd-and-release.md`.
-
-## Documentation ownership in the repository
-
-- Keep `docs/NovaModuleTools/en-US/*.md` focused on command help source material
-- Keep GitHub Pages content in `docs/*.html` focused on end-user usage flows
-- Keep contributor guidance in `README.md`, `CONTRIBUTING.md`, and `developer-docs/*.md`
-- Do not reintroduce consumer onboarding into the repository `README.md`
-
-## Contributing
-
-Start with `CONTRIBUTING.md` and then use the developer docs hub in `developer-docs/README.md`.
-
-Before opening a pull request, make sure you have:
-
-- built the module
-- run ScriptAnalyzer
-- run the relevant Pester coverage
-- reviewed help/docs changes
-- updated `CHANGELOG.md` when the change is user-visible or contributor-relevant
+- Keep detailed contributor workflow documentation under `developer-docs/`
+- Keep `README.md` short and navigation-focused
+- Keep `docs/NovaModuleTools/en-US/*.md` focused on command-help source material
+- Keep `docs/*.html` focused on end-user guides
+- Do not duplicate the same workflow or setup prose across `README.md` and `developer-docs/`
 
 ## License
 
 This project is licensed under the MIT License. See `LICENSE` for details.
 
-[BadgeIOCount]: https://img.shields.io/powershellgallery/dt/NovaModuleTools?label=NovaModuleTools%40PowerShell%20Gallery
-[PSGalleryLink]: https://www.powershellgallery.com/packages/NovaModuleTools/
 [WorkFlowStatus]: https://img.shields.io/github/actions/workflow/status/stiwicourage/NovaModuleTools/Tests.yml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NovaModuleTools | [![CodeScene general](https://codescene.io/images/analyzed-by-codescene-badge.svg)](https://codescene.io/projects/78904) ![WorkFlow Status][WorkFlowStatus] [![NovaModuleTools@PowerShell Gallery][BadgeIOCount]][PSGalleryLink]
+# NovaModuleTools | [![CodeScene general](https://codescene.io/images/analyzed-by-codescene-badge.svg)](https://codescene.io/projects/78904) ![WorkFlow Status][WorkFlowStatus]
 
 NovaModuleTools is an enterprise-focused evolution of ModuleTools, designed for large-scale PowerShell projects with a
 strong emphasis on structure, maintainability, and automated CI/CD pipelines that make up the Nova workflow.
@@ -71,8 +71,6 @@ For structure and ownership details, use
 ## License
 
 This project is licensed under the MIT License. See LICENSE for details.
-
-[BadgeIOCount]: https://img.shields.io/powershellgallery/dt/NovaModuleTools?label=NovaModuleTools%40PowerShell%20Gallery
 
 [PSGalleryLink]: https://www.powershellgallery.com/packages/NovaModuleTools/
 [WorkFlowStatus]: https://img.shields.io/github/actions/workflow/status/stiwicourage/NovaModuleTools/Tests.yml

--- a/README.md
+++ b/README.md
@@ -1,307 +1,109 @@
 # NovaModuleTools | [![CodeScene general](https://codescene.io/images/analyzed-by-codescene-badge.svg)](https://codescene.io/projects/78904) ![WorkFlow Status][WorkFlowStatus]
 
-NovaModuleTools is an enterprise-focused evolution of ModuleTools, designed for large-scale PowerShell projects with a
-strong emphasis on structure, maintainability, and automated CI/CD pipelines.
+NovaModuleTools is the source repository for the PowerShell module builder, scaffold, test workflow, CLI launcher, and
+release automation that make up the Nova workflow.
 
-## Description
-Whether you're creating simple or robust modules, NovaModuleTools streamlines the process, making it perfect for CI/CD and automation environments. With comprehensive features included, you can start building PowerShell modules in less than 30 seconds. Let NovaModuleTools handle the build logic, so you can focus on developing the core functionality of your module.
+This `README.md` is intentionally **developer-focused**. It explains how to work on the repository, validate changes,
+and understand the internal structure of the project.
 
-The structure of the NovaModuleTools module is meticulously designed according to PowerShell best practices for module development. While some design decisions may seem unconventional, they are made to ensure that NovaModuleTools and the process of building modules remain straightforward and easy to manage.
+If you want to **use** NovaModuleTools rather than contribute to it, start with the public user guides on GitHub Pages:
 
-If you want a more user-focused overview of what NovaModuleTools does and how to get started without diving into all
-repository details, see the public landing page in `docs/index.html`.
+- https://www.novamoduletools.com/
 
-## Install | [![NovaModuleTools@PowerShell Gallery][BadgeIOCount]][PSGalleryLink]
-```PowerShell
-PS> Install-Module -Name NovaModuleTools
-PS> Import-Module NovaModuleTools
+## Documentation split
 
-# Optional on macOS/Linux: install the standalone nova launcher
-PS> Install-NovaCli
-```
+This repository now keeps documentation on two separate tracks:
 
-`nova` is always available as a PowerShell alias after the module is imported.
+| Audience                     | Location          | Purpose                                                   |
+|------------------------------|-------------------|-----------------------------------------------------------|
+| Contributors and maintainers | GitHub repository | Build, test, debug, document, and release NovaModuleTools |
+| End users                    | GitHub Pages      | Install NovaModuleTools and follow guided usage workflows |
 
-If you want to run `nova` directly from `zsh`/`bash`, `Install-NovaCli` copies the bundled launcher to
-`~/.local/bin/nova` by default. Add that directory to your shell `PATH` if it is not already present:
+Repository-side developer docs:
 
-```zsh
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
-source ~/.zshrc
-```
+- `README.md` — contributor entry point
+- `CONTRIBUTING.md` — contribution expectations and review checklist
+- `developer-docs/README.md` — developer documentation hub
+- `developer-docs/development-workflow.md` — local development, build, test, and reload workflows
+- `developer-docs/repository-structure.md` — architecture and repository layout
+- `developer-docs/ci-cd-and-release.md` — CI, release automation, and publish expectations
 
-## Design
-To ensure this module works correctly, you need to maintain the folder structure and the `project.json` file path. The
-best way to get started is by running `New-NovaModule` (`nova init`), which guides you through a series of questions
-and creates the necessary scaffolding.
+User-facing guides are intentionally kept out of the repository `README.md` and live under GitHub Pages in
+`docs/*.html`.
 
-## Preview changes safely with `-WhatIf`
-State-changing NovaModuleTools commands support PowerShell `-WhatIf`, so you can preview what would happen before files,
-versions, test artifacts, or publish targets are changed.
+## Technical overview
+
+NovaModuleTools provides:
+
+- project scaffolding through `New-NovaModule` / `nova init`
+- module building through `Invoke-NovaBuild` / `nova build`
+- test execution through `Test-NovaBuild` / `nova test`
+- version bumping through `Update-NovaModuleVersion` / `nova bump`
+- publish and release orchestration through `Publish-NovaModule` and `Invoke-NovaRelease`
+- a packaged macOS/Linux launcher installed through `Install-NovaCli`
+- generated PowerShell help from PlatyPS markdown under `docs/NovaModuleTools/en-US/`
+
+The repository is intentionally organized around maintainability:
+
+- public entrypoints under `src/public/`
+- internal helpers under `src/private/`
+- packaged module resources under `src/resources/`
+- Pester coverage under `tests/`
+- CI and release scripts under `scripts/`
+
+## Development setup
+
+### Required tools
+
+- PowerShell 7.4 or newer for repository development
+- Git
+- PowerShell modules used by the local quality flow:
+    - `Pester`
+    - `PSScriptAnalyzer`
+    - `Microsoft.PowerShell.PlatyPS`
+- Node.js is only required when you work on the current semantic-release based publish pipeline
+
+### Local bootstrap
+
+From the repository root, build the module and load the freshly built output:
 
 ```powershell
-PS> Invoke-NovaBuild -WhatIf
-PS> Test-NovaBuild -WhatIf
-PS> Publish-NovaModule -Local -WhatIf
-PS> Invoke-NovaRelease -PublishOption @{ Local = $true } -WhatIf
-PS> Update-NovaModuleVersion -WhatIf
-PS> Install-NovaCli -WhatIf
+Set-Location $PSScriptRoot
+Invoke-NovaBuild
+Import-Module ./dist/NovaModuleTools -Force
 ```
 
-From the standalone CLI on macOS/Linux, the routed commands forward preview mode to the underlying PowerShell cmdlets:
+If you need the reusable CI bootstrap behavior locally, review:
 
-```bash
-nova build -WhatIf
-nova test -WhatIf
-nova bump -WhatIf
-nova publish -local -WhatIf
-nova release -local -WhatIf
-```
+- `scripts/build/ci/Install-CiPowerShellModules.ps1`
+- `scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
 
-`nova init` is intentionally still interactive, so the standalone CLI does not support `nova init -WhatIf`.
-Use `nova init -Path <path>` when you want an explicit destination, and use `nova init -Example` when you want the
-packaged working example instead of the minimal scaffold. Positional `nova init <path>` is no longer supported.
+## Repository structure
 
-For command-specific details and examples, run `Get-Help <CommandName> -Full` after importing the module.
+High-level layout:
 
-## Folder Structure
-All module files should be inside the `src` folder.
-
-```
+```text
 .
-├── project.json
-└── src
-    ├── classes
-    │   └── Person.classes.ps1
-    │   └── Person.enums.ps1
-    ├── public
-    │   └── New-PublicFunction.ps1
-    ├── resources
-    │   └── some-config.json
-    └── private
-        └── New-PrivateFunction.ps1
+├── .github/                     # workflows
+├── developer-docs/             # contributor-focused documentation
+├── docs/                       # GitHub Pages HTML and PlatyPS command-help markdown
+├── scripts/                    # build, CI, and release automation
+├── src/public/                 # public cmdlets
+├── src/private/                # internal helpers
+├── src/resources/              # packaged resources, launcher, schemas, example project
+├── tests/                      # Pester suites and test support helpers
+├── project.json                # NovaModuleTools project definition
+└── package.json                # semantic-release tooling for the current release pipeline
 ```
 
-### Dist Folder
-The generated module is stored in the `dist` folder. You can easily import it or publish it to a PowerShell repository.
+For a deeper breakdown of repository responsibilities and architectural boundaries, see
+`developer-docs/repository-structure.md`.
 
-```
-dist
-└── TestModule
-    ├── TestModule.psd1
-    └── TestModule.psm1
-```
+## Local development workflow
 
-### Docs Folder
-Store `Microsoft.PowerShell.PlatyPS` generated Markdown files in the `docs` folder. If the `docs` folder exists and contains valid Markdown files, the build will generate a MAML help file in the built module.
-
-The generated help is meant to work with normal PowerShell help commands after the module is built and imported.
-That means your Markdown help should be written so built help can be activated with `Get-Help` for the matching command
-names.
-
-```
-docs
-├── NovaModuleTools.md
-└── Invoke-NovaBuild.md
-```
-
-### Project JSON File
-
-The `project.json` file contains all the important details about your module and is used during the module build. It
-should comply with a specific schema. You can refer to the packaged working example project in `src/resources/example/`,
-especially `src/resources/example/project.json` and `src/resources/example/README.md`, for guidance.
-
-Run `New-NovaModule` (`nova init`) to generate the scaffolding; this will also create the `project.json` file.
-
-#### Build settings (optional)
-NovaModuleTools supports these optional settings at the top level of `project.json`.
-If a setting is omitted, NovaModuleTools now treats it as `true` by default:
-
-- `BuildRecursiveFolders` (default: `true`)
-  - When `true`, NovaModuleTools will discover `.ps1` files recursively in `src/classes` and `src/private`.
-  - `src/public` is always **top-level only** (never recursive).
-  - For `Test-NovaBuild` (`nova test`), `BuildRecursiveFolders=false` runs only top-level `tests/*.Tests.ps1` files (the
-    usual Pester
-    naming convention), while `BuildRecursiveFolders=true` also includes tests in subfolders.
-- `SetSourcePath` (default: `true`)
-  - When `true`, NovaModuleTools writes exactly one `# Source: <relative path>` line before each concatenated source file in the generated `dist/<Project>/<Project>.psm1`.
-  - Relative paths are project-relative and normalized to `/`, for example `# Source: src/private/core/security/SetTls12SecurityProtocol.ps1`.
-  - This is useful when parser errors or runtime exceptions point at line numbers in the generated `.psm1` and you need to map them back to files under `src`.
-- `Preamble` (default: omitted / no output)
-    - When present, this must be a top-level array of strings in `project.json`.
-    - NovaModuleTools writes each configured line at the very top of the generated `dist/<Project>/<Project>.psm1`, then
-      inserts one blank line before the rest of the generated module content.
-    - `Preamble` is independent from `SetSourcePath`: if both are used, the preamble is written first and the generated
-      `# Source: ...` markers come after the blank line.
-- `FailOnDuplicateFunctionNames` (default: `true`)
-  - When `true`, NovaModuleTools will parse the generated `dist/<Project>/<Project>.psm1` and fail the build if duplicate **top-level** function names exist.
-
-Example:
-```json
-{
-  "BuildRecursiveFolders": true,
-  "SetSourcePath": true,
-  "Preamble": [
-    "Set-StrictMode -Version Latest"
-  ],
-  "FailOnDuplicateFunctionNames": true
-}
-```
-
-#### Manifest validation
-
-If you include a `Manifest` section in `project.json`, NovaModuleTools now validates the keys before writing the built
-module manifest.
-
-- Use the exact parameter names supported by `New-ModuleManifest`.
-- Unsupported keys now fail the build early with a clear error message instead of being silently ignored.
-
-For example, a manifest key such as `BogusKey` now causes the build to stop with an error similar to:
-
-```text
-Unknown parameter(s) in Manifest: BogusKey
-```
-
-When `SetSourcePath` is enabled, the generated `.psm1` contains one marker line before each source block:
-```powershell
-# Source: src/classes/AgentListing.ps1
-class AgentListing {
-    # ...
-}
-
-# Source: src/private/core/security/SetTls12SecurityProtocol.ps1
-function Set-Tls12SecurityProtocol {
-    # ...
-}
-```
-
-With `Preamble`, you can inject module-level setup lines before those source markers and before any generated class or
-function content:
-
-```json
-{
-  "Preamble": [
-    "Set-StrictMode -Version Latest"
-  ],
-  "SetSourcePath": true
-}
-```
-
-This produces a generated module that starts like this:
+Recommended contributor loop from the repository root:
 
 ```powershell
-Set-StrictMode -Version Latest
-
-# Source: src/classes/AgentListing.ps1
-class AgentListing {
-    # ...
-}
-```
-
-### Src Folder
-- Place all your functions in the `private` and `public` folders within the `src` directory.
-- All functions in the `public` folder are exported during the module build.
-- All functions in the `private` folder are accessible internally within the module but are not exposed outside the module.
-- `src/classes` should contain classes and enums. These files are placed at the top of the generated `psm1`.
-- `src/resources` content is handled based on the optional `CopyResourcesToModuleRoot` setting.
-
-#### Deterministic processing order
-To ensure builds are deterministic across platforms, files are processed in this order:
-1. `src/classes`
-2. `src/public`
-3. `src/private`
-
-Within each folder group, files are processed in a deterministic order by relative path (case-insensitive).
-
-#### Recursive folder support
-By default, NovaModuleTools loads `src/classes` and `src/private` recursively, while `src/public` remains top-level only.
-
-If `BuildRecursiveFolders` is set to `false`:
-- `src/classes`, `src/private`, and `tests` switch to top-level-only discovery.
-- `src/public` remains top-level only.
-- This preserves the legacy top-level-only behavior for test discovery and source loading.
-
-#### Resources Folder
-The `resources` folder within the `src` directory is intended for including any additional resources required by your module. This can include files such as:
-- **Configuration files**: Store any JSON, XML, or other configuration files needed by your module.
-- **Script files**: Place any scripts that are used by your functions or modules, but are not directly part of the public or private functions.
-- **formatdata files**: Store `Example.Format.ps1xml` file for custom format data types to be imported to manifest
-- **types files**: Store `Example.Types.ps1xml` file for custom types data types to be imported to manifest
-- **Documentation files**: Include any supplementary documentation that supports the usage or development of the module.
-- **Data files**: Store any data files that are used by your module, such as CSV or JSON files.
-- **Subfolder**: Include any additional folders and their content to be included with the module, such as dependant Modules, APIs, DLLs, etc... organized by a subfolder.
-
-By default, resource files from `src/resources` go into `dist/resources`. You do not need to add
-`CopyResourcesToModuleRoot` to `project.json` unless you want to override that default. To place resources directly in
-dist (avoiding the resources subfolder), set `CopyResourcesToModuleRoot` to `true`. This provides greater control in
-certain deployment scenarios where resources files are preferred in module root directory.
-
-Leave `src\resources` empty if there is no need to include any additional content in the `dist` folder.
-
-An example of the module build where resources were included and `CopyResourcesToModuleRoot` is set to true.
-
-```text
-dist
-└── TestModule
-├── TestModule.psd1
-├── TestModule.psm1
-├── config.json
-├── additionalScript.ps1
-├── helpDocumentation.md
-├── sampleData.csv
-└── subfolder
-├── subConfig.json
-├── subScript.ps1
-└── subData.csv
-```
-
-### Tests Folder
-If you want to run Pester tests, keep them in the `tests` folder. Otherwise, you can ignore this feature.
-
-## Working example project
-
-This repository includes a real example project in `src/resources/example/`.
-
-Use it when you want something you can build, test, import, and inspect right away instead of reading a minimal schema
-example in isolation.
-
-The example demonstrates:
-
-- a real `project.json`
-- a public command under `src/public`
-- a private helper under `src/private`
-- a bundled resource file under `src/resources`
-- Pester tests that import the built module from `dist/`
-
-Start here:
-
-- `src/resources/example/README.md`
-- `src/resources/example/project.json`
-
-Typical local flow from the repository root:
-
-```powershell
-PS> Import-Module ./dist/NovaModuleTools -Force
-PS> Set-Location ./src/resources/example
-PS> Invoke-NovaBuild
-PS> Test-NovaBuild
-PS> $project = Get-NovaProjectInfo
-PS> Import-Module $project.OutputModuleDir -Force
-PS> Get-ExampleGreeting
-```
-
-Expected output:
-
-```text
-Hello, Nova user!
-```
-
-## Local quality workflow
-
-For local repository work, a practical quality loop is:
-
-```powershell
-#run.ps1
 Set-Location $PSScriptRoot
 
 $projectName = (Get-Content -LiteralPath (Join-Path $PSScriptRoot 'project.json') -Raw | ConvertFrom-Json).ProjectName
@@ -311,312 +113,96 @@ Invoke-NovaBuild
 & (Join-Path $PSScriptRoot 'scripts/build/Invoke-ScriptAnalyzerCI.ps1')
 Remove-Module $projectName -ErrorAction SilentlyContinue
 Import-Module $distModuleDir -Force
-
 Test-NovaBuild
 ```
 
-You generally do not need to add `$ErrorActionPreference = 'Stop'` to a module preamble or helper script.
-NovaModuleTools now
-uses explicit terminating errors in its own build/test paths, so examples in this repository keep the preamble focused
-on
-module setup such as `Set-StrictMode -Version Latest`.
+This produces the normal local artifacts under `artifacts/`, including:
 
-This keeps ScriptAnalyzer as a separate code-quality step while `Test-NovaBuild` remains focused on Pester tests.
-When ScriptAnalyzer runs this way, its findings are written to `artifacts/scriptanalyzer.txt` and are not counted as
-Pester test cases. `Test-NovaBuild` also writes the Pester XML report to `artifacts/TestResults.xml` so test output and
-quality artifacts stay in the same place.
+- `artifacts/TestResults.xml`
+- `artifacts/scriptanalyzer.txt`
+- CI-compatible reports created by the CI helper flow
 
-For CI parity, this repository now also includes reusable helper scripts under `scripts/build/ci/`:
+For the full development guide, including reload tips and CI parity helpers, see
+`developer-docs/development-workflow.md`.
 
-- `scripts/build/ci/Install-CiPowerShellModules.ps1`
-- `scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
-- `scripts/build/ci/Invoke-CodeSceneAnalysis.ps1`
+## Build and test expectations
 
-The CI helper flow builds the module, runs ScriptAnalyzer, runs the normal `Test-NovaBuild` workflow, generates
-additional CI-friendly reports, and remaps Cobertura coverage from `dist/<Project>/<Project>.psm1` back to `src/...`
-paths using the generated `# Source:` markers.
-
-Expected CI artifacts:
-
-- `artifacts/novamoduletools-nunit.xml` — NUnit XML from `Test-NovaBuild`
-- `artifacts/pester-junit.xml` — JUnit XML for CI systems that expect JUnit-compatible test reports
-- `artifacts/pester-coverage.cobertura.xml` — Cobertura XML with source-relative paths suitable for CodeScene upload
-- `artifacts/coverage-low.txt` — a simple low-coverage summary sorted by the least-covered source files first
-- `artifacts/scriptanalyzer.txt` — ScriptAnalyzer findings (or a no-findings report)
-
-## Commands
-
-All `nova ...` examples below work in either of these modes:
-
-- inside `pwsh` after `Import-Module NovaModuleTools`
-- directly from `zsh`/`bash` on macOS/Linux after running `Install-NovaCli`
-
-### Install-NovaCli
-
-Use `Install-NovaCli` when you want the bundled `nova` launcher available directly from your normal shell.
+Core developer commands:
 
 ```powershell
-# Install to the default macOS/Linux location
-PS> Install-NovaCli
-
-# Install to a custom directory
-PS> Install-NovaCli -DestinationDirectory ~/bin -Force
+Invoke-NovaBuild
+Test-NovaBuild
+Update-NovaModuleVersion -WhatIf
+Publish-NovaModule -Local -WhatIf
+Invoke-NovaRelease -PublishOption @{ Local = $true } -WhatIf
 ```
 
-On Windows, keep using the `nova` alias inside `pwsh` after importing the module.
+Notes for contributors:
 
-### New-NovaModule (`nova init`)
+- `Test-NovaBuild` validates the built module and writes NUnit XML to `artifacts/TestResults.xml`
+- `scripts/build/Invoke-ScriptAnalyzerCI.ps1` is the repository ScriptAnalyzer entrypoint
+- `scripts/build/ci/Invoke-NovaModuleToolsCI.ps1` is the CI-parity flow for coverage and report generation
+- PlatyPS markdown under `docs/NovaModuleTools/en-US/` is used to build MAML help during `Invoke-NovaBuild`
 
-This interactive command helps you create the module structure. Easily create the skeleton of your module and get started with module building in no time.
-```powershell
-## Create a module skeleton in the current directory
-PS> New-NovaModule
+## Reloading during development
 
-## Create a module skeleton under an explicit base path
-PS> New-NovaModule -Path ~/Work
-
-## Create a working example-based project under an explicit base path
-PS> New-NovaModule -Example -Path ~/Work
-
-## Same actions through the nova CLI
-nova init -Path ~/Work
-nova init -Example -Path ~/Work
-```
-
-`New-NovaModule` and `nova init` now require `-Path` when you want to target a specific base directory.
-`nova init some/path` is intentionally rejected instead of being treated as path shorthand.
-
-### A typical interactive session looks like this:
-
-```text
-PS ~/Work> nova init -Example
-
-Module Name
-Enter Module name of your choice, should be single word with no special characters
-Name: NovaModuleTools
-
-Module Description
-What does your module do? Describe in simple words
-Description: Self-contained installer that configures Azure DevOps build agents on Windows.
-
-Semantic Version
-Starting Version of the module (Default: 0.0.1)
-Version: 1.7.2
-
-Module Author
-Enter Author or company name
-Name: Stiwi Gabriel Courage
-
-Supported PowerShell Version
-What is minimum supported version of PowerShell for this module (Default: 7.4)
-Version: 7.4
-
-Git Version Control
-Do you want to enable version controlling using Git
-[Y] Enable Git  [N] Skip Git initialization: Y
-
-
-Module NovaModuleTools scaffolding complete
-```
-
-### Invoke-NovaBuild (`nova build`)
-`NovaModuleTools` is designed so that you don't need any additional tools like `make` or `psake` to run the build
-commands. There's no need to maintain complex `build.ps1` files or sample `.psd1` files. Simply follow the structure
-outlined above, and you can run `Invoke-NovaBuild` (`nova build`) to build the module. The output will be saved in the
-`dist` folder, ready for distribution.
-
-If `SetSourcePath` is enabled in `project.json`, `Invoke-NovaBuild` (`nova build`) also annotates the generated `.psm1`
-with `# Source: src/...` comments before each concatenated file block to make debugging easier.
-
-If `Preamble` is present, `Invoke-NovaBuild` writes those lines first, adds one blank line, and then continues with the
-normal generated module content. This keeps module-level initialization explicit while preserving the existing build
-order for classes, public functions, private functions, exports, and resource handling.
+When you are iterating on the module, prefer reloading the built output instead of relying on an older installed copy:
 
 ```powershell
-# From the Module root 
-PS> Invoke-NovaBuild
-
-## Verbose for more details
-PS> Invoke-NovaBuild -Verbose
-
-## Same action through the nova CLI
-nova build
+Remove-Module NovaModuleTools -ErrorAction SilentlyContinue
+Invoke-NovaBuild
+Import-Module ./dist/NovaModuleTools -Force
 ```
 
-### Get-NovaProjectInfo (`nova info` / `nova version`)
+If you are testing local publish behavior, reload after publishing as well:
 
-This function provides complete info about the project, which can be used in Pester tests or for general
-troubleshooting. Use `nova info` for the full project object or `nova version` for a concise
-`<ProjectName> <ProjectVersion>` string.
-
-Use `nova --version` when you want to see the installed `NovaModuleTools` module name and version on the current
-machine as `NovaModuleTools <ModuleVersion>`.
-
-### Test-NovaBuild (`nova test`)
-
-All Pester configuration is stored in `project.json`. Run `Test-NovaBuild` (`nova test`) from the project root. With the
-default
-`BuildRecursiveFolders=true`, it discovers test files in nested folders under `tests`; set `BuildRecursiveFolders=false`
-to run only top-level `tests/*.Tests.ps1` files, matching Pester's normal test-file convention.
-
-- The generated Pester XML report is written to `artifacts/TestResults.xml`.
-- To skip a test inside the test directory, use `-skip` in a `Describe`/`It`/`Context` block within the Pester test.
-- Use `Get-NovaProjectInfo` (`nova info`) inside Pester to get detailed information about the project and files.
-
-### Publish-NovaModule (`nova publish`)
-
-Use `Publish-NovaModule` (`nova publish`) to build, test, and publish in one step.
 ```powershell
-# Publish to your local PowerShell modules path
-PS> Publish-NovaModule -Local
-
-# Publish to a repository
-PS> Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API
-
-# Same action through the nova CLI
-nova publish --local
-
-# Same repository publish through the nova CLI
-nova publish --repository PSGallery --apikey $env:PSGALLERY_API
+Remove-Module NovaModuleTools -ErrorAction SilentlyContinue
+Publish-NovaModule -Local
+Import-Module ./dist/NovaModuleTools -Force
 ```
 
-For local mode, `Publish-NovaModule -Local` (`nova publish --local`) copies the built module directly to your local
-module path.
+## CI/CD and release expectations
 
-> [!TIP]
-> During local development, make sure your shell uses the module you just built (not an older installed copy).
->
-> ```powershell
-> PS> Remove-Module NovaModuleTools -ErrorAction SilentlyContinue
-> PS> Publish-NovaModule -Local
-> PS> Import-Module ./dist/NovaModuleTools -Force
-> ```
+The repository currently uses:
 
-When running from the repository root, build-time schema/resource lookup also falls back to project resources under
-`src/resources`.
+- GitHub Actions under `.github/workflows/`
+- PowerShell CI helper scripts under `scripts/build/ci/`
+- semantic-release orchestration for the publish workflow
 
-### Update-NovaModuleVersion (`nova bump`)
+The current release pipeline does more than version bumping. It coordinates:
 
-Use `Update-NovaModuleVersion` (`nova bump`) to update the version stored in `project.json` based on your Git commit
-history.
+- release version selection
+- `project.json` updates
+- changelog release preparation
+- rebuild after version changes
+- tagging and GitHub release automation
+- PowerShell Gallery publish steps
 
-- breaking changes produce a `Major` bump
-- `feat:` commits produce a `Minor` bump
-- `fix:` commits and all other cases produce a `Patch` bump
+For the release flow details and the role of `package.json`, see `developer-docs/ci-cd-and-release.md`.
 
-Use `nova bump -WhatIf` when you want to preview the exact next version before writing it. The preview returns the same
-`PreviousVersion`, `NewVersion`, `Label`, and `CommitCount` information as a real bump, but it leaves `project.json`
-unchanged.
+## Documentation ownership in the repository
 
-If the current folder is not a Git repository, NovaModuleTools falls back to a patch bump. If the repository exists but
-has no commits yet, `nova bump` stops with: `Cannot bump version because the repository has no commits yet. Create an
-initial commit first.`
+- Keep `docs/NovaModuleTools/en-US/*.md` focused on command help source material
+- Keep GitHub Pages content in `docs/*.html` focused on end-user usage flows
+- Keep contributor guidance in `README.md`, `CONTRIBUTING.md`, and `developer-docs/*.md`
+- Do not reintroduce consumer onboarding into the repository `README.md`
 
-Use `nova bump -Confirm` when you want an interactive CLI confirmation before applying the version bump. If you decline
-or suspend that confirmation, NovaModuleTools returns to your shell without changing `project.json` and without printing
-the version result table.
+## Contributing
 
-## Advanced - Use it in Github Actions
-> [!TIP]
-> This repository uses Github actions to run tests and publish to PowerShell Gallery, use it as reference.
+Start with `CONTRIBUTING.md` and then use the developer docs hub in `developer-docs/README.md`.
 
-This is not required for local module builds. In this repository, GitHub Actions uses `semantic-release` on `main` to determine the next version from conventional commits, update `project.json` and `CHANGELOG.md`, create the `Version_<semver>` tag, create the GitHub release, and then publish the built module to PowerShell Gallery.
+Before opening a pull request, make sure you have:
 
-As part of that prepare step, NovaModuleTools also refreshes the comparison links at the bottom of `CHANGELOG.md` so the
-`[Unreleased]` section and each released version point to the matching GitHub diff view.
-
-If you are running GitHub Actions, use the following yaml workflow template to test, build and publish a module, which helps to automate the process of:
-1. Checking out the repository code.
-1. Installing the `NovaModuleTools` bootstrap module from the PowerShell Gallery.
-1. Building the module.
-1. Running Pester tests.
-1. Running semantic-release to choose the version, update release files, tag, and publish.
-
-This allows for seamless and automated management of your PowerShell module, ensuring consistency and reliability in your build, test, and release processes.
-```yaml
-name: Build, Test and Publish
-
-on:
-  push:
-    branches:
-      - main
-
-permissions:
-  contents: write
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install npm dependencies
-        run: |
-          npm ci
-        shell: pwsh
-
-      - name: Install NovaModuleTools bootstrap module form PSGallery
-        run: |
-          Install-PSResource -Repository PSGallery -Name NovaModuleTools -TrustRepository
-          Install-PSResource -Repository PSGallery -Name Microsoft.PowerShell.PlatyPS -TrustRepository
-          Install-PSResource -Repository PSGallery -Name Pester -TrustRepository
-        shell: pwsh
-
-      - name: Build Module
-        run: Invoke-NovaBuild -Verbose
-        shell: pwsh
-
-      - name: Run Pester Tests
-        run: Test-NovaBuild
-        shell: pwsh
-
-      - name: Run semantic-release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PSGALLERY_API: ${{ secrets.PSGALLERY_API }}
-        run: npx semantic-release
-        shell: pwsh
-```
-
-### Code coverage and CodeScene upload in GitHub Actions
-
-`Tests.yml` now separates testing from CodeScene analysis:
-
-1. `test-and-coverage`
-    - installs the required PowerShell modules
-   - runs `scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
-    - uploads `artifacts/` and `dist/` as workflow artifacts
-2. `codescene-analysis`
-    - downloads the artifacts from the successful test job
-   - can upload `artifacts/pester-coverage.cobertura.xml` to CodeScene as `line-coverage` when `-CoveragePath` is
-     supplied
-   - can also trigger a CodeScene analysis on `push` to `develop`/`main` and on manual runs without uploading coverage
-     by omitting `-CoveragePath`
-
-The analysis step expects these secrets or environment variables:
-
-- `CS_URL`
-- `CS_PROJECT_ID`
-- `CS_ACCESS_TOKEN`
-
-If one of these values is missing, the workflow fails early with a clear error message. If CodeScene rejects the
-analysis trigger because the daily analysis rate limit has been reached, the workflow warns and continues instead of
-failing the pipeline unnecessarily.
-
-## Requirement
-- Only tested on PowerShell 7.4, so it most likely will not work on 5.1. The underlying module can still support older versions; only the NovaModuleTools builder won't work on older versions.
-- No dependencies. This module doesn’t depend on any other module. Completely self-contained.
+- built the module
+- run ScriptAnalyzer
+- run the relevant Pester coverage
+- reviewed help/docs changes
+- updated `CHANGELOG.md` when the change is user-visible or contributor-relevant
 
 ## License
-This project is licensed under the MIT License. See the LICENSE file for details.
+
+This project is licensed under the MIT License. See `LICENSE` for details.
 
 [BadgeIOCount]: https://img.shields.io/powershellgallery/dt/NovaModuleTools?label=NovaModuleTools%40PowerShell%20Gallery
 [PSGalleryLink]: https://www.powershellgallery.com/packages/NovaModuleTools/

--- a/developer-docs/README.md
+++ b/developer-docs/README.md
@@ -4,16 +4,25 @@ This folder is the developer-side documentation hub for the NovaModuleTools repo
 
 Use these documents when you are changing the module, tests, workflows, or release automation.
 
+## Navigation
+
+- [Contributor entry page](../README.md)
+- [Contribution guide](../CONTRIBUTING.md)
+- [Development workflow](./development-workflow.md)
+- [Repository structure](./repository-structure.md)
+- [CI/CD and release automation](./ci-cd-and-release.md)
+
 ## Start here
 
-- `../README.md` — contributor entry point and local workflow summary
-- `../CONTRIBUTING.md` — contribution expectations and review checklist
+- [`../README.md`](../README.md) — contributor entry point and local workflow summary
+- [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — contribution expectations and review checklist
 
 ## Developer guides
 
-- `development-workflow.md` — local setup, build, test, reload, and quality loop
-- `repository-structure.md` — top-level architecture and ownership of major folders
-- `ci-cd-and-release.md` — CI jobs, release automation, semantic-release, and publish flow responsibilities
+- [`development-workflow.md`](./development-workflow.md) — local setup, build, test, reload, and quality loop
+- [`repository-structure.md`](./repository-structure.md) — top-level architecture and ownership of major folders
+- [`ci-cd-and-release.md`](./ci-cd-and-release.md) — CI jobs, release automation, semantic-release, and publish flow
+  responsibilities
 
 ## Documentation ownership rules
 

--- a/developer-docs/README.md
+++ b/developer-docs/README.md
@@ -14,14 +14,14 @@ Use these documents when you are changing the module, tests, workflows, or relea
 
 ## Start here
 
-- [`../README.md`](../README.md) — contributor entry point and local workflow summary
-- [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — contribution expectations and review checklist
+- [../README.md](../README.md) — contributor entry point and local workflow summary
+- [../CONTRIBUTING.md](../CONTRIBUTING.md) — contribution expectations and review checklist
 
 ## Developer guides
 
-- [`development-workflow.md`](./development-workflow.md) — local setup, build, test, reload, and quality loop
-- [`repository-structure.md`](./repository-structure.md) — top-level architecture and ownership of major folders
-- [`ci-cd-and-release.md`](./ci-cd-and-release.md) — CI jobs, release automation, semantic-release, and publish flow
+- [development-workflow.md](./development-workflow.md) — local setup, build, test, reload, and quality loop
+- [repository-structure.md](./repository-structure.md) — top-level architecture and ownership of major folders
+- [ci-cd-and-release.md](./ci-cd-and-release.md) — CI jobs, release automation, semantic-release, and publish flow
   responsibilities
 
 ## Documentation ownership rules

--- a/developer-docs/README.md
+++ b/developer-docs/README.md
@@ -1,0 +1,28 @@
+# Developer documentation
+
+This folder is the developer-side documentation hub for the NovaModuleTools repository.
+
+Use these documents when you are changing the module, tests, workflows, or release automation.
+
+## Start here
+
+- `../README.md` — contributor entry point and local workflow summary
+- `../CONTRIBUTING.md` — contribution expectations and review checklist
+
+## Developer guides
+
+- `development-workflow.md` — local setup, build, test, reload, and quality loop
+- `repository-structure.md` — top-level architecture and ownership of major folders
+- `ci-cd-and-release.md` — CI jobs, release automation, semantic-release, and publish flow responsibilities
+
+## Documentation ownership rules
+
+Use this folder when the topic answers questions like:
+
+- How do I work on NovaModuleTools itself?
+- How do I build and test changes safely?
+- How is the repository structured internally?
+- How do CI and release automation fit together?
+
+Do **not** use this folder for end-user onboarding or task guides. Those belong on GitHub Pages under `docs/*.html`.
+

--- a/developer-docs/ci-cd-and-release.md
+++ b/developer-docs/ci-cd-and-release.md
@@ -2,6 +2,13 @@
 
 This guide describes the current repository automation used to validate and publish NovaModuleTools.
 
+## See also
+
+- [Developer docs hub](./README.md)
+- [Contribution guide](../CONTRIBUTING.md)
+- [Development workflow](./development-workflow.md)
+- [Repository structure](./repository-structure.md)
+
 ## CI expectations
 
 The repository uses GitHub Actions under `.github/workflows/`.

--- a/developer-docs/ci-cd-and-release.md
+++ b/developer-docs/ci-cd-and-release.md
@@ -1,0 +1,73 @@
+# CI/CD and release automation
+
+This guide describes the current repository automation used to validate and publish NovaModuleTools.
+
+## CI expectations
+
+The repository uses GitHub Actions under `.github/workflows/`.
+
+At a minimum, contributor changes are expected to keep these workflows healthy:
+
+- build
+- test
+- analyzer / coverage
+- publish/release automation
+
+Repository scripts under `scripts/build/ci/` provide local parity for CI-oriented reporting.
+
+## Build and test automation
+
+The normal repository workflow is:
+
+1. `Invoke-NovaBuild`
+2. `Test-NovaBuild`
+3. ScriptAnalyzer via `scripts/build/Invoke-ScriptAnalyzerCI.ps1`
+4. Optional CI helper flow via `scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
+
+The CI helper flow also produces JUnit and Cobertura artifacts for external systems.
+
+## Release automation
+
+The current publish pipeline is still semantic-release based.
+
+Key pieces:
+
+- `.github/workflows/Publish.yml`
+- `.releaserc.json`
+- `package.json`
+- `scripts/release/Prepare-SemanticRelease.ps1`
+- `scripts/release/Publish-ToPSGallery.ps1`
+- `scripts/release/SemanticReleaseSupport.ps1`
+
+Responsibilities currently covered by the release pipeline include:
+
+- choosing the next release version from commit history
+- updating `project.json`
+- finalizing `CHANGELOG.md`
+- rebuilding after version changes
+- creating release tags
+- creating GitHub releases
+- publishing to PowerShell Gallery
+
+## Where NovaModuleTools cmdlets fit
+
+NovaModuleTools already provides strong release building blocks:
+
+- `Update-NovaModuleVersion`
+- `Publish-NovaModule`
+- `Invoke-NovaRelease`
+
+But these do not yet replace every semantic-release responsibility in the current repository workflow.
+
+If you work on release automation, treat `package.json` and `.releaserc.json` as active parts of the present release
+system.
+
+## Contributor expectations
+
+When you change CI, build, or release behavior:
+
+- update tests
+- update command help if public command behavior changes
+- update `README.md` / `developer-docs/` when contributor workflow changes
+- update `CHANGELOG.md` when the change is relevant to users or maintainers
+

--- a/developer-docs/development-workflow.md
+++ b/developer-docs/development-workflow.md
@@ -1,0 +1,135 @@
+# Development workflow
+
+This guide describes how to work on the NovaModuleTools repository itself.
+
+## Prerequisites
+
+Repository development expects:
+
+- PowerShell 7.4 or newer
+- Git
+- `Pester`
+- `PSScriptAnalyzer`
+- `Microsoft.PowerShell.PlatyPS`
+
+Node.js is only required if you are working on the current semantic-release based publish pipeline.
+
+## Build the module locally
+
+From the repository root:
+
+```powershell
+Set-Location $PSScriptRoot
+Invoke-NovaBuild
+```
+
+This creates the built module under `dist/NovaModuleTools/`.
+
+## Reload the built module while iterating
+
+Use the built output during development so you validate the same shape CI uses:
+
+```powershell
+Remove-Module NovaModuleTools -ErrorAction SilentlyContinue
+Invoke-NovaBuild
+Import-Module ./dist/NovaModuleTools -Force
+```
+
+If you are testing local publish behavior:
+
+```powershell
+Remove-Module NovaModuleTools -ErrorAction SilentlyContinue
+Publish-NovaModule -Local
+Import-Module ./dist/NovaModuleTools -Force
+```
+
+## Run tests
+
+Run the repository test workflow from the repository root:
+
+```powershell
+Test-NovaBuild
+```
+
+Notes:
+
+- `Test-NovaBuild` validates the built module output, not just loose source files
+- it writes NUnit XML to `artifacts/TestResults.xml`
+- it respects `BuildRecursiveFolders` when discovering tests
+
+## Run code quality checks
+
+Run ScriptAnalyzer with the repository helper:
+
+```powershell
+& ./scripts/build/Invoke-ScriptAnalyzerCI.ps1
+```
+
+This writes findings to `artifacts/scriptanalyzer.txt`.
+
+For CI-parity coverage and report generation, use:
+
+```powershell
+& ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1
+```
+
+That flow builds the module, runs ScriptAnalyzer, runs the normal test workflow, and emits CI-friendly reports such as:
+
+- `artifacts/novamoduletools-nunit.xml`
+- `artifacts/pester-junit.xml`
+- `artifacts/pester-coverage.cobertura.xml`
+- `artifacts/coverage-low.txt`
+
+## Recommended local quality loop
+
+```powershell
+#run.ps1
+Set-Location $PSScriptRoot
+
+$projectName = (Get-Content -LiteralPath (Join-Path $PSScriptRoot 'project.json') -Raw | ConvertFrom-Json).ProjectName
+$distModuleDir = Join-Path $PSScriptRoot "dist/$projectName"
+
+Invoke-NovaBuild
+& (Join-Path $PSScriptRoot 'scripts/build/Invoke-ScriptAnalyzerCI.ps1')
+Remove-Module $projectName -ErrorAction SilentlyContinue
+Import-Module $distModuleDir -Force
+Test-NovaBuild
+```
+
+```powershell
+#reload.ps1
+Set-Location $PSScriptRoot
+
+$projectName = (Get-Content -LiteralPath (Join-Path $PSScriptRoot 'project.json') -Raw | ConvertFrom-Json).ProjectName
+$distModuleDir = Join-Path $PSScriptRoot "dist/$projectName"
+$distManifestPath = Join-Path $distModuleDir "$projectName.psd1"
+
+Get-Module $projectName -All | Remove-Module -Force -ErrorAction SilentlyContinue
+Invoke-NovaBuild
+Get-Module $projectName -All | Remove-Module -Force -ErrorAction SilentlyContinue
+$module = Import-Module $distManifestPath -Force -PassThru
+
+& $module {
+    Publish-NovaModule -Local
+}
+
+Get-Module $projectName -All | Remove-Module -Force -ErrorAction SilentlyContinue
+$module = Import-Module $distManifestPath -Force -PassThru
+
+& $module {
+    Install-NovaCli -Force
+}
+```
+
+## Working on help and docs
+
+Command help markdown lives under `docs/NovaModuleTools/en-US/` and is consumed by `Invoke-NovaBuild`.
+
+Important distinction:
+
+- `docs/NovaModuleTools/en-US/*.md` → PlatyPS command-help source
+- `docs/*.html` → GitHub Pages end-user guides
+- `developer-docs/*.md` → contributor documentation
+
+Do not place general developer markdown under `docs/`, because the build scans `docs/**/*.md` when generating help.
+

--- a/developer-docs/development-workflow.md
+++ b/developer-docs/development-workflow.md
@@ -43,6 +43,32 @@ Publish-NovaModule -Local
 Import-Module ./dist/NovaModuleTools -Force
 ```
 
+```powershell title="reload.ps1"
+#reload.ps1
+Set-Location $PSScriptRoot
+
+$projectName = (Get-Content -LiteralPath (Join-Path $PSScriptRoot 'project.json') -Raw | ConvertFrom-Json).ProjectName
+$distModuleDir = Join-Path $PSScriptRoot "dist/$projectName"
+$distManifestPath = Join-Path $distModuleDir "$projectName.psd1"
+
+Get-Module $projectName -All | Remove-Module -Force -ErrorAction SilentlyContinue
+Invoke-NovaBuild
+Get-Module $projectName -All | Remove-Module -Force -ErrorAction SilentlyContinue
+$module = Import-Module $distManifestPath -Force -PassThru
+
+& $module {
+    Publish-NovaModule -Local
+}
+
+Get-Module $projectName -All | Remove-Module -Force -ErrorAction SilentlyContinue
+$module = Import-Module $distManifestPath -Force -PassThru
+
+#Only use Install-NovaCli for macOS/Linux users.
+#& $module {
+#    Install-NovaCli -Force
+#}
+```
+
 ## Run tests
 
 Run the repository test workflow from the repository root:

--- a/developer-docs/development-workflow.md
+++ b/developer-docs/development-workflow.md
@@ -2,6 +2,13 @@
 
 This guide describes how to work on the NovaModuleTools repository itself.
 
+## See also
+
+- [Developer docs hub](./README.md)
+- [Contribution guide](../CONTRIBUTING.md)
+- [Repository structure](./repository-structure.md)
+- [CI/CD and release automation](./ci-cd-and-release.md)
+
 ## Prerequisites
 
 Repository development expects:

--- a/developer-docs/repository-structure.md
+++ b/developer-docs/repository-structure.md
@@ -1,0 +1,102 @@
+# Repository structure
+
+This guide explains how the NovaModuleTools repository is organized and what each major area owns.
+
+## Top-level overview
+
+```text
+.
+├── .github/                     # GitHub Actions workflows
+├── developer-docs/             # contributor-focused documentation
+├── docs/                       # GitHub Pages HTML + PlatyPS help markdown
+├── scripts/                    # build, CI, and release automation
+├── src/                        # production PowerShell code and packaged resources
+├── tests/                      # Pester suites and reusable test helpers
+├── project.json                # NovaModuleTools project definition
+├── package.json                # semantic-release tooling for current publish automation
+└── CHANGELOG.md                # release notes and unreleased change tracking
+```
+
+## Source code layout
+
+### `src/public/`
+
+Public cmdlets that make up the NovaModuleTools API surface, for example:
+
+- `Invoke-NovaBuild`
+- `Test-NovaBuild`
+- `New-NovaModule`
+- `Update-NovaModuleVersion`
+
+### `src/private/`
+
+Internal implementation helpers grouped by concern, including:
+
+- `build/`
+- `cli/`
+- `quality/`
+- `release/`
+- `scaffold/`
+- `shared/`
+
+Keep new helpers small, focused, and near the concern they belong to.
+
+### `src/resources/`
+
+Packaged resources that ship with the module, including:
+
+- schemas
+- the standalone `nova` launcher
+- the packaged example project under `src/resources/example/`
+
+The example project is both a shipped resource and a maintained working reference.
+
+## Test layout
+
+### `tests/`
+
+Repository-level Pester coverage for:
+
+- public command behavior
+- internal helper behavior
+- build and packaging expectations
+- CI/report generation flows
+
+Shared test utilities live alongside the tests, for example:
+
+- `GitTestSupport.ps1`
+- `BuildOptions.TestSupport.ps1`
+- `NovaCommandModel.TestSupport.ps1`
+
+## Documentation layout
+
+### `README.md` and `CONTRIBUTING.md`
+
+These are the top-level GitHub entry points for contributors and maintainers.
+
+### `developer-docs/`
+
+Structured contributor documentation for repository workflows, architecture, and CI/release behavior.
+
+### `docs/`
+
+This folder has two different responsibilities that must stay separated by file type:
+
+- `docs/*.html` → GitHub Pages end-user guides
+- `docs/NovaModuleTools/en-US/*.md` → PlatyPS command-help source
+
+The build treats markdown under `docs/` as help input, so general-purpose markdown docs should not be added here.
+
+## Scripts and automation
+
+### `scripts/build/`
+
+Build, analyzer, and CI helper scripts.
+
+### `scripts/release/`
+
+Release preparation and publish helpers used by the current release workflow.
+
+These scripts are currently part of a wider GitHub Actions + semantic-release pipeline, not a standalone replacement for
+it.
+

--- a/developer-docs/repository-structure.md
+++ b/developer-docs/repository-structure.md
@@ -6,7 +6,7 @@ This guide explains how the NovaModuleTools repository is organized and what eac
 
 ```text
 .
-├── .github/                     # GitHub Actions workflows
+├── .github/                    # GitHub Actions workflows
 ├── developer-docs/             # contributor-focused documentation
 ├── docs/                       # GitHub Pages HTML + PlatyPS help markdown
 ├── scripts/                    # build, CI, and release automation

--- a/developer-docs/repository-structure.md
+++ b/developer-docs/repository-structure.md
@@ -2,6 +2,13 @@
 
 This guide explains how the NovaModuleTools repository is organized and what each major area owns.
 
+## See also
+
+- [Developer docs hub](./README.md)
+- [Contribution guide](../CONTRIBUTING.md)
+- [Development workflow](./development-workflow.md)
+- [CI/CD and release automation](./ci-cd-and-release.md)
+
 ## Top-level overview
 
 ```text
@@ -70,11 +77,11 @@ Shared test utilities live alongside the tests, for example:
 
 ## Documentation layout
 
-### `README.md` and `CONTRIBUTING.md`
+### [`README.md`](../README.md) and [`CONTRIBUTING.md`](../CONTRIBUTING.md)
 
 These are the top-level GitHub entry points for contributors and maintainers.
 
-### `developer-docs/`
+### [`developer-docs/`](./README.md)
 
 Structured contributor documentation for repository workflows, architecture, and CI/release behavior.
 

--- a/developer-docs/repository-structure.md
+++ b/developer-docs/repository-structure.md
@@ -77,11 +77,11 @@ Shared test utilities live alongside the tests, for example:
 
 ## Documentation layout
 
-### [`README.md`](../README.md) and [`CONTRIBUTING.md`](../CONTRIBUTING.md)
+### [README.md](../README.md) and [CONTRIBUTING.md](../CONTRIBUTING.md)
 
 These are the top-level GitHub entry points for contributors and maintainers.
 
-### [`developer-docs/`](./README.md)
+### [developer-docs/](./README.md)
 
 Structured contributor documentation for repository workflows, architecture, and CI/release behavior.
 

--- a/docs/advanced.html
+++ b/docs/advanced.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1" name="viewport">
+    <title>NovaModuleTools — Advanced Usage</title>
+    <meta content="Go beyond the default NovaModuleTools workflow with CI/CD integration, versioning expectations, and project.json customization."
+          name="description">
+    <link href="./assets/site.css" rel="stylesheet">
+</head>
+<body>
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-brand" href="./index.html">NovaModuleTools</a>
+        <nav aria-label="Primary" class="site-nav">
+            <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
+            <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
+            <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+            <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
+            <a class="site-nav__link site-nav__link--active" href="./advanced.html">Advanced</a>
+        </nav>
+    </div>
+</header>
+
+<main class="page-shell">
+    <section class="guide-hero">
+        <p class="eyebrow">Advanced usage</p>
+        <h1>Adapt NovaModuleTools to larger workflows and more opinionated module projects</h1>
+        <p class="lead">Use these advanced options when you want to integrate NovaModuleTools into CI/CD or customize
+            how projects are built and tested.</p>
+    </section>
+
+    <section class="guide-content guide-content--single">
+        <section class="content-section">
+            <h2>Use the CLI or the PowerShell cmdlets directly</h2>
+            <p>Every core workflow is available both as a PowerShell command or <code>nova</code> alias, and through the
+                <code>nova</code> CLI surface. Choose the interface that fits your environment best.</p>
+        </section>
+
+        <section class="content-section">
+            <h2>Versioning behavior depends on commit history</h2>
+            <p><code>nova bump</code> reads Git history, not just <code>project.json</code>. If you want predictable
+                release automation, keep your commit messages intentional and make sure release jobs run in repositories
+                with full history and tags available.</p>
+        </section>
+
+        <section class="content-section">
+            <h2>Useful <code>project.json</code> settings</h2>
+            <ul class="plain-list">
+                <li><strong><code>BuildRecursiveFolders</code></strong> — switch recursive discovery on or off for
+                    classes, private helpers, and tests
+                </li>
+                <li><strong><code>SetSourcePath</code></strong> — write source markers into the generated module to help
+                    debug parser and runtime issues
+                </li>
+                <li><strong><code>Preamble</code></strong> — add module-level setup lines before generated source
+                    content
+                </li>
+                <li><strong><code>FailOnDuplicateFunctionNames</code></strong> — fail the build if duplicate top-level
+                    function names are emitted
+                </li>
+                <li><strong><code>CopyResourcesToModuleRoot</code></strong> — copy resources directly into the built
+                    module root instead of a nested <code>resources/</code> folder
+                </li>
+            </ul>
+        </section>
+
+        <section class="content-section">
+            <h2>CI/CD integration</h2>
+            <p>NovaModuleTools works well in build pipelines that follow the normal order:</p>
+            <ol class="plain-list plain-list--ordered">
+                <li>build the module</li>
+                <li>run tests</li>
+                <li>publish artifacts or release</li>
+            </ol>
+            <p>If your CI system needs standard report formats, generate JUnit and Cobertura outputs as part of the
+                NovaModuleTools workflow rather than reinventing test-report conversion yourself.</p>
+        </section>
+
+        <section class="content-section">
+            <h2>Use local publish before repository publish</h2>
+            <p>When you change manifest, resources, or module loading behavior, validate with local publish first:</p>
+            <pre><code>nova publish -local</code></pre>
+            <p>This helps catch packaging issues before a real repository publish or release run.</p>
+        </section>
+    </section>
+</main>
+</body>
+</html>
+

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -32,6 +32,56 @@ body {
         linear-gradient(180deg, #0b1020 0%, #0f1731 48%, #0d1327 100%);
 }
 
+a {
+    color: inherit;
+}
+
+.site-header {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    backdrop-filter: blur(16px);
+    background: rgba(11, 16, 32, 0.78);
+    border-bottom: 1px solid var(--outline);
+}
+
+.site-header__inner {
+    max-width: var(--max-width);
+    margin: 0 auto;
+    padding: 0.95rem 1.5rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.site-brand {
+    text-decoration: none;
+    font-weight: 800;
+    letter-spacing: 0.02em;
+}
+
+.site-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.site-nav__link {
+    text-decoration: none;
+    color: var(--muted);
+    padding: 0.45rem 0.85rem;
+    border-radius: 999px;
+    border: 1px solid transparent;
+}
+
+.site-nav__link:hover,
+.site-nav__link--active {
+    color: var(--text);
+    border-color: var(--outline);
+    background: rgba(255, 255, 255, 0.06);
+}
+
 code,
 pre {
     font-family: "SFMono-Regular", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -71,6 +121,89 @@ pre code {
     grid-template-columns: 1.15fr 0.85fr;
     gap: 2rem;
     align-items: center;
+}
+
+.page-shell {
+    max-width: var(--max-width);
+    margin: 0 auto;
+    padding: 2.5rem 1.5rem 5rem;
+}
+
+.guide-hero {
+    margin-bottom: 2rem;
+}
+
+.content-grid {
+    display: grid;
+    grid-template-columns: 280px minmax(0, 1fr);
+    gap: 1.5rem;
+    align-items: start;
+}
+
+.guide-content {
+    display: grid;
+    gap: 1.25rem;
+}
+
+.guide-content--single {
+    max-width: 820px;
+}
+
+.toc-card,
+.content-section {
+    background: var(--panel);
+    border: 1px solid var(--outline);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    backdrop-filter: blur(12px);
+}
+
+.toc-card {
+    padding: 1.15rem;
+    position: sticky;
+    top: 5.75rem;
+}
+
+.toc-list,
+.link-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.65rem;
+}
+
+.toc-list a,
+.text-link {
+    color: var(--accent);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.text-link:hover,
+.toc-list a:hover {
+    text-decoration: underline;
+}
+
+.content-section {
+    padding: 1.35rem;
+}
+
+.guide-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1.1rem;
+}
+
+.guide-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.9rem;
+    margin-top: 1rem;
+}
+
+.plain-list--ordered {
+    list-style: decimal;
 }
 
 .hero__content,
@@ -322,14 +455,26 @@ p {
 }
 
 @media (max-width: 960px) {
+    .site-header__inner,
     .hero,
     .split,
     .card-grid,
     .steps,
-    .cta-banner {
+    .cta-banner,
+    .content-grid,
+    .guide-grid {
         grid-template-columns: 1fr;
         flex-direction: column;
         align-items: stretch;
+    }
+
+    .site-header__inner {
+        padding-top: 0.9rem;
+        padding-bottom: 0.9rem;
+    }
+
+    .toc-card {
+        position: static;
     }
 
     .hero {
@@ -349,8 +494,14 @@ p {
     }
 
     .hero,
+    .page-shell,
     .section,
     .footer {
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
+
+    .site-header__inner {
         padding-left: 1rem;
         padding-right: 1rem;
     }

--- a/docs/core-workflows.html
+++ b/docs/core-workflows.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1" name="viewport">
+    <title>NovaModuleTools — Core Workflows</title>
+    <meta content="Follow the normal NovaModuleTools workflow for scaffolding, building, testing, versioning, and releasing a PowerShell module."
+          name="description">
+    <link href="./assets/site.css" rel="stylesheet">
+</head>
+<body>
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-brand" href="./index.html">NovaModuleTools</a>
+        <nav aria-label="Primary" class="site-nav">
+            <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
+            <a class="site-nav__link site-nav__link--active" href="./core-workflows.html">Core Workflows</a>
+            <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+            <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
+            <a class="site-nav__link" href="./advanced.html">Advanced</a>
+        </nav>
+    </div>
+</header>
+
+<main class="page-shell">
+    <section class="guide-hero">
+        <p class="eyebrow">Core workflows</p>
+        <h1>Use NovaModuleTools as a repeatable scaffold → build → test → bump → release flow</h1>
+        <p class="lead">This guide explains the normal command sequence for day-to-day module work.</p>
+    </section>
+
+    <section class="content-grid">
+        <aside class="toc-card">
+            <h2>On this page</h2>
+            <ul class="toc-list">
+                <li><a href="#scaffold">Scaffold</a></li>
+                <li><a href="#build">Build</a></li>
+                <li><a href="#test">Test</a></li>
+                <li><a href="#bump">Version bump</a></li>
+                <li><a href="#release">Release</a></li>
+            </ul>
+        </aside>
+
+        <div class="guide-content">
+            <section class="content-section" id="scaffold">
+                <h2>Create a project scaffold</h2>
+                <pre><code>nova init
+nova init -Path ~/Work
+nova init -Example</code></pre>
+                <p>Use the default scaffold when you want a clean starting point. Use <code>-Example</code> when you
+                    want a complete working reference project.</p>
+            </section>
+
+            <section class="content-section" id="build">
+                <h2>Build the module</h2>
+                <pre><code>nova build</code></pre>
+                <p>The build combines your source files into a real PowerShell module under <code>dist/&lt;ProjectName&gt;</code>.
+                </p>
+                <p>Use the built output when validating import, test, and publish behavior.</p>
+            </section>
+
+            <section class="content-section" id="test">
+                <h2>Test the built result</h2>
+                <pre><code>nova test</code></pre>
+                <p>NovaModuleTools runs Pester against the project test suite and writes test results for the workflow
+                    under <code>artifacts/TestResults.xml</code>.</p>
+                <p>If your project uses nested test folders, discovery follows the <code>BuildRecursiveFolders</code>
+                    setting in <code>project.json</code>.</p>
+            </section>
+
+            <section class="content-section" id="bump">
+                <h2>Update the project version</h2>
+                <pre><code>nova bump
+nova bump -WhatIf</code></pre>
+                <p>NovaModuleTools chooses the bump label from your Git commit history:</p>
+                <ul class="plain-list">
+                    <li>breaking change → <strong>Major</strong></li>
+                    <li><code>feat:</code> → <strong>Minor</strong></li>
+                    <li><code>fix:</code> and other commit types → <strong>Patch</strong></li>
+                </ul>
+                <p>If the current folder is not a Git repository, NovaModuleTools falls back to a patch bump. If the
+                    repository exists but has no commits yet, create the first commit before running <code>nova
+                        bump</code>.</p>
+            </section>
+
+            <section class="content-section" id="release">
+                <h2>Run the release workflow</h2>
+                <pre><code>nova release -local
+nova release -repository PSGallery -apikey $env:PSGALLERY_API</code></pre>
+                <p>The release flow coordinates build, test, version bump, rebuild, and publish. Use local mode when you
+                    want to validate the release path without pushing to a repository.</p>
+            </section>
+        </div>
+    </section>
+</main>
+</body>
+</html>
+

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1" name="viewport">
+    <title>NovaModuleTools — Getting Started</title>
+    <meta content="Install NovaModuleTools, import the module, add the optional nova launcher, and create your first project with a guided setup path."
+          name="description">
+    <link href="./assets/site.css" rel="stylesheet">
+</head>
+<body>
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-brand" href="./index.html">NovaModuleTools</a>
+        <nav aria-label="Primary" class="site-nav">
+            <a class="site-nav__link site-nav__link--active" href="./getting-started.html">Getting Started</a>
+            <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
+            <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+            <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
+            <a class="site-nav__link" href="./advanced.html">Advanced</a>
+        </nav>
+    </div>
+</header>
+
+<main class="page-shell">
+    <section class="guide-hero">
+        <p class="eyebrow">Getting started</p>
+        <h1>Install NovaModuleTools and create your first project</h1>
+        <p class="lead">This guide takes you from installation to a working project scaffold.</p>
+    </section>
+
+    <section class="content-grid">
+        <aside class="toc-card">
+            <h2>On this page</h2>
+            <ul class="toc-list">
+                <li><a href="#install">1. Install the module</a></li>
+                <li><a href="#launcher">2. Optional CLI launcher</a></li>
+                <li><a href="#first-project">3. Create your first project</a></li>
+                <li><a href="#example-project">4. Start from the example</a></li>
+                <li><a href="#next-step">5. What to do next</a></li>
+            </ul>
+        </aside>
+
+        <div class="guide-content">
+            <section class="content-section" id="install">
+                <h2>1. Install the module</h2>
+                <p>Install NovaModuleTools from the PowerShell Gallery and load it into your session:</p>
+                <pre><code>Install-Module -Name NovaModuleTools
+Import-Module NovaModuleTools</code></pre>
+                <p>After import, you can use the PowerShell cmdlets directly, and the <code>nova</code> alias is also
+                    available inside PowerShell.</p>
+            </section>
+
+            <section class="content-section" id="launcher">
+                <h2>2. Optional CLI launcher for macOS and Linux</h2>
+                <p>If you want to run <code>nova</code> directly from your shell instead of from inside PowerShell,
+                    install the launcher:</p>
+                <pre><code>Install-NovaCli</code></pre>
+                <p>The launcher is copied to <code>~/.local/bin/nova</code> by default. If that folder is not on your
+                    shell path yet, add it:</p>
+                <pre><code>echo 'export PATH="$HOME/.local/bin:$PATH"' &gt;&gt; ~/.zshrc
+source ~/.zshrc</code></pre>
+                <p>On Windows, keep using the <code>nova</code> alias inside PowerShell after importing the module.</p>
+            </section>
+
+            <section class="content-section" id="first-project">
+                <h2>3. Create your first project</h2>
+                <p>The normal entry point is the scaffold flow:</p>
+                <pre><code>nova init</code></pre>
+                <p>If you want to create the project under a specific parent folder, make the destination explicit:</p>
+                <pre><code>nova init -Path ~/Work</code></pre>
+                <p>NovaModuleTools will ask for:</p>
+                <ul class="plain-list">
+                    <li>module name</li>
+                    <li>description</li>
+                    <li>starting semantic version</li>
+                    <li>author name</li>
+                    <li>minimum PowerShell version</li>
+                    <li>whether Git should be initialized</li>
+                </ul>
+                <p>When the prompts finish, you get a project folder with <code>src/</code>, <code>tests/</code> (if
+                    enabled), and <code>project.json</code>.</p>
+            </section>
+
+            <section class="content-section" id="example-project">
+                <h2>4. Start from the packaged example when you want a working reference</h2>
+                <p>If you would rather inspect a complete example than start from a minimal scaffold, use:</p>
+                <pre><code>nova init -Example
+nova init -Example -Path ~/Work</code></pre>
+                <p>This creates a project from the packaged example template, including source files, a resource file,
+                    and tests. The interactive prompt still applies your own project name, description, version, author,
+                    and PowerShell version.</p>
+            </section>
+
+            <section class="content-section" id="next-step">
+                <h2>5. What to do next</h2>
+                <p>After your project exists, continue with the workflow guides:</p>
+                <div class="guide-links">
+                    <a class="button button--primary" href="./core-workflows.html">Go to Core Workflows</a>
+                    <a class="button button--secondary" href="./working-with-modules.html">Learn how to import and
+                        reload modules</a>
+                </div>
+            </section>
+        </div>
+    </section>
+</main>
+</body>
+</html>
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,48 +3,58 @@
 <head>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
-    <title>NovaModuleTools — Build consistent, well-structured PowerShell modules</title>
-    <meta content="NovaModuleTools helps developers create consistent, correctly structured PowerShell modules with less guesswork and a smoother path from scaffold to build, test, and publish."
+    <title>NovaModuleTools — Guided PowerShell module workflows</title>
+    <meta content="NovaModuleTools helps you scaffold, build, test, version, and release PowerShell modules through a guided workflow."
           name="description">
     <link href="./assets/site.css" rel="stylesheet">
 </head>
 <body>
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-brand" href="./index.html">NovaModuleTools</a>
+        <nav aria-label="Primary" class="site-nav">
+            <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
+            <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
+            <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+            <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
+            <a class="site-nav__link" href="./advanced.html">Advanced</a>
+        </nav>
+    </div>
+</header>
+
 <header class="hero">
     <div class="hero__content">
         <p class="eyebrow">NovaModuleTools for end users</p>
-        <h1>Build consistent, correctly structured PowerShell modules without reinventing the workflow</h1>
+        <h1>Build PowerShell modules with a guided scaffold, build, test, and release workflow</h1>
         <p class="lead">
-            NovaModuleTools gives you a practical starting point for PowerShell module development: scaffold a project,
-            follow a clear folder structure, build a distributable module, and run tests with a repeatable workflow.
+            NovaModuleTools gives you a repeatable path from a new project to a built module in <code>dist/</code>, with
+            testing, versioning, and release commands that work together as one flow.
         </p>
         <div class="hero__actions">
-            <a class="button button--primary"
-               href="https://github.com/stiwicourage/NovaModuleTools/blob/main/README.md">Read the quick start</a>
-            <a class="button button--secondary"
-               href="https://github.com/stiwicourage/NovaModuleTools/tree/main/src/resources/example">Open the working
-                example</a>
+            <a class="button button--primary" href="./getting-started.html">Start with installation and setup</a>
+            <a class="button button--secondary" href="./core-workflows.html">See the full workflow</a>
         </div>
         <ul class="hero__signals">
             <li>Clear project structure</li>
-            <li>Fast scaffold-to-build workflow</li>
-            <li>Beginner-friendly path into PowerShell modules</li>
+            <li>Practical CLI and PowerShell workflow</li>
+            <li>Guided path from first scaffold to release</li>
         </ul>
     </div>
     <div aria-label="Nova workflow summary" class="hero__panel">
         <div class="panel-card">
             <span class="panel-step">1</span>
-            <strong>Scaffold</strong>
-            <p>Start with <code>nova init</code> or <code>PS&gt; New-NovaModule</code>.</p>
+            <strong>Install</strong>
+            <p>Install from the PowerShell Gallery and optionally add the shell launcher.</p>
         </div>
         <div class="panel-card">
             <span class="panel-step">2</span>
-            <strong>Build</strong>
-            <p>Turn your source files into a real module with <code>nova build</code>.</p>
+            <strong>Scaffold</strong>
+            <p>Create a new project with <code>nova init</code> or use the full example workflow.</p>
         </div>
         <div class="panel-card">
             <span class="panel-step">3</span>
-            <strong>Test</strong>
-            <p>Run <code>nova test</code> and validate the built result, not just loose scripts.</p>
+            <strong>Build and test</strong>
+            <p>Generate the module in <code>dist/</code> and validate the built result with Pester.</p>
         </div>
     </div>
 </header>
@@ -52,15 +62,10 @@
 <main>
     <section class="section section--muted">
         <div class="section__inner narrow">
-            <h2>Who NovaModuleTools is for</h2>
+            <h2>Use this site as your user guide</h2>
             <p>
-                NovaModuleTools is for developers who want to create PowerShell modules with a clear, repeatable
-                structure — especially if they do <strong>not</strong> already feel confident about PowerShell module
-                layout, build flow, or best practices.
-            </p>
-            <p>
-                It is designed to give you a simpler path from idea to working module, without needing deep PowerShell
-                module knowledge on day one.
+                This documentation is intentionally task-oriented. Each page helps you complete a real NovaModuleTools
+                workflow without needing to read repository documentation first.
             </p>
         </div>
     </section>
@@ -68,32 +73,34 @@
     <section class="section">
         <div class="section__inner">
             <div class="section-heading">
-                <h2>Why developers use NovaModuleTools</h2>
-                <p>
-                    Most PowerShell module problems do not start with the business logic. They start with inconsistent
-                    structure, unclear conventions, ad-hoc packaging, and test flows that are hard to repeat.
-                </p>
+                <h2>Choose your next step</h2>
+                <p>Start where you are right now and move forward one workflow at a time.</p>
             </div>
-            <div class="card-grid">
+            <div class="guide-grid">
                 <article class="info-card">
-                    <h3>Reduce guesswork</h3>
-                    <p>Use a known layout for public functions, private helpers, classes, resources, tests, and
-                        output.</p>
+                    <h3>Getting Started</h3>
+                    <p>Install the module, add the optional CLI launcher, and create your first project.</p>
+                    <a class="text-link" href="./getting-started.html">Open guide</a>
                 </article>
                 <article class="info-card">
-                    <h3>Build with confidence</h3>
-                    <p>Generate a real module in <code>dist/</code> so you can validate the same shape you plan to
-                        publish.</p>
+                    <h3>Core Workflows</h3>
+                    <p>Follow the normal <code>init → build → test → bump → release</code> flow.</p>
+                    <a class="text-link" href="./core-workflows.html">Open guide</a>
                 </article>
                 <article class="info-card">
-                    <h3>Stay consistent over time</h3>
-                    <p>Keep module development predictable across one project or many projects in the same
-                        organization.</p>
+                    <h3>Working with Modules</h3>
+                    <p>Import the built output, reload it after changes, and use the packaged example effectively.</p>
+                    <a class="text-link" href="./working-with-modules.html">Open guide</a>
                 </article>
                 <article class="info-card">
-                    <h3>Learn by doing</h3>
-                    <p>Start from a scaffold or inspect the included example project when you want a working
-                        reference.</p>
+                    <h3>Troubleshooting</h3>
+                    <p>Fix common issues around paths, tests, module reloads, and version bumps.</p>
+                    <a class="text-link" href="./troubleshooting.html">Open guide</a>
+                </article>
+                <article class="info-card">
+                    <h3>Advanced Usage</h3>
+                    <p>Go deeper with CI/CD expectations, project.json settings, and publish/release habits.</p>
+                    <a class="text-link" href="./advanced.html">Open guide</a>
                 </article>
             </div>
         </div>
@@ -102,21 +109,18 @@
     <section class="section section--accent">
         <div class="section__inner split">
             <div>
-                <h2>What you get out of the box</h2>
+                <h2>What NovaModuleTools gives you</h2>
                 <ul class="check-list">
-                    <li>A scaffolded project with a practical PowerShell module layout</li>
-                    <li>A build flow that combines your source into a module under <code>dist/</code></li>
-                    <li>Test support built around validating the built module result</li>
-                    <li>Support for resources, classes, manifest settings, and help generation</li>
-                    <li>A CLI workflow through <code>nova</code> or the PowerShell cmdlets directly</li>
+                    <li>A scaffolded PowerShell module structure you can start using immediately</li>
+                    <li>A build flow that turns your source files into a proper module under <code>dist/</code></li>
+                    <li>A test flow that validates the built module result</li>
+                    <li>Built-in support for resources, classes, version bumps, and release workflows</li>
                 </ul>
             </div>
             <aside class="callout">
                 <h3>Good fit if you want to…</h3>
-                <p>
-                    create modules faster, enforce a consistent structure, and give yourself or your team a cleaner path
-                    from idea to build, test, and release.
-                </p>
+                <p>move from loose scripts to a structured PowerShell module workflow without inventing the build and
+                    test process yourself.</p>
             </aside>
         </div>
     </section>
@@ -124,117 +128,25 @@
     <section class="section">
         <div class="section__inner">
             <div class="section-heading">
-                <h2>Start here in 3 steps</h2>
-                <p>You do not need to know everything about PowerShell modules before you start.</p>
+                <h2>Recommended first path</h2>
+                <p>If you are completely new to NovaModuleTools, follow this order:</p>
             </div>
             <div class="steps">
                 <article class="step-card">
                     <span class="step-number">01</span>
-                    <h3>Install NovaModuleTools</h3>
-                    <pre><code>PS&gt; Install-Module -Name NovaModuleTools
-PS&gt; Import-Module NovaModuleTools</code></pre>
-                    <p>If you want a shell command on macOS/Linux, install the launcher with
-                        <code>PS&gt; Install-NovaCli</code>.</p>
+                    <h3>Install and import</h3>
+                    <p>Start with the Gallery install and optional CLI launcher setup.</p>
                 </article>
                 <article class="step-card">
                     <span class="step-number">02</span>
-                    <h3>Create a module scaffold</h3>
-                    <pre><code>nova init
-nova init -Example</code></pre>
-                    <p>Answer the prompts and let NovaModuleTools create either the default scaffold or the packaged
-                        working example. Use <code>-Path</code> when you want an explicit destination folder.</p>
+                    <h3>Create a project</h3>
+                    <p>Use the default scaffold or choose the packaged example for a complete working reference.</p>
                 </article>
                 <article class="step-card">
                     <span class="step-number">03</span>
-                    <h3>Build and test your module</h3>
-                    <pre><code>nova build
-nova test</code></pre>
-                    <p>This gives you a repeatable workflow from source files to a built module in <code>dist/</code>.
-                    </p>
+                    <h3>Build, test, and iterate</h3>
+                    <p>Generate the module in <code>dist/</code>, test it, and reload it as you change source files.</p>
                 </article>
-            </div>
-        </div>
-    </section>
-
-    <section class="section section--muted">
-        <div class="section__inner split">
-            <div>
-                <h2>What the project structure helps you do</h2>
-                <p>
-                    NovaModuleTools keeps the structure explicit so it is easier to understand what belongs where.
-                </p>
-                <ul class="plain-list">
-                    <li><strong><code>src/public</code></strong> — functions exported from the module</li>
-                    <li><strong><code>src/private</code></strong> — internal helpers used by your public commands</li>
-                    <li><strong><code>src/classes</code></strong> — classes and enums</li>
-                    <li><strong><code>src/resources</code></strong> — bundled files such as JSON config</li>
-                    <li><strong><code>tests</code></strong> — Pester tests</li>
-                    <li><strong><code>dist</code></strong> — the built module output</li>
-                </ul>
-            </div>
-            <div aria-label="Example folder structure" class="code-window">
-<pre><code>project.json
-src/
-  public/
-  private/
-  classes/
-  resources/
-tests/
-dist/</code></pre>
-            </div>
-        </div>
-    </section>
-
-    <section class="section">
-        <div class="section__inner">
-            <div class="section-heading">
-                <h2>Use the example when you want to see a complete working setup</h2>
-                <p>
-                    If you learn best by inspecting something real, the repository includes an example module project
-                    that
-                    can be built, tested, imported, and run.
-                </p>
-            </div>
-            <div class="cta-banner">
-                <div>
-                    <h3>Recommended next step for new users</h3>
-                    <p>Open the packaged example project under <code>src/resources/example</code>, run the commands, and
-                        compare the source files with the built
-                        output.</p>
-                </div>
-                <a class="button button--primary"
-                   href="https://github.com/stiwicourage/NovaModuleTools/blob/main/src/resources/example/README.md">View
-                    example
-                    guide</a>
-            </div>
-        </div>
-    </section>
-
-    <section class="section section--faq">
-        <div class="section__inner narrow">
-            <h2>Frequently asked questions</h2>
-            <div class="faq-list">
-                <details>
-                    <summary>Do I need to know advanced PowerShell module concepts before using NovaModuleTools?
-                    </summary>
-                    <p>No. The tool is useful specifically because it gives you structure and a workflow you can follow
-                        while learning.</p>
-                </details>
-                <details>
-                    <summary>Can I use the CLI instead of PowerShell cmdlet names?</summary>
-                    <p>Yes. Inside PowerShell you can use the <code>nova</code> alias, and on macOS/Linux you can
-                        install a standalone launcher with <code>Install-NovaCli</code>.</p>
-                </details>
-                <details>
-                    <summary>What does <code>nova build</code> actually give me?</summary>
-                    <p>It creates a built module under <code>dist/&lt;ProjectName&gt;</code> so you can import, test,
-                        and publish the result as a proper module.</p>
-                </details>
-                <details>
-                    <summary>Should I start from the scaffold or the example?</summary>
-                    <p>Use the scaffold if you want to begin your own module immediately. Use the example if you want a
-                        working reference project you can inspect and run first.</p>
-                </details>
             </div>
         </div>
     </section>
@@ -242,15 +154,12 @@ dist/</code></pre>
 
 <footer class="footer">
     <div class="footer__inner">
-        <h2>Ready to start your first well-structured module?</h2>
-        <p>Use the quick start, inspect the example, and let NovaModuleTools handle the repetitive scaffolding and build
-            workflow.</p>
+        <h2>Ready to use NovaModuleTools?</h2>
+        <p>Start with installation, then follow the guided workflows all the way through build, test, bump, and
+            release.</p>
         <div class="hero__actions">
-            <a class="button button--primary"
-               href="https://github.com/stiwicourage/NovaModuleTools/blob/main/README.md">Open README</a>
-            <a class="button button--secondary"
-               href="https://github.com/stiwicourage/NovaModuleTools/blob/main/docs/NovaModuleTools/en-US/Install-NovaCli.md">Read
-                CLI install guide</a>
+            <a class="button button--primary" href="./getting-started.html">Open Getting Started</a>
+            <a class="button button--secondary" href="./troubleshooting.html">Need help troubleshooting?</a>
         </div>
     </div>
 </footer>

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1" name="viewport">
+    <title>NovaModuleTools — Troubleshooting</title>
+    <meta content="Fix common NovaModuleTools issues around scaffolding, building, testing, module reloads, and version bumps."
+          name="description">
+    <link href="./assets/site.css" rel="stylesheet">
+</head>
+<body>
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-brand" href="./index.html">NovaModuleTools</a>
+        <nav aria-label="Primary" class="site-nav">
+            <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
+            <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
+            <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+            <a class="site-nav__link site-nav__link--active" href="./troubleshooting.html">Troubleshooting</a>
+            <a class="site-nav__link" href="./advanced.html">Advanced</a>
+        </nav>
+    </div>
+</header>
+
+<main class="page-shell">
+    <section class="guide-hero">
+        <p class="eyebrow">Troubleshooting</p>
+        <h1>Common NovaModuleTools problems and how to get unstuck</h1>
+        <p class="lead">These are the issues users most often hit while scaffolding, building, testing, and versioning a
+            project.</p>
+    </section>
+
+    <section class="guide-content guide-content--single">
+        <section class="content-section">
+            <h2><code>nova init some/path</code> does not work</h2>
+            <p>Path input is explicit. Use:</p>
+            <pre><code>nova init -Path ~/Work</code></pre>
+            <p>or, for the full working example:</p>
+            <pre><code>nova init -Example -Path ~/Work</code></pre>
+        </section>
+
+        <section class="content-section">
+            <h2><code>nova bump</code> says the repository has no commits yet</h2>
+            <p><code>nova bump</code> chooses the version label from Git history. If the repository exists but has no
+                commits yet, create the first commit and run the command again.</p>
+            <pre><code>git add .
+git commit -m "feat: initial project scaffold"
+nova bump -WhatIf</code></pre>
+        </section>
+
+        <section class="content-section">
+            <h2>The module does not seem to reload after I rebuild</h2>
+            <p>PowerShell may still have the previous version loaded in memory. Remove the module first, then rebuild
+                and import again:</p>
+            <pre><code>$project = Get-NovaProjectInfo
+Remove-Module $project.ProjectName -ErrorAction SilentlyContinue
+nova build
+Import-Module $project.OutputModuleDir -Force</code></pre>
+        </section>
+
+        <section class="content-section">
+            <h2>Tests fail but I cannot see where the results went</h2>
+            <p>The normal Nova test workflow writes XML results to:</p>
+            <pre><code>artifacts/TestResults.xml</code></pre>
+            <p>If you run Pester directly instead of through <code>nova test</code> / <code>Test-NovaBuild</code>, you
+                may get different output behavior.</p>
+        </section>
+
+        <section class="content-section">
+            <h2>Build errors point at the generated <code>.psm1</code> file</h2>
+            <p>Enable or keep <code>SetSourcePath</code> in <code>project.json</code>. NovaModuleTools will add <code>#
+                Source:</code> markers to the generated module so you can map errors back to the original files under
+                <code>src/</code>.</p>
+        </section>
+    </section>
+</main>
+</body>
+</html>
+

--- a/docs/working-with-modules.html
+++ b/docs/working-with-modules.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1" name="viewport">
+    <title>NovaModuleTools — Working with Modules</title>
+    <meta content="Import built modules, reload them during local development, and use NovaModuleTools effectively while you iterate."
+          name="description">
+    <link href="./assets/site.css" rel="stylesheet">
+</head>
+<body>
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-brand" href="./index.html">NovaModuleTools</a>
+        <nav aria-label="Primary" class="site-nav">
+            <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
+            <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
+            <a class="site-nav__link site-nav__link--active" href="./working-with-modules.html">Working with Modules</a>
+            <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
+            <a class="site-nav__link" href="./advanced.html">Advanced</a>
+        </nav>
+    </div>
+</header>
+
+<main class="page-shell">
+    <section class="guide-hero">
+        <p class="eyebrow">Working with modules</p>
+        <h1>Import, reload, and validate the built module during local development</h1>
+        <p class="lead">NovaModuleTools is designed around working with the built module in <code>dist/</code>, not just
+            loose script files.</p>
+    </section>
+
+    <section class="content-grid">
+        <aside class="toc-card">
+            <h2>On this page</h2>
+            <ul class="toc-list">
+                <li><a href="#import-built">Import the built module</a></li>
+                <li><a href="#reload">Reload after changes</a></li>
+                <li><a href="#local-publish">Use local publish</a></li>
+                <li><a href="#example">Use the packaged example</a></li>
+            </ul>
+        </aside>
+
+        <div class="guide-content">
+            <section class="content-section" id="import-built">
+                <h2>Import the built module</h2>
+                <p>After building, import the output from <code>dist/&lt;ProjectName&gt;</code>:</p>
+                <pre><code>nova build
+$project = Get-NovaProjectInfo
+Import-Module $project.OutputModuleDir -Force</code></pre>
+                <p>This keeps your runtime behavior aligned with what you intend to publish.</p>
+            </section>
+
+            <section class="content-section" id="reload">
+                <h2>Reload after changes</h2>
+                <p>When you edit source files, rebuild and reload the module to avoid using stale code already loaded in
+                    the session:</p>
+                <pre><code>$project = Get-NovaProjectInfo
+Remove-Module $project.ProjectName -ErrorAction SilentlyContinue
+nova build
+Import-Module $project.OutputModuleDir -Force</code></pre>
+            </section>
+
+            <section class="content-section" id="local-publish">
+                <h2>Validate a local publish flow</h2>
+                <p>If you want to test how the module behaves when copied to your local PowerShell module path:</p>
+                <pre><code>nova publish -local</code></pre>
+                <p>This is useful when you want to simulate a more realistic install-and-import cycle without publishing
+                    to a shared repository.</p>
+            </section>
+
+            <section class="content-section" id="example">
+                <h2>Use the packaged example as a working reference</h2>
+                <p>The packaged example is available through <code>nova init -Example</code>. It is the fastest way to
+                    inspect a complete workflow that includes:</p>
+                <ul class="plain-list">
+                    <li>a real <code>project.json</code></li>
+                    <li>a public command</li>
+                    <li>a private helper</li>
+                    <li>a resource file</li>
+                    <li>Pester tests against the built output</li>
+                </ul>
+                <p>If you prefer learning from a working sample first, start there and then adapt the generated project
+                    to your own module.</p>
+            </section>
+        </div>
+    </section>
+</main>
+</body>
+</html>
+

--- a/project.json
+++ b/project.json
@@ -19,7 +19,7 @@
       "Maintainability",
       "Enterprise"
     ],
-    "ProjectUri": "https://www.novamoduletools.com/"
+    "ProjectUri": "https://www.novamoduletools.com"
   },
   "Pester": {
     "TestResult": {


### PR DESCRIPTION
- Change documentation ownership so GitHub repository docs focus on contributors, while GitHub Pages now provides the
  task-oriented end-user guide experience.