### PR TITLE
feat(#68): allow users to update NovaModuleTools directly from a Nova…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   check and a user-configurable prerelease notification preference.
     - Supports `Set-NovaUpdateNotificationPreference` / `Get-NovaUpdateNotificationPreference` for PowerShell usage.
     - Supports `nova notification`, `nova notification -disable`, and `nova notification -enable` for CLI usage.
+  - Supports `Update-NovaModuleTool` (with `Update-NovaModuleTools` as a compatibility alias) and `nova update` for
+    self-updating the installed module.
+  - Reuses the same stored prerelease preference for both build notifications and self-update eligibility.
+  - Requires explicit confirmation before a prerelease self-update proceeds.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -79,13 +79,21 @@ Only newer versions emit a warning.
 PS> Set-NovaUpdateNotificationPreference -DisablePrereleaseNotifications
 PS> Set-NovaUpdateNotificationPreference -EnablePrereleaseNotifications
 PS> Get-NovaUpdateNotificationPreference
+PS> Update-NovaModuleTool
+PS> Update-NovaModuleTools   # alias
 PS> nova notification -disable
 PS> nova notification -enable
 PS> nova notification
+PS> nova update
 ```
 
 Use `nova notification` when you want the CLI-oriented workflow and the `Set-` / `Get-` cmdlets when you want the
 PowerShell function form in scripts.
+
+`Update-NovaModuleTool` (and its `Update-NovaModuleTools` alias) / `nova update` use the same stored prerelease
+preference as the automatic build notifications. When prerelease notifications are disabled, self-update stays on stable
+releases. When prerelease notifications are enabled, self-update may target a prerelease, but it asks for explicit
+confirmation before proceeding.
 
 ### Reload the built module while iterating
 

--- a/docs/NovaModuleTools/en-US/Get-NovaUpdateNotificationPreference.md
+++ b/docs/NovaModuleTools/en-US/Get-NovaUpdateNotificationPreference.md
@@ -28,6 +28,9 @@ PS> Get-NovaUpdateNotificationPreference [<CommonParameters>]
 `Get-NovaUpdateNotificationPreference` returns the current user preference that controls whether successful builds also
 notify about newer prerelease versions of `NovaModuleTools`.
 
+The same stored preference is also used by `Update-NovaModuleTool` (alias: `Update-NovaModuleTools`) and `nova update`
+when they decide whether a prerelease self-update is eligible.
+
 Stable release notifications always remain enabled and cannot be disabled.
 
 If you prefer the Nova CLI surface, run `nova notification` to view the same preference.
@@ -40,7 +43,8 @@ If you prefer the Nova CLI surface, run `nova notification` to view the same pre
 PS> Get-NovaUpdateNotificationPreference
 ```
 
-Shows whether prerelease update notifications are currently enabled and where the preference is stored.
+Shows whether prerelease update notifications are currently enabled, whether stable notifications remain enabled, and
+where the preference is stored.
 
 ### EXAMPLE 2
 
@@ -78,8 +82,13 @@ prerelease notifications.
 Use `PS> Set-NovaUpdateNotificationPreference -EnablePrereleaseNotifications` or `nova notification -enable` to turn
 prerelease notifications back on.
 
+When prerelease notifications are enabled again, `Update-NovaModuleTool` / `Update-NovaModuleTools` and `nova update`
+may again select a prerelease target. Prerelease self-updates still require explicit confirmation before the update
+proceeds.
+
 ## RELATED LINKS
 
 - `Invoke-NovaBuild`
 - `Set-NovaUpdateNotificationPreference`
+- `Update-NovaModuleTool`
 

--- a/docs/NovaModuleTools/en-US/Invoke-NovaBuild.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaBuild.md
@@ -52,6 +52,10 @@ Stable release notifications always remain enabled. To control prerelease notifi
 For the CLI-oriented workflow, use `nova notification -disable`, `nova notification -enable`, and
 `nova notification`.
 
+When you decide to apply one of the reported updates, you can either run the suggested `Update-Module` command directly
+or use `Update-NovaModuleTool` (alias: `Update-NovaModuleTools`) / `nova update`. The self-update command uses the same
+stored prerelease preference.
+
 If `SetSourcePath` is enabled, the generated `.psm1` includes `# Source:` markers before each source block.
 
 If `Preamble` is configured, those lines are written at the very top of the generated `.psm1` before the rest of the
@@ -93,6 +97,9 @@ PS> Invoke-NovaBuild
 Builds the current project and keeps stable release notifications enabled while suppressing prerelease update warnings.
 
 The CLI equivalent is `nova notification -disable` before running `nova build`.
+
+With prerelease notifications disabled, `Update-NovaModuleTool` / `Update-NovaModuleTools` and `nova update` also stay
+on the stable release channel.
 
 ## PARAMETERS
 

--- a/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
@@ -29,13 +29,14 @@ PS> Invoke-NovaCli [[-Command] <string>] [[-Arguments] <string[]>] [-WhatIf] [-C
 `nova` CLI rather than call `Invoke-NovaCli` directly.
 
 It dispatches high-level commands such as `nova info`, `nova version`, `nova --version`, `nova --help`, `nova build`,
-`nova test`, `nova init`, `nova notification`, `nova publish`, `nova bump`, and `nova release` to the matching Nova
-cmdlet.
+`nova test`, `nova init`, `nova update`, `nova notification`, `nova publish`, `nova bump`, and `nova release` to the
+matching Nova cmdlet.
 
 Use `Invoke-NovaCli` when you need a scriptable PowerShell command entrypoint. Use `nova` when you want the
 user-focused CLI experience.
 
-Mutating routed commands (`build`, `test`, `bump`, `notification`, `publish`, and `release`) forward PowerShell
+Mutating routed commands (`build`, `test`, `bump`, `update`, `notification`, `publish`, and `release`) forward
+PowerShell
 `-WhatIf`/`-Confirm` to the underlying cmdlet. That means `nova build -WhatIf` and
 `Invoke-NovaCli -Command build -WhatIf` both preview the build instead of running it.
 
@@ -45,6 +46,11 @@ resolved local install path after the copy succeeds. Preview or cancelled runs d
 Use `nova notification` to show the current prerelease build-update notification preference,
 `nova notification -disable` to stop prerelease warnings after successful builds, and
 `nova notification -enable` to turn those warnings back on. Stable release notifications remain enabled.
+
+Use `nova update` to self-update the installed `NovaModuleTools` module. It uses the same stored prerelease preference
+as the automatic post-build update notifications. When that preference is disabled, `nova update` only targets stable
+releases. When it is enabled, `nova update` may target a prerelease, but it always asks for explicit confirmation
+before running a prerelease update.
 
 For the standalone launcher, `nova bump -Confirm` uses a CLI-friendly confirmation prompt. Declined or suspended choices
 cancel the bump cleanly and return control to the shell without printing a version result.
@@ -139,12 +145,24 @@ Runs the interactive init flow, scaffolds from the packaged example project, and
 ### EXAMPLE 10
 
 ```powershell
+nova update
+```
+
+Updates the installed `NovaModuleTools` module using the same stored prerelease preference as the automatic build-update
+notifications.
+
+If the resolved target is a prerelease, `nova update` asks for explicit confirmation before calling
+`Update-Module NovaModuleTools -AllowPrerelease`.
+
+### EXAMPLE 11
+
+```powershell
 nova notification
 ```
 
 Shows whether prerelease build-update notifications are enabled and where the preference is stored.
 
-### EXAMPLE 11
+### EXAMPLE 12
 
 ```powershell
 nova notification -disable
@@ -152,7 +170,7 @@ nova notification -disable
 
 Disables prerelease build-update notifications while keeping stable release notifications enabled.
 
-### EXAMPLE 12
+### EXAMPLE 13
 
 ```powershell
 PS> Invoke-NovaCli -Command notification -Arguments @('-enable')
@@ -165,7 +183,7 @@ Re-enables prerelease build-update notifications from the routed PowerShell entr
 ### -Command
 
 The command to execute. Supported values: `info`, `version`, `--version`, `--help`, `build`, `test`, `init`,
-`notification`, `publish`, `bump`, `release`.
+`update`, `notification`, `publish`, `bump`, `release`.
 
 ```yaml
 Type: System.String
@@ -180,7 +198,7 @@ ParameterSets:
     ValueFromPipelineByPropertyName: false
     ValueFromRemainingArguments: false
 DontShow: false
-AcceptedValues: [ info, version, --version, --help, build, test, init, notification, publish, bump, release ]
+AcceptedValues: [ info, version, --version, --help, build, test, init, update, notification, publish, bump, release ]
 HelpMessage: ''
 ```
 
@@ -221,7 +239,8 @@ Returned for text-oriented commands such as `nova --help`, `nova version`, and `
 
 ### PSCustomObject
 
-Returned when the selected subcommand returns an object, for example `nova info` or `nova notification`.
+Returned when the selected subcommand returns an object, for example `nova info`, `nova notification`, or
+`nova update`.
 
 ### None
 
@@ -242,5 +261,6 @@ only to mutating subcommands.
 - `Invoke-NovaBuild`
 - `Install-NovaCli`
 - `Test-NovaBuild`
+- `Update-NovaModuleTool`
 - `Invoke-NovaRelease`
 

--- a/docs/NovaModuleTools/en-US/NovaModuleTools.md
+++ b/docs/NovaModuleTools/en-US/NovaModuleTools.md
@@ -50,6 +50,11 @@ Runs the Nova release pipeline (build, test, version bump, rebuild, publish).
 
 Runs the project's Pester test workflow using settings from `project.json`.
 
+### `PS> Update-NovaModuleTool`
+
+Updates the installed `NovaModuleTools` module by using the same prerelease preference shared with the automatic
+post-build update notifications. The compatibility alias `Update-NovaModuleTools` is also available.
+
 ### `PS> New-NovaModule`
 
 Creates a new NovaModuleTools project scaffold through an interactive prompt flow.

--- a/docs/NovaModuleTools/en-US/Set-NovaUpdateNotificationPreference.md
+++ b/docs/NovaModuleTools/en-US/Set-NovaUpdateNotificationPreference.md
@@ -34,6 +34,9 @@ PS> Set-NovaUpdateNotificationPreference -DisablePrereleaseNotifications [-WhatI
 `Set-NovaUpdateNotificationPreference` manages the user preference that controls whether successful builds warn about
 newer prerelease versions of `NovaModuleTools`.
 
+The same stored preference is also used by `Update-NovaModuleTool` (alias: `Update-NovaModuleTools`) and `nova update`
+when they decide whether a prerelease self-update can be selected.
+
 Stable release notifications always remain enabled and cannot be disabled.
 
 If you prefer the Nova CLI surface, use `nova notification -disable` and `nova notification -enable` for the same
@@ -47,7 +50,8 @@ stored preference.
 PS> Set-NovaUpdateNotificationPreference -DisablePrereleaseNotifications
 ```
 
-Turns off prerelease update notifications for future successful builds.
+Turns off prerelease update notifications for future successful builds and restricts `Update-NovaModuleTool` /
+`nova update` to stable releases only.
 
 ### EXAMPLE 2
 
@@ -55,7 +59,8 @@ Turns off prerelease update notifications for future successful builds.
 PS> Set-NovaUpdateNotificationPreference -EnablePrereleaseNotifications
 ```
 
-Turns prerelease update notifications back on.
+Turns prerelease update notifications back on, which allows `Update-NovaModuleTool` / `Update-NovaModuleTools` and
+`nova update` to consider a prerelease target again.
 
 ### EXAMPLE 3
 

--- a/docs/NovaModuleTools/en-US/Update-NovaModuleTools.md
+++ b/docs/NovaModuleTools/en-US/Update-NovaModuleTools.md
@@ -1,0 +1,161 @@
+---
+document type: cmdlet
+external help file: NovaModuleTools-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: NovaModuleTools
+ms.date: 04/18/2026
+PlatyPS schema version: 2024-05-01
+title: Update-NovaModuleTool
+---
+
+# Update-NovaModuleTool
+
+## SYNOPSIS
+
+Updates the installed `NovaModuleTools` module using the shared prerelease preference.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```powershell
+PS> Update-NovaModuleTool [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+`Update-NovaModuleTool` self-updates the installed `NovaModuleTools` module.
+
+The cmdlet is also available through the compatibility alias `Update-NovaModuleTools`.
+
+Before it runs `Update-Module`, it resolves the best available update candidate by using the same stored prerelease
+preference that controls the automatic post-build update notifications.
+
+When prerelease notifications are disabled, `Update-NovaModuleTool` only considers stable releases and never passes
+`-AllowPrerelease` to the update flow.
+
+When prerelease notifications are enabled, `Update-NovaModuleTool` may target a prerelease. If the selected target is a
+prerelease, the command always asks for explicit confirmation before it proceeds.
+
+Stable updates do not require prerelease confirmation.
+
+Use `nova update` when you want the same behavior through the Nova CLI entrypoint.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+PS> Update-NovaModuleTool
+```
+
+Updates the installed `NovaModuleTools` module by using the stored prerelease preference to resolve the update
+candidate.
+
+### EXAMPLE 2
+
+```powershell
+PS> Set-NovaUpdateNotificationPreference -DisablePrereleaseNotifications
+PS> Update-NovaModuleTool
+```
+
+Restricts self-update to stable releases only.
+
+### EXAMPLE 3
+
+```powershell
+nova update
+```
+
+Runs the same self-update flow from the Nova CLI. If the selected target is a prerelease, the CLI asks for explicit
+confirmation before running the update.
+
+### EXAMPLE 4
+
+```powershell
+PS> Update-NovaModuleTool -WhatIf
+```
+
+Previews the resolved update action without running `Update-Module`.
+
+## PARAMETERS
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs. `Update-NovaModuleTool` resolves the target version first, then previews the
+selected stable or prerelease update action without changing the installed module.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: [ wi ]
+ParameterSets:
+  - Name: (All)
+    Position: Named
+    IsRequired: false
+    ValueFromPipeline: false
+    ValueFromPipelineByPropertyName: false
+    ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: [ ]
+HelpMessage: ''
+```
+
+### -Confirm
+
+Prompts you for confirmation before the cmdlet runs.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: [ cf ]
+ParameterSets:
+  - Name: (All)
+    Position: Named
+    IsRequired: false
+    ValueFromPipeline: false
+    ValueFromPipelineByPropertyName: false
+    ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: [ ]
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`,
+`-InformationVariable`, `-OutBuffer`, `-OutVariable`, `-PipelineVariable`, `-ProgressAction`, `-Verbose`,
+`-WarningAction`, `-WarningVariable`, `-WhatIf`, and `-Confirm`.
+
+## INPUTS
+
+### None
+
+You can't pipe objects to this cmdlet.
+
+## OUTPUTS
+
+### PSCustomObject
+
+Returns a self-update plan/result object that shows the current version, the resolved target version, whether a newer
+update was available, whether the target was prerelease, and whether the update ran or was cancelled.
+
+## NOTES
+
+If the PowerShell Gallery cannot be reached well enough to resolve an update candidate, the command stops before calling
+`Update-Module`.
+
+Use `Get-NovaUpdateNotificationPreference`, `Set-NovaUpdateNotificationPreference`, `nova notification`,
+`nova notification -disable`, and `nova notification -enable` to inspect or change the same stored prerelease setting.
+
+## RELATED LINKS
+
+- `Invoke-NovaCli`
+- `Get-NovaUpdateNotificationPreference`
+- `Set-NovaUpdateNotificationPreference`
+- `Invoke-NovaBuild`
+
+

--- a/docs/core-workflows.html
+++ b/docs/core-workflows.html
@@ -90,6 +90,9 @@ nova init -Example</code></pre>
                 <pre><code>nova notification
 nova notification -disable
 nova notification -enable</code></pre>
+                <p>When you want to update NovaModuleTools itself, use <code>nova update</code>. It uses the same stored
+                    prerelease preference. Stable updates run normally, while prerelease targets require explicit
+                    confirmation before the update proceeds.</p>
             </section>
 
             <section class="content-section" id="test">

--- a/project.json
+++ b/project.json
@@ -1,7 +1,7 @@
 {
   "ProjectName": "NovaModuleTools",
   "Description": "NovaModuleTools is an enterprise-focused evolution of ModuleTools, designed for large-scale PowerShell projects with a strong emphasis on structure, maintainability, and automated CI/CD pipelines.",
-  "Version": "1.8.0-prerelease.1",
+  "Version": "1.8.0-prerelease.2",
   "Preamble": [
     "Set-StrictMode -Version Latest",
     "$ErrorActionPreference = 'Stop'"

--- a/src/private/cli/ConvertFromNovaUpdateCliArgument.ps1
+++ b/src/private/cli/ConvertFromNovaUpdateCliArgument.ps1
@@ -1,0 +1,15 @@
+function ConvertFrom-NovaUpdateCliArgument {
+    [CmdletBinding()]
+    param(
+        [string[]]$Arguments
+    )
+
+    $Arguments = ConvertTo-NovaCliArgumentArray -BoundParameters $PSBoundParameters -Arguments $Arguments
+    if ($Arguments.Count -eq 0) {
+        return @{}
+    }
+
+    throw "Unsupported 'nova update' usage. Use 'nova update'."
+}
+
+

--- a/src/private/cli/GetNovaCliHelp.ps1
+++ b/src/private/cli/GetNovaCliHelp.ps1
@@ -13,6 +13,7 @@ work with the current project
    build      Build the module into the dist folder
    test       Run Pester tests for the project
    bump       Update the module version in project.json
+   update     Update the installed NovaModuleTools module using the stored prerelease preference
    notification Show or change prerelease build-update notifications
 
 publish and release
@@ -23,7 +24,7 @@ global options
    --help     Show this help message
    --version  Show the installed NovaModuleTools module name and version, including prerelease label when present
    -Verbose   Show verbose output for the routed PowerShell command
-   -WhatIf    Preview build, test, bump, notification, publish, and release without changing files
+   -WhatIf    Preview build, test, bump, update, notification, publish, and release without changing files
    -Confirm   Request confirmation before mutating routed commands; nova bump cancels cleanly on No/No to All/Suspend
 
 Examples:
@@ -36,6 +37,7 @@ Examples:
    nova build
    nova test
    nova bump -WhatIf
+    nova update
    nova notification
    nova notification -disable
    nova notification -enable
@@ -53,6 +55,10 @@ when you want a scriptable function interface.
 Use 'nova notification' to show the current prerelease notification preference,
 'nova notification -disable' to suppress prerelease build-update warnings,
 and 'nova notification -enable' to turn them back on.
+
+Use 'nova update' to self-update NovaModuleTools. It uses the same stored prerelease
+preference as the automatic build-update notifications. Stable updates proceed normally,
+while prerelease targets require explicit confirmation before the update runs.
 
 Inside PowerShell, 'nova publish -local' also reloads the published module from the
 local install path after a successful publish.

--- a/src/private/cli/InvokeNovaCliUpdateCommand.ps1
+++ b/src/private/cli/InvokeNovaCliUpdateCommand.ps1
@@ -1,0 +1,12 @@
+function Invoke-NovaCliUpdateCommand {
+    [CmdletBinding()]
+    param(
+        [string[]]$Arguments,
+        [Parameter(Mandatory)][hashtable]$ForwardedParameters
+    )
+
+    $options = ConvertFrom-NovaUpdateCliArgument -Arguments $Arguments
+    return Update-NovaModuleTool @options @ForwardedParameters
+}
+
+

--- a/src/private/update/ConfirmNovaPrereleaseModuleUpdate.ps1
+++ b/src/private/update/ConfirmNovaPrereleaseModuleUpdate.ps1
@@ -1,0 +1,13 @@
+function Confirm-NovaPrereleaseModuleUpdate {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$Cmdlet,
+        [Parameter(Mandatory)][string]$CurrentVersion,
+        [Parameter(Mandatory)][string]$TargetVersion
+    )
+
+    $prompt = Get-NovaPrereleaseModuleUpdateConfirmationPrompt -CurrentVersion $CurrentVersion -TargetVersion $TargetVersion
+    return $Cmdlet.ShouldContinue($prompt.Message, $prompt.Caption)
+}
+
+

--- a/src/private/update/ConvertToNovaModuleSelfUpdatePlan.ps1
+++ b/src/private/update/ConvertToNovaModuleSelfUpdatePlan.ps1
@@ -1,0 +1,24 @@
+function ConvertTo-NovaModuleSelfUpdatePlan {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$InstalledModule,
+        [Parameter(Mandatory)][bool]$PrereleaseNotificationsEnabled,
+        [string]$TargetVersion,
+        [switch]$PrereleaseTarget
+    )
+
+    return [pscustomobject]@{
+        ModuleName = $InstalledModule.ModuleName
+        CurrentVersion = $InstalledModule.Version
+        TargetVersion = $TargetVersion
+        PrereleaseNotificationsEnabled = $PrereleaseNotificationsEnabled
+        UpdateAvailable = -not [string]::IsNullOrWhiteSpace($TargetVersion)
+        Updated = $false
+        Cancelled = $false
+        IsPrereleaseTarget = $PrereleaseTarget.IsPresent
+        UsedAllowPrerelease = $PrereleaseTarget.IsPresent
+    }
+}
+
+
+

--- a/src/private/update/GetNovaModuleSelfUpdatePlan.ps1
+++ b/src/private/update/GetNovaModuleSelfUpdatePlan.ps1
@@ -1,0 +1,23 @@
+function Get-NovaModuleSelfUpdatePlan {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$InstalledModule,
+        [Parameter(Mandatory)][pscustomobject]$LookupResult,
+        [Parameter(Mandatory)][bool]$PrereleaseNotificationsEnabled
+    )
+
+    $stableVersion = Get-NovaAvailableSemanticVersion -VersionInfo $LookupResult.Stable
+    if (Test-NovaPrereleaseUpdateAvailable -LookupResult $LookupResult -InstalledVersion $InstalledModule.SemanticVersion -StableVersion $stableVersion -PrereleaseNotificationsEnabled $PrereleaseNotificationsEnabled) {
+        return ConvertTo-NovaModuleSelfUpdatePlan -InstalledModule $InstalledModule -PrereleaseNotificationsEnabled:$PrereleaseNotificationsEnabled -TargetVersion $LookupResult.Prerelease.Version -PrereleaseTarget
+    }
+
+    if (Test-NovaStableUpdateAvailable -StableVersion $stableVersion -InstalledVersion $InstalledModule.SemanticVersion) {
+        return ConvertTo-NovaModuleSelfUpdatePlan -InstalledModule $InstalledModule -PrereleaseNotificationsEnabled:$PrereleaseNotificationsEnabled -TargetVersion $LookupResult.Stable.Version
+    }
+
+    return ConvertTo-NovaModuleSelfUpdatePlan -InstalledModule $InstalledModule -PrereleaseNotificationsEnabled:$PrereleaseNotificationsEnabled
+}
+
+
+
+

--- a/src/private/update/GetNovaPrereleaseModuleUpdateConfirmationPrompt.ps1
+++ b/src/private/update/GetNovaPrereleaseModuleUpdateConfirmationPrompt.ps1
@@ -1,0 +1,19 @@
+function Get-NovaPrereleaseModuleUpdateConfirmationPrompt {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$CurrentVersion,
+        [Parameter(Mandatory)][string]$TargetVersion
+    )
+
+    return [pscustomobject]@{
+        Caption = 'Confirm prerelease NovaModuleTools update'
+        Message = @"
+NovaModuleTools would update from $CurrentVersion to prerelease $TargetVersion.
+
+Prerelease updates may be less stable than released versions.
+Continue with the prerelease update?
+"@
+    }
+}
+
+

--- a/src/private/update/InvokeNovaModuleSelfUpdate.ps1
+++ b/src/private/update/InvokeNovaModuleSelfUpdate.ps1
@@ -1,0 +1,15 @@
+function Invoke-NovaModuleSelfUpdate {
+    [CmdletBinding()]
+    param(
+        [string]$ModuleName = 'NovaModuleTools',
+        [switch]$AllowPrerelease
+    )
+
+    if ($AllowPrerelease) {
+        return Update-Module $ModuleName -AllowPrerelease
+    }
+
+    return Update-Module $ModuleName
+}
+
+

--- a/src/private/update/WriteNovaAvailableModuleUpdateWarning.ps1
+++ b/src/private/update/WriteNovaAvailableModuleUpdateWarning.ps1
@@ -28,6 +28,7 @@ function Write-NovaAvailableModuleUpdateWarning {
         ''
         'Update:'
         $updateCommand
+        'nova update'
     )
 
     if ($Prerelease) {

--- a/src/public/InvokeNovaCli.ps1
+++ b/src/public/InvokeNovaCli.ps1
@@ -4,13 +4,11 @@ function Invoke-NovaCli {
     param(
         [Parameter(Position = 0)]
         [string]$Command = '--help',
-
         [Parameter(Position = 1, ValueFromRemainingArguments)]
         [string[]]$Arguments
     )
 
-    $commonParameters = Get-NovaCliForwardingParameterSet -BoundParameters $PSBoundParameters
-    $mutatingCommonParameters = Get-NovaCliForwardingParameterSet -BoundParameters $PSBoundParameters -IncludeShouldProcess
+    $commonParameters = Get-NovaCliForwardingParameterSet -BoundParameters $PSBoundParameters; $mutatingCommonParameters = Get-NovaCliForwardingParameterSet -BoundParameters $PSBoundParameters -IncludeShouldProcess
 
     $Arguments = ConvertTo-NovaCliArgumentArray -BoundParameters $PSBoundParameters -Arguments $Arguments
 
@@ -38,6 +36,9 @@ function Invoke-NovaCli {
         }
         'bump' {
             return Update-NovaModuleVersion @mutatingCommonParameters
+        }
+        'update' {
+            return Invoke-NovaCliUpdateCommand -Arguments $Arguments -ForwardedParameters $mutatingCommonParameters
         }
         'publish' {
             $options = ConvertFrom-NovaCliArgument -Arguments $Arguments

--- a/src/public/UpdateNovaModuleTools.ps1
+++ b/src/public/UpdateNovaModuleTools.ps1
@@ -1,0 +1,42 @@
+function Update-NovaModuleTool {
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    [Alias('Update-NovaModuleTools')]
+    param()
+
+    $preference = Read-NovaUpdateNotificationPreference
+    $installedModule = Get-NovaInstalledModuleVersionInfo
+    $lookupResult = Invoke-NovaModuleUpdateLookup -AllowPrereleaseNotifications:$preference.PrereleaseNotificationsEnabled -TimeoutMilliseconds 10000
+    if ($null -eq $lookupResult) {
+        throw 'Unable to determine a NovaModuleTools update candidate. Try again when the PowerShell Gallery is reachable.'
+    }
+
+    $plan = Get-NovaModuleSelfUpdatePlan -InstalledModule $installedModule -LookupResult $lookupResult -PrereleaseNotificationsEnabled $preference.PrereleaseNotificationsEnabled
+    if (-not $plan.UpdateAvailable) {
+        return $plan
+    }
+
+    if ($plan.IsPrereleaseTarget -and -not (Confirm-NovaPrereleaseModuleUpdate -Cmdlet $PSCmdlet -CurrentVersion $plan.CurrentVersion -TargetVersion $plan.TargetVersion)) {
+        $plan.Cancelled = $true
+        return $plan
+    }
+
+    $action = if ($plan.IsPrereleaseTarget) {
+        "Update NovaModuleTools to prerelease version $( $plan.TargetVersion )"
+    }
+    else {
+        "Update NovaModuleTools to version $( $plan.TargetVersion )"
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($plan.ModuleName, $action)) {
+        return $plan
+    }
+
+    $null = Invoke-NovaModuleSelfUpdate -ModuleName $plan.ModuleName -AllowPrerelease:$plan.UsedAllowPrerelease
+    $plan.Updated = $true
+    return $plan
+}
+
+
+
+
+

--- a/tests/UpdateNotification.TestSupport.ps1
+++ b/tests/UpdateNotification.TestSupport.ps1
@@ -85,3 +85,59 @@ function Assert-TestNotificationPreferenceToggleResult {
     $Result.Enabled.StableReleaseNotificationsEnabled | Should -BeTrue
 }
 
+function Invoke-TestNovaSelfUpdate {
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Options
+    )
+
+    InModuleScope $script:moduleName -Parameters @{
+        Options = $Options
+    } {
+        param($Options)
+
+        $script:preferenceReadCount = 0
+        $script:prereleaseConfirmationCount = 0
+        $script:updateInvocation = $null
+
+        Mock Read-NovaUpdateNotificationPreference {
+            $script:preferenceReadCount++
+            [pscustomobject]@{PrereleaseNotificationsEnabled = $Options.PrereleaseNotificationsEnabled}
+        }
+        Mock Get-NovaInstalledModuleVersionInfo {
+            [pscustomobject]@{
+                ModuleName = 'NovaModuleTools'
+                Version = '1.0.0'
+                SemanticVersion = [semver]'1.0.0'
+                IsPrerelease = $false
+            }
+        }
+        Mock Invoke-NovaModuleUpdateLookup {$Options.LookupResult}
+        Mock Confirm-NovaPrereleaseModuleUpdate {
+            $script:prereleaseConfirmationCount++
+            return $Options.ConfirmPrerelease
+        }
+        Mock Invoke-NovaModuleSelfUpdate {
+            param([string]$ModuleName, [switch]$AllowPrerelease)
+
+            $script:updateInvocation = [pscustomobject]@{
+                ModuleName = $ModuleName
+                AllowPrerelease = $AllowPrerelease.IsPresent
+            }
+        }
+
+        $result = if ($Options.UseCli) {
+            Invoke-NovaCli update -Confirm:$false
+        }
+        else {
+            Update-NovaModuleTool -Confirm:$false
+        }
+
+        return [pscustomobject]@{
+            Result = $result
+            PreferenceReadCount = $script:preferenceReadCount
+            PrereleaseConfirmationCount = $script:prereleaseConfirmationCount
+            UpdateInvocation = $script:updateInvocation
+        }
+    }
+}
+

--- a/tests/UpdateNotification.Tests.ps1
+++ b/tests/UpdateNotification.Tests.ps1
@@ -3,6 +3,7 @@ $global:updateNotificationTestSupportFunctionNameList = @(
     'Invoke-TestBuildUpdateNotification'
     'Invoke-TestNotificationPreferenceToggle'
     'Assert-TestNotificationPreferenceToggleResult'
+    'Invoke-TestNovaSelfUpdate'
 )
 
 . $script:updateNotificationTestSupportPath
@@ -71,6 +72,22 @@ Describe 'Update notification behavior' {
         Assert-TestNotificationPreferenceToggleResult -Result $result
     }
 
+    It 'Invoke-NovaCli update routes to Update-NovaModuleTool' {
+        InModuleScope $script:moduleName {
+            Mock Update-NovaModuleTool {[pscustomobject]@{Routed = $true}}
+
+            (Invoke-NovaCli update -Confirm:$false).Routed | Should -BeTrue
+            Assert-MockCalled Update-NovaModuleTool -Times 1
+        }
+    }
+
+    It 'ConvertFrom-NovaUpdateCliArgument allows no arguments and rejects unsupported usage' {
+        InModuleScope $script:moduleName {
+            (ConvertFrom-NovaUpdateCliArgument).Count | Should -Be 0
+            {ConvertFrom-NovaUpdateCliArgument -Arguments @('--bogus')} | Should -Throw "Unsupported 'nova update' usage*"
+        }
+    }
+
     It 'Invoke-NovaModuleUpdateLookup returns nothing when the lookup exceeds the timeout' {
         InModuleScope $script:moduleName {
             $started = [datetime]::UtcNow
@@ -109,6 +126,7 @@ throw 'offline'
         $result.Warnings | Should -HaveCount 1
         $result.Warnings[0] | Should -Match 'newer NovaModuleTools release is available'
         $result.Warnings[0] | Should -Match 'Update-Module NovaModuleTools'
+        $result.Warnings[0] | Should -Match 'nova update'
     }
 
     It 'Invoke-NovaBuildUpdateNotification warns about a newer prerelease only when prerelease notifications are enabled' {
@@ -120,8 +138,130 @@ throw 'offline'
         $result.Warnings | Should -HaveCount 1
         $result.Warnings[0] | Should -Match 'newer NovaModuleTools prerelease is available'
         $result.Warnings[0] | Should -Match 'Update-Module NovaModuleTools -AllowPrerelease'
+        $result.Warnings[0] | Should -Match 'nova update'
         $result.Warnings[0] | Should -Match 'Set-NovaUpdateNotificationPreference -DisablePrereleaseNotifications'
         $result.Warnings[0] | Should -Match 'nova notification -disable'
+    }
+
+    It 'Update-NovaModuleTool applies a stable update without prerelease confirmation' {
+        $result = Invoke-TestNovaSelfUpdate -Options ([pscustomobject]@{
+            PrereleaseNotificationsEnabled = $true
+            LookupResult = [pscustomobject]@{
+                Stable = [pscustomobject]@{Version = '1.1.0'}
+                Prerelease = $null
+            }
+            ConfirmPrerelease = $true
+            UseCli = $false
+        })
+
+        $result.PreferenceReadCount | Should -Be 1
+        $result.PrereleaseConfirmationCount | Should -Be 0
+        $result.Result.UpdateAvailable | Should -BeTrue
+        $result.Result.Updated | Should -BeTrue
+        $result.Result.TargetVersion | Should -Be '1.1.0'
+        $result.Result.UsedAllowPrerelease | Should -BeFalse
+        $result.UpdateInvocation.AllowPrerelease | Should -BeFalse
+    }
+
+    It 'Update-NovaModuleTool requires explicit confirmation before a prerelease update proceeds' {
+        $result = Invoke-TestNovaSelfUpdate -Options ([pscustomobject]@{
+            PrereleaseNotificationsEnabled = $true
+            LookupResult = [pscustomobject]@{
+                Stable = $null
+                Prerelease = [pscustomobject]@{Version = '1.1.0-preview'}
+            }
+            ConfirmPrerelease = $false
+            UseCli = $false
+        })
+
+        $result.PrereleaseConfirmationCount | Should -Be 1
+        $result.Result.UpdateAvailable | Should -BeTrue
+        $result.Result.Updated | Should -BeFalse
+        $result.Result.Cancelled | Should -BeTrue
+        $result.UpdateInvocation | Should -BeNullOrEmpty
+    }
+
+    It 'Update-NovaModuleTool respects the shared prerelease preference when both stable and prerelease candidates exist' {
+        foreach ($testCase in @(
+            @{
+                Name = 'disabled preference stays on stable'
+                PrereleaseNotificationsEnabled = $false
+                ExpectedConfirmationCount = 0
+                ExpectedTargetVersion = '1.1.0'
+                ExpectedAllowPrerelease = $false
+            }
+            @{
+                Name = 're-enabled preference can target prerelease again'
+                PrereleaseNotificationsEnabled = $true
+                ExpectedConfirmationCount = 1
+                ExpectedTargetVersion = '2.0.0-preview'
+                ExpectedAllowPrerelease = $true
+            }
+        )) {
+            $result = Invoke-TestNovaSelfUpdate -Options ([pscustomobject]@{
+                PrereleaseNotificationsEnabled = $testCase.PrereleaseNotificationsEnabled
+                LookupResult = [pscustomobject]@{
+                    Stable = [pscustomobject]@{Version = '1.1.0'}
+                    Prerelease = [pscustomobject]@{Version = '2.0.0-preview'}
+                }
+                ConfirmPrerelease = $true
+                UseCli = $false
+            })
+
+            $result.PrereleaseConfirmationCount | Should -Be $testCase.ExpectedConfirmationCount -Because $testCase.Name
+            $result.Result.TargetVersion | Should -Be $testCase.ExpectedTargetVersion -Because $testCase.Name
+            $result.Result.UsedAllowPrerelease | Should -Be $testCase.ExpectedAllowPrerelease -Because $testCase.Name
+            $result.UpdateInvocation.AllowPrerelease | Should -Be $testCase.ExpectedAllowPrerelease -Because $testCase.Name
+        }
+    }
+
+    It 'Invoke-NovaBuildUpdateNotification and Update-NovaModuleTool both use the shared prerelease preference helper' {
+        InModuleScope $script:moduleName {
+            $script:preferenceReadCount = 0
+
+            Mock Read-NovaUpdateNotificationPreference {
+                $script:preferenceReadCount++
+                [pscustomobject]@{PrereleaseNotificationsEnabled = $true}
+            }
+            Mock Get-NovaInstalledModuleVersionInfo {
+                [pscustomobject]@{
+                    ModuleName = 'NovaModuleTools'
+                    Version = '1.0.0'
+                    SemanticVersion = [semver]'1.0.0'
+                    IsPrerelease = $false
+                }
+            }
+            Mock Invoke-NovaModuleUpdateLookup {
+                [pscustomobject]@{
+                    Stable = $null
+                    Prerelease = $null
+                }
+            }
+            Mock Write-Warning {throw 'should stay silent'}
+            Mock Confirm-NovaPrereleaseModuleUpdate {throw 'should not prompt'}
+            Mock Invoke-NovaModuleSelfUpdate {throw 'should not update'}
+
+            Invoke-NovaBuildUpdateNotification
+            $result = Update-NovaModuleTool -Confirm:$false
+
+            $script:preferenceReadCount | Should -Be 2
+            $result.PrereleaseNotificationsEnabled | Should -BeTrue
+            $result.UpdateAvailable | Should -BeFalse
+        }
+    }
+
+    It 'CLI and command help include nova update and its prerelease behavior' {
+        InModuleScope $script:moduleName {
+            $cliHelp = Invoke-NovaCli --help
+            $commandHelp = Get-Help Update-NovaModuleTool -Full -ErrorAction Stop | Out-String
+
+            $cliHelp | Should -Match 'update\s+Update the installed NovaModuleTools module using the stored prerelease preference'
+            $cliHelp | Should -Match 'nova update'
+            $cliHelp | Should -Match 'prerelease targets require explicit confirmation'
+            $commandHelp | Should -Match 'same stored prerelease preference'
+            $commandHelp | Should -Match 'explicit confirmation'
+            $commandHelp | Should -Match 'nova update'
+        }
     }
 
     It 'Invoke-NovaBuildUpdateNotification stays silent when lookup returns nothing' {


### PR DESCRIPTION
… command

- Introduced `Update-NovaModuleTool` and its alias `Update-NovaModuleTools` for self-updating.
- Added `nova update` command for CLI-based self-updating.
- Implemented confirmation prompt for prerelease updates.
- Reused stored prerelease preference for update eligibility.