### PR TITLE
Feature/80 add a new package workflow for user projects built with novamoduletools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `nova version -Installed` so users can compare the locally installed version of the current project/module with
   the current project version from `project.json`, while keeping `nova --version` dedicated to the installed
   NovaModuleTools version.
+- Add `Pack-NovaModule` and `nova pack` so projects can build, test, and package the built module output as a `.nupkg`
+  artifact under `artifacts/packages/` by using generic metadata from `project.json`, including repositories whose test
+  runs reload or remove `NovaModuleTools` before the final package step.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `Pack-NovaModule` and `nova pack` so projects can build, test, and package the built module output as a `.nupkg`
   artifact by using generic metadata from `project.json`, including repositories whose test runs reload or remove
   `NovaModuleTools` before the final package step.
+    - Package output now supports `Package.Types` with case-insensitive `NuGet`, `Zip`, `.nupkg`, and `.zip` values.
+    - Omitting `Package.Types` still defaults packaging to a `.nupkg` artifact.
+    - Selecting both `NuGet` and `Zip` creates both package formats in the configured output directory.
     - Package output now uses `Package.OutputDirectory.Path` with `Package.OutputDirectory.Clean` defaulting to `true`.
     - `nova pack` and `Pack-NovaModule` no longer depend on a separate `Package.Enabled` switch.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix configuration and validation errors so empty `project.json` files and unsupported `Manifest` keys fail fast with
   clear messages.
+- Fix `Pack-NovaModule` and `nova pack` so schema-optional `Manifest` metadata such as `ProjectUri`, `ReleaseNotes`,
+  `LicenseUri`, and `Tags` are omitted cleanly instead of causing packaging failures when they are not present.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the current project version from `project.json`, while keeping `nova --version` dedicated to the installed
   NovaModuleTools version.
 - Add `Pack-NovaModule` and `nova pack` so projects can build, test, and package the built module output as a `.nupkg`
-  artifact under `artifacts/packages/` by using generic metadata from `project.json`, including repositories whose test
-  runs reload or remove `NovaModuleTools` before the final package step.
+  artifact by using generic metadata from `project.json`, including repositories whose test runs reload or remove
+  `NovaModuleTools` before the final package step.
+    - Package output now uses `Package.OutputDirectory.Path` with `Package.OutputDirectory.Clean` defaulting to `true`.
+    - `nova pack` and `Pack-NovaModule` no longer depend on a separate `Package.Enabled` switch.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ PS> nova pack
 
 The package command runs the normal build and test flow, then writes the generated package to
 `artifacts/packages/` by default by using the generic `Package` section in `project.json` when present.
+When `Manifest.Tags`, `Manifest.ProjectUri`, `Manifest.ReleaseNotes`, or `Manifest.LicenseUri` are present, Nova
+copies them into the generated package metadata; when they are omitted, packaging still succeeds and the matching
+package metadata fields are simply left out.
 
 Use this `project.json` shape when you want to control the package output directory:
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,19 @@ Notes:
 - it writes NUnit XML to `artifacts/TestResults.xml`
 - it respects `BuildRecursiveFolders` when discovering tests
 
+### Create a package artifact
+
+Use the explicit packaging workflow when you want a `.nupkg` artifact for a Nova project without publishing to a
+PowerShell repository:
+
+```powershell
+PS> Pack-NovaModule
+PS> nova pack
+```
+
+The package command runs the normal build and test flow, then writes the generated package to
+`artifacts/packages/` by using the generic `Package` section in `project.json` when present.
+
 ### Run code quality checks
 
 Run ScriptAnalyzer with the repository helper:

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Notes:
 
 ### Create a package artifact
 
-Use the explicit packaging workflow when you want a `.nupkg` artifact for a Nova project without publishing to a
+Use the explicit packaging workflow when you want a package artifact for a Nova project without publishing to a
 PowerShell repository:
 
 ```powershell
@@ -182,16 +182,17 @@ PS> Pack-NovaModule
 PS> nova pack
 ```
 
-The package command runs the normal build and test flow, then writes the generated package to
+The package command runs the normal build and test flow, then writes the generated package artifacts to
 `artifacts/packages/` by default by using the generic `Package` section in `project.json` when present.
 When `Manifest.Tags`, `Manifest.ProjectUri`, `Manifest.ReleaseNotes`, or `Manifest.LicenseUri` are present, Nova
 copies them into the generated package metadata; when they are omitted, packaging still succeeds and the matching
 package metadata fields are simply left out.
 
-Use this `project.json` shape when you want to control the package output directory:
+Use this `project.json` shape when you want to control the package types and output directory:
 
 ```json
 "Package": {
+"Types": ["NuGet", "Zip"],
   "OutputDirectory": {
     "Path": "artifacts/packages",
     "Clean": true
@@ -199,7 +200,10 @@ Use this `project.json` shape when you want to control the package output direct
 }
 ```
 
-- `Path` selects where the `.nupkg` is written.
+- `Types` is optional. When it is missing, empty, or null, Nova defaults to `NuGet` and creates a `.nupkg`.
+- Supported `Types` values are `NuGet`, `Zip`, `.nupkg`, and `.zip`, and matching is case-insensitive.
+- Use `Types = ["Zip"]` when you only want a `.zip`, or `Types = ["NuGet", "Zip"]` when you want both files.
+- `Path` selects where the package artifact(s) are written.
 - `Clean` defaults to `true` and removes that output directory before a new package is created.
 - Set `Clean` to `false` when you want to keep existing files in the package output directory.
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,22 @@ PS> nova pack
 ```
 
 The package command runs the normal build and test flow, then writes the generated package to
-`artifacts/packages/` by using the generic `Package` section in `project.json` when present.
+`artifacts/packages/` by default by using the generic `Package` section in `project.json` when present.
+
+Use this `project.json` shape when you want to control the package output directory:
+
+```json
+"Package": {
+  "OutputDirectory": {
+    "Path": "artifacts/packages",
+    "Clean": true
+  }
+}
+```
+
+- `Path` selects where the `.nupkg` is written.
+- `Clean` defaults to `true` and removes that output directory before a new package is created.
+- Set `Clean` to `false` when you want to keep existing files in the package output directory.
 
 ### Run code quality checks
 

--- a/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
@@ -4,7 +4,7 @@ external help file: NovaModuleTools-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: NovaModuleTools
-ms.date: 04/14/2026
+ms.date: 04/19/2026
 PlatyPS schema version: 2024-05-01
 title: Invoke-NovaCli
 ---
@@ -41,8 +41,12 @@ PowerShell
 `-WhatIf`/`-Confirm` to the underlying cmdlet. That means `nova build -WhatIf` and
 `Invoke-NovaCli -Command build -WhatIf` both preview the build instead of running it.
 
-Use `nova pack` when you want to build, test, and package the current project into a `.nupkg` artifact. By default it
-writes to `artifacts/packages/`, and you can override that with `Package.OutputDirectory.Path` in `project.json`.
+Use `nova pack` when you want to build, test, and package the current project into one or more configured package
+artifacts. By default it writes a `.nupkg` to `artifacts/packages/`, and you can override that with
+`Package.OutputDirectory.Path` in `project.json`.
+
+Use `Package.Types` in `project.json` when you want to switch from the default `NuGet` output to `Zip`, or when you
+want both formats. Supported values are `NuGet`, `Zip`, `.nupkg`, and `.zip`, and matching is case-insensitive.
 
 For local publish inside an imported PowerShell session, `nova publish -local` now reloads the published module from the
 resolved local install path after the copy succeeds. Preview or cancelled runs do not import anything.
@@ -118,7 +122,8 @@ Builds the module using `Invoke-NovaBuild`.
 nova pack
 ```
 
-Builds, tests, and packages the current project as a `.nupkg` artifact.
+Builds, tests, and packages the current project by using the configured `Package.Types` values. When `Package.Types` is
+omitted, `nova pack` creates a `.nupkg` by default.
 
 ### EXAMPLE 6
 

--- a/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
@@ -29,16 +29,20 @@ PS> Invoke-NovaCli [[-Command] <string>] [[-Arguments] <string[]>] [-WhatIf] [-C
 `nova` CLI rather than call `Invoke-NovaCli` directly.
 
 It dispatches high-level commands such as `nova info`, `nova version`, `nova --version`, `nova --help`, `nova build`,
-`nova test`, `nova init`, `nova update`, `nova notification`, `nova publish`, `nova bump`, and `nova release` to the
-matching Nova cmdlet.
+`nova test`, `nova pack`, `nova init`, `nova update`, `nova notification`, `nova publish`, `nova bump`, and
+`nova release`
+to the matching Nova cmdlet.
 
 Use `Invoke-NovaCli` when you need a scriptable PowerShell command entrypoint. Use `nova` when you want the
 user-focused CLI experience.
 
-Mutating routed commands (`build`, `test`, `bump`, `update`, `notification`, `publish`, and `release`) forward
+Mutating routed commands (`build`, `test`, `pack`, `bump`, `update`, `notification`, `publish`, and `release`) forward
 PowerShell
 `-WhatIf`/`-Confirm` to the underlying cmdlet. That means `nova build -WhatIf` and
 `Invoke-NovaCli -Command build -WhatIf` both preview the build instead of running it.
+
+Use `nova pack` when you want to build, test, and package the current project into a `.nupkg` artifact under
+`artifacts/packages/`.
 
 For local publish inside an imported PowerShell session, `nova publish -local` now reloads the published module from the
 resolved local install path after the copy succeeds. Preview or cancelled runs do not import anything.
@@ -111,6 +115,14 @@ Builds the module using `Invoke-NovaBuild`.
 ### EXAMPLE 5
 
 ```powershell
+nova pack
+```
+
+Builds, tests, and packages the current project as a `.nupkg` artifact.
+
+### EXAMPLE 6
+
+```powershell
 nova publish --repository PSGallery --apikey $env:PSGALLERY_API
 ```
 
@@ -118,7 +130,7 @@ Parses CLI arguments and publishes using `Publish-NovaModule`.
 
 When routed inside PowerShell with `-local`, the published module is reloaded from the local install path.
 
-### EXAMPLE 6
+### EXAMPLE 7
 
 ```powershell
 nova --help
@@ -126,7 +138,7 @@ nova --help
 
 Displays the built-in Nova CLI help text.
 
-### EXAMPLE 7
+### EXAMPLE 8
 
 ```powershell
 PS> Invoke-NovaCli -Command build
@@ -134,7 +146,7 @@ PS> Invoke-NovaCli -Command build
 
 Shows the equivalent scripted PowerShell form behind `nova build`.
 
-### EXAMPLE 8
+### EXAMPLE 9
 
 ```powershell
 PS> Invoke-NovaCli -Command publish -Arguments @('-local') -WhatIf
@@ -142,7 +154,7 @@ PS> Invoke-NovaCli -Command publish -Arguments @('-local') -WhatIf
 
 Previews the routed local publish flow without rebuilding, testing, or copying the module.
 
-### EXAMPLE 9
+### EXAMPLE 10
 
 ```powershell
 PS> Invoke-NovaCli -Command init -Arguments @('-Path', '~/Work')
@@ -150,7 +162,7 @@ PS> Invoke-NovaCli -Command init -Arguments @('-Path', '~/Work')
 
 Runs the interactive init flow and creates the project under `~/Work`.
 
-### EXAMPLE 10
+### EXAMPLE 11
 
 ```powershell
 PS> Invoke-NovaCli -Command init -Arguments @('-Example', '-Path', '~/Work')
@@ -158,7 +170,7 @@ PS> Invoke-NovaCli -Command init -Arguments @('-Example', '-Path', '~/Work')
 
 Runs the interactive init flow, scaffolds from the packaged example project, and creates the project under `~/Work`.
 
-### EXAMPLE 11
+### EXAMPLE 12
 
 ```powershell
 nova update
@@ -175,7 +187,7 @@ Successful updates print the release notes link from the installed module manife
 If no newer version is available, the standalone launcher prints `You're up to date!` and reports the installed
 `NovaModuleTools` version.
 
-### EXAMPLE 12
+### EXAMPLE 13
 
 ```powershell
 nova notification
@@ -183,7 +195,7 @@ nova notification
 
 Shows whether prerelease self-updates are enabled and where the preference is stored.
 
-### EXAMPLE 13
+### EXAMPLE 14
 
 ```powershell
 nova notification -disable
@@ -191,7 +203,7 @@ nova notification -disable
 
 Disables prerelease self-update targets so `nova update` stays on stable releases.
 
-### EXAMPLE 14
+### EXAMPLE 15
 
 ```powershell
 PS> Invoke-NovaCli -Command notification -Arguments @('-enable')
@@ -203,7 +215,7 @@ Re-enables prerelease self-update targets from the routed PowerShell entrypoint.
 
 ### -Command
 
-The command to execute. Supported values: `info`, `version`, `--version`, `--help`, `build`, `test`, `init`,
+The command to execute. Supported values: `info`, `version`, `--version`, `--help`, `build`, `test`, `pack`, `init`,
 `update`, `notification`, `publish`, `bump`, `release`.
 
 ```yaml

--- a/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
@@ -41,8 +41,8 @@ PowerShell
 `-WhatIf`/`-Confirm` to the underlying cmdlet. That means `nova build -WhatIf` and
 `Invoke-NovaCli -Command build -WhatIf` both preview the build instead of running it.
 
-Use `nova pack` when you want to build, test, and package the current project into a `.nupkg` artifact under
-`artifacts/packages/`.
+Use `nova pack` when you want to build, test, and package the current project into a `.nupkg` artifact. By default it
+writes to `artifacts/packages/`, and you can override that with `Package.OutputDirectory.Path` in `project.json`.
 
 For local publish inside an imported PowerShell session, `nova publish -local` now reloads the published module from the
 resolved local install path after the copy succeeds. Preview or cancelled runs do not import anything.

--- a/docs/NovaModuleTools/en-US/NovaModuleTools.md
+++ b/docs/NovaModuleTools/en-US/NovaModuleTools.md
@@ -14,8 +14,8 @@ title: NovaModuleTools Module
 
 ## Description
 
-NovaModuleTools helps you scaffold, build, test, version, and publish PowerShell modules with a consistent project
-layout and a repeatable workflow.
+NovaModuleTools helps you scaffold, build, test, package, version, and publish PowerShell modules with a consistent
+project layout and a repeatable workflow.
 
 Use the module when you want a structured path from source files under `src/` to a built module under `dist/`, including
 manifest generation, external help generation, resource copying, and Pester-based validation.
@@ -45,6 +45,10 @@ Routes the `nova` CLI experience through a single PowerShell command entrypoint.
 ### `PS> Invoke-NovaRelease`
 
 Runs the Nova release pipeline (build, test, version bump, rebuild, publish).
+
+### `PS> Pack-NovaModule`
+
+Builds, tests, and packages the current project as a `.nupkg` artifact.
 
 ### `PS> Test-NovaBuild`
 

--- a/docs/NovaModuleTools/en-US/Pack-NovaModule.md
+++ b/docs/NovaModuleTools/en-US/Pack-NovaModule.md
@@ -160,6 +160,9 @@ Package metadata reuses values from `project.json` when possible, including:
 - `Manifest.ReleaseNotes`
 - `Manifest.LicenseUri`
 
+`Manifest.Tags`, `Manifest.ProjectUri`, `Manifest.ReleaseNotes`, and `Manifest.LicenseUri` are optional. When they are
+missing, `Pack-NovaModule` omits the matching package metadata fields instead of treating them as required.
+
 Use the top-level `Package` section only for generic packaging overrides such as output directory or package file name.
 `Pack-NovaModule` always allows packaging when you invoke it; there is no separate `Package.Enabled` switch.
 

--- a/docs/NovaModuleTools/en-US/Pack-NovaModule.md
+++ b/docs/NovaModuleTools/en-US/Pack-NovaModule.md
@@ -1,0 +1,155 @@
+---
+document type: cmdlet
+external help file: NovaModuleTools-Help.xml
+HelpUri: ''
+Locale: en-US
+Module Name: NovaModuleTools
+ms.date: 04/19/2026
+PlatyPS schema version: 2024-05-01
+title: Pack-NovaModule
+---
+
+# Pack-NovaModule
+
+## SYNOPSIS
+
+Builds, tests, and packages the current project as a `.nupkg` artifact.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```powershell
+PS> Pack-NovaModule [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+`Pack-NovaModule` runs the normal NovaModuleTools build and test flow, then packages the built module output from
+`dist/<ProjectName>/` into a NuGet-compatible `.nupkg` artifact.
+
+The package is written to `artifacts/packages/` by default. You can override generic package metadata through the
+optional `Package` section in `project.json`.
+
+This command is intended for NovaModuleTools user projects that need a deployable package artifact without publishing to
+PowerShell Gallery.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+PS> Pack-NovaModule
+```
+
+Builds the project, runs `Test-NovaBuild`, and writes a `.nupkg` to `artifacts/packages/`.
+
+### EXAMPLE 2
+
+```powershell
+PS> nova pack
+```
+
+Runs the same packaging workflow through the `nova` CLI.
+
+### EXAMPLE 3
+
+```powershell
+PS> Pack-NovaModule -WhatIf
+```
+
+Previews the build, test, and package workflow without writing a package artifact.
+
+### EXAMPLE 4
+
+```powershell
+PS> Pack-NovaModule -Confirm
+```
+
+Prompts before the package artifact is created.
+
+## PARAMETERS
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases:
+  - wi
+ParameterSets:
+  - Name: (All)
+	Position: Named
+	IsRequired: false
+	ValueFromPipeline: false
+	ValueFromPipelineByPropertyName: false
+	ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: [ ]
+HelpMessage: ''
+```
+
+### -Confirm
+
+Prompts for confirmation before the package artifact is created.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases:
+  - cf
+ParameterSets:
+  - Name: (All)
+	Position: Named
+	IsRequired: false
+	ValueFromPipeline: false
+	ValueFromPipelineByPropertyName: false
+	ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: [ ]
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, -WarningVariable, -WhatIf, and -Confirm. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+You can't pipe objects to this cmdlet.
+
+## OUTPUTS
+
+### System.Management.Automation.PSCustomObject
+
+Returns package metadata that includes the generated package path, output directory, and source module directory.
+
+## NOTES
+
+Package metadata reuses values from `project.json` when possible, including:
+
+- `ProjectName`
+- `Description`
+- `Version`
+- `Manifest.Author`
+- `Manifest.Tags`
+- `Manifest.ProjectUri`
+- `Manifest.ReleaseNotes`
+- `Manifest.LicenseUri`
+
+Use the top-level `Package` section only for generic packaging overrides such as output directory or package file name.
+
+## RELATED LINKS
+
+- https://github.com/stiwicourage/NovaModuleTools/blob/main/docs/NovaModuleTools/en-US/Invoke-NovaBuild.md
+- https://github.com/stiwicourage/NovaModuleTools/blob/main/docs/NovaModuleTools/en-US/Test-NovaBuild.md
+- https://github.com/stiwicourage/NovaModuleTools/blob/main/docs/NovaModuleTools/en-US/Invoke-NovaCli.md

--- a/docs/NovaModuleTools/en-US/Pack-NovaModule.md
+++ b/docs/NovaModuleTools/en-US/Pack-NovaModule.md
@@ -13,7 +13,7 @@ title: Pack-NovaModule
 
 ## SYNOPSIS
 
-Builds, tests, and packages the current project as a `.nupkg` artifact.
+Builds, tests, and packages the current project as one or more configured package artifacts.
 
 ## SYNTAX
 
@@ -26,21 +26,27 @@ PS> Pack-NovaModule [-WhatIf] [-Confirm] [<CommonParameters>]
 ## DESCRIPTION
 
 `Pack-NovaModule` runs the normal NovaModuleTools build and test flow, then packages the built module output from
-`dist/<ProjectName>/` into a NuGet-compatible `.nupkg` artifact.
+`dist/<ProjectName>/` into the package formats requested by `Package.Types`.
 
 The package is written to `artifacts/packages/` by default. You can override generic package metadata through the
 optional `Package` section in `project.json`.
 
-Use this `project.json` shape when you want to control the package output directory:
+Use this `project.json` shape when you want to control package types and the package output directory:
 
 ```json
 "Package": {
+"Types": ["NuGet", "Zip"],
   "OutputDirectory": {
 	"Path": "artifacts/packages",
 	"Clean": true
   }
 }
 ```
+
+`Package.Types` is optional. When it is missing, empty, or null, `Pack-NovaModule` defaults to `NuGet` and creates a
+`.nupkg` file.
+
+Supported `Package.Types` values are `NuGet`, `Zip`, `.nupkg`, and `.zip`, and matching is case-insensitive.
 
 `Package.OutputDirectory.Clean` defaults to `true`, which deletes the configured package output directory before a new
 package is created. Set it to `false` when you want to keep existing files in that directory.
@@ -56,7 +62,8 @@ PowerShell Gallery.
 PS> Pack-NovaModule
 ```
 
-Builds the project, runs `Test-NovaBuild`, cleans `artifacts/packages/` by default, and writes a new `.nupkg` there.
+Builds the project, runs `Test-NovaBuild`, cleans `artifacts/packages/` by default, and writes a new `.nupkg` there
+when `Package.Types` is omitted or resolves to `NuGet`.
 
 ### EXAMPLE 2
 
@@ -69,12 +76,21 @@ Runs the same packaging workflow through the `nova` CLI.
 ### EXAMPLE 3
 
 ```powershell
+PS> Pack-NovaModule
+```
+
+When `Package.Types` is `@('NuGet', 'Zip')`, the command writes both `*.nupkg` and `*.zip` artifacts to the configured
+package output directory.
+
+### EXAMPLE 4
+
+```powershell
 PS> Pack-NovaModule -WhatIf
 ```
 
 Previews the build, test, and package workflow without writing a package artifact.
 
-### EXAMPLE 4
+### EXAMPLE 5
 
 ```powershell
 PS> Pack-NovaModule -Confirm
@@ -145,7 +161,8 @@ You can't pipe objects to this cmdlet.
 
 ### System.Management.Automation.PSCustomObject
 
-Returns package metadata that includes the generated package path, output directory, and source module directory.
+Returns one artifact metadata object per generated package, including the package type, generated package path, output
+directory, and source module directory.
 
 ## NOTES
 
@@ -163,8 +180,9 @@ Package metadata reuses values from `project.json` when possible, including:
 `Manifest.Tags`, `Manifest.ProjectUri`, `Manifest.ReleaseNotes`, and `Manifest.LicenseUri` are optional. When they are
 missing, `Pack-NovaModule` omits the matching package metadata fields instead of treating them as required.
 
-Use the top-level `Package` section only for generic packaging overrides such as output directory or package file name.
-`Pack-NovaModule` always allows packaging when you invoke it; there is no separate `Package.Enabled` switch.
+Use the top-level `Package` section only for generic packaging overrides such as package type selection, output
+directory, or package file name. `Pack-NovaModule` always allows packaging when you invoke it; there is no separate
+`Package.Enabled` switch.
 
 ## RELATED LINKS
 

--- a/docs/NovaModuleTools/en-US/Pack-NovaModule.md
+++ b/docs/NovaModuleTools/en-US/Pack-NovaModule.md
@@ -31,6 +31,20 @@ PS> Pack-NovaModule [-WhatIf] [-Confirm] [<CommonParameters>]
 The package is written to `artifacts/packages/` by default. You can override generic package metadata through the
 optional `Package` section in `project.json`.
 
+Use this `project.json` shape when you want to control the package output directory:
+
+```json
+"Package": {
+  "OutputDirectory": {
+	"Path": "artifacts/packages",
+	"Clean": true
+  }
+}
+```
+
+`Package.OutputDirectory.Clean` defaults to `true`, which deletes the configured package output directory before a new
+package is created. Set it to `false` when you want to keep existing files in that directory.
+
 This command is intended for NovaModuleTools user projects that need a deployable package artifact without publishing to
 PowerShell Gallery.
 
@@ -42,7 +56,7 @@ PowerShell Gallery.
 PS> Pack-NovaModule
 ```
 
-Builds the project, runs `Test-NovaBuild`, and writes a `.nupkg` to `artifacts/packages/`.
+Builds the project, runs `Test-NovaBuild`, cleans `artifacts/packages/` by default, and writes a new `.nupkg` there.
 
 ### EXAMPLE 2
 
@@ -147,6 +161,7 @@ Package metadata reuses values from `project.json` when possible, including:
 - `Manifest.LicenseUri`
 
 Use the top-level `Package` section only for generic packaging overrides such as output directory or package file name.
+`Pack-NovaModule` always allows packaging when you invoke it; there is no separate `Package.Enabled` switch.
 
 ## RELATED LINKS
 

--- a/docs/core-workflows.html
+++ b/docs/core-workflows.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
-    <title>NovaModuleTools — PowerShell module build, test, bump, and release workflows</title>
-    <meta content="Follow the normal NovaModuleTools workflow for scaffolding, building, testing, versioning, and releasing a PowerShell module."
+    <title>NovaModuleTools — PowerShell module build, test, package, bump, and release workflows</title>
+    <meta content="Follow the normal NovaModuleTools workflow for scaffolding, building, testing, packaging, versioning, and releasing a PowerShell module."
           name="description">
     <meta content="index,follow,max-image-preview:large" name="robots">
     <meta content="#0b1020" name="theme-color">
@@ -12,14 +12,16 @@
     <link href="./assets/icon.png" rel="icon" type="image/png">
     <link href="./assets/icon.png" rel="apple-touch-icon">
     <meta content="article" property="og:type">
-    <meta content="NovaModuleTools — PowerShell module build, test, bump, and release workflows" property="og:title">
-    <meta content="Learn the standard NovaModuleTools workflow for scaffolding, building, testing, versioning, and releasing a PowerShell module."
+    <meta content="NovaModuleTools — PowerShell module build, test, package, bump, and release workflows"
+          property="og:title">
+    <meta content="Learn the standard NovaModuleTools workflow for scaffolding, building, testing, packaging, versioning, and releasing a PowerShell module."
           property="og:description">
     <meta content="https://www.novamoduletools.com/core-workflows.html" property="og:url">
     <meta content="https://www.novamoduletools.com/assets/icon.png" property="og:image">
     <meta content="summary" name="twitter:card">
-    <meta content="NovaModuleTools — PowerShell module build, test, bump, and release workflows" name="twitter:title">
-    <meta content="Learn the standard NovaModuleTools workflow for scaffolding, building, testing, versioning, and releasing a PowerShell module."
+    <meta content="NovaModuleTools — PowerShell module build, test, package, bump, and release workflows"
+          name="twitter:title">
+    <meta content="Learn the standard NovaModuleTools workflow for scaffolding, building, testing, packaging, versioning, and releasing a PowerShell module."
           name="twitter:description">
     <link href="./assets/site.css" rel="stylesheet">
     <script type="application/ld+json">
@@ -27,7 +29,7 @@
             "@context": "https://schema.org",
             "@type": "TechArticle",
             "headline": "NovaModuleTools Core Workflows",
-            "description": "Build, test, bump, and release PowerShell modules with NovaModuleTools.",
+            "description": "Build, test, package, bump, and release PowerShell modules with NovaModuleTools.",
             "url": "https://www.novamoduletools.com/core-workflows.html"
         }
     </script>
@@ -52,7 +54,7 @@
 <main class="page-shell">
     <section class="guide-hero">
         <p class="eyebrow">Core workflows</p>
-        <h1>Use NovaModuleTools as a repeatable scaffold → build → test → bump → release flow</h1>
+        <h1>Use NovaModuleTools as a repeatable scaffold → build → test → pack → bump → release flow</h1>
         <p class="lead">This guide explains the normal command sequence for day-to-day PowerShell module work.</p>
     </section>
 
@@ -63,6 +65,7 @@
                 <li><a href="#scaffold">Scaffold</a></li>
                 <li><a href="#build">Build</a></li>
                 <li><a href="#test">Test</a></li>
+                <li><a href="#pack">Pack</a></li>
                 <li><a href="#bump">Version bump</a></li>
                 <li><a href="#release">Release</a></li>
             </ul>
@@ -93,6 +96,17 @@ nova init -Example</code></pre>
                     under <code>artifacts/TestResults.xml</code>.</p>
                 <p>If your project uses nested test folders, discovery follows the <code>BuildRecursiveFolders</code>
                     setting in <code>project.json</code>.</p>
+            </section>
+
+            <section class="content-section" id="pack">
+                <h2>Create a package artifact</h2>
+                <pre><code>nova pack</code></pre>
+                <p><code>nova pack</code> runs the normal build and test flow, then writes a <code>.nupkg</code>
+                    artifact to
+                    <code>artifacts/packages/</code>.</p>
+                <p>Use the optional <code>Package</code> section in <code>project.json</code> when you want to override
+                    the
+                    package ID, output directory, or other generic package metadata.</p>
             </section>
 
             <section class="content-section" id="bump">

--- a/docs/core-workflows.html
+++ b/docs/core-workflows.html
@@ -101,10 +101,13 @@ nova init -Example</code></pre>
             <section class="content-section" id="pack">
                 <h2>Create a package artifact</h2>
                 <pre><code>nova pack</code></pre>
-                <p><code>nova pack</code> runs the normal build and test flow, then writes a <code>.nupkg</code>
-                    artifact to <code>artifacts/packages/</code> by default.</p>
+                <p><code>nova pack</code> runs the normal build and test flow, then writes package artifacts to
+                    <code>artifacts/packages/</code> by default. When <code>Package.Types</code> is omitted, it creates
+                    a
+                    <code>.nupkg</code>.</p>
                 <p>Use the optional <code>Package</code> section in <code>project.json</code> when you want to override
-                    the package ID, output directory, or other generic package metadata. Use
+                    the package ID, package types, output directory, or other generic package metadata. Use
+                    <code>Package.Types</code> for <code>NuGet</code>, <code>Zip</code>, or both, and use
                     <code>Package.OutputDirectory.Path</code> for the target folder and
                     <code>Package.OutputDirectory.Clean</code> when you want to keep or clear existing package files
                     before a new package is created.</p>

--- a/docs/core-workflows.html
+++ b/docs/core-workflows.html
@@ -102,11 +102,12 @@ nova init -Example</code></pre>
                 <h2>Create a package artifact</h2>
                 <pre><code>nova pack</code></pre>
                 <p><code>nova pack</code> runs the normal build and test flow, then writes a <code>.nupkg</code>
-                    artifact to
-                    <code>artifacts/packages/</code>.</p>
+                    artifact to <code>artifacts/packages/</code> by default.</p>
                 <p>Use the optional <code>Package</code> section in <code>project.json</code> when you want to override
-                    the
-                    package ID, output directory, or other generic package metadata.</p>
+                    the package ID, output directory, or other generic package metadata. Use
+                    <code>Package.OutputDirectory.Path</code> for the target folder and
+                    <code>Package.OutputDirectory.Clean</code> when you want to keep or clear existing package files
+                    before a new package is created.</p>
             </section>
 
             <section class="content-section" id="bump">

--- a/project.json
+++ b/project.json
@@ -25,8 +25,9 @@
     "LicenseUri": "https://www.novamoduletools.com/license.html"
   },
   "Package": {
-    "Enabled": false,
-    "OutputDirectory": "artifacts/packages"
+    "OutputDirectory": {
+      "Path": "artifacts/packages"
+    }
   },
   "Pester": {
     "TestResult": {

--- a/project.json
+++ b/project.json
@@ -25,8 +25,12 @@
     "LicenseUri": "https://www.novamoduletools.com/license.html"
   },
   "Package": {
+    "Types": [
+      "NuGet"
+    ],
     "OutputDirectory": {
-      "Path": "artifacts/packages"
+      "Path": "artifacts/packages",
+      "Clean": true
     }
   },
   "Pester": {

--- a/project.json
+++ b/project.json
@@ -1,7 +1,7 @@
 {
   "ProjectName": "NovaModuleTools",
   "Description": "NovaModuleTools is an enterprise-focused evolution of ModuleTools, designed for large-scale PowerShell projects with a strong emphasis on structure, maintainability, and automated CI/CD pipelines.",
-  "Version": "2.0.0-preview5",
+  "Version": "2.0.0-preview6",
   "Preamble": [
     "Set-StrictMode -Version Latest",
     "$ErrorActionPreference = 'Stop'"
@@ -23,6 +23,10 @@
     "ReleaseNotes": "https://www.novamoduletools.com/release-notes.html",
     "IconUri": "https://www.novamoduletools.com/assets/icon.png",
     "LicenseUri": "https://www.novamoduletools.com/license.html"
+  },
+  "Package": {
+    "Enabled": false,
+    "OutputDirectory": "artifacts/packages"
   },
   "Pester": {
     "TestResult": {

--- a/src/private/cli/InvokeNovaCliNotificationCommand.ps1
+++ b/src/private/cli/InvokeNovaCliNotificationCommand.ps1
@@ -1,0 +1,23 @@
+function Invoke-NovaCliNotificationCommand {
+    [CmdletBinding()]
+    param(
+        [AllowEmptyCollection()][string[]]$Arguments = @(),
+        [Parameter(Mandatory)][hashtable]$CommonParameters,
+        [Parameter(Mandatory)][hashtable]$MutatingCommonParameters
+    )
+
+    $notificationAction = ConvertFrom-NovaNotificationCliArgument -Arguments $Arguments
+
+    switch ($notificationAction) {
+        'status' {
+            return Get-NovaUpdateNotificationPreference @CommonParameters
+        }
+        'enable' {
+            return Set-NovaUpdateNotificationPreference -EnablePrereleaseNotifications @MutatingCommonParameters
+        }
+        default {
+            return Set-NovaUpdateNotificationPreference -DisablePrereleaseNotifications @MutatingCommonParameters
+        }
+    }
+}
+

--- a/src/private/package/AddNovaZipFileEntry.ps1
+++ b/src/private/package/AddNovaZipFileEntry.ps1
@@ -1,0 +1,20 @@
+function Add-NovaZipFileEntry {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][System.IO.Compression.ZipArchive]$Archive,
+        [Parameter(Mandatory)][string]$EntryPath,
+        [Parameter(Mandatory)][string]$SourcePath
+    )
+
+    $entry = $Archive.CreateEntry($EntryPath, [System.IO.Compression.CompressionLevel]::Optimal)
+    $entryStream = $entry.Open()
+    $sourceStream = [System.IO.File]::OpenRead($SourcePath)
+    try {
+        $sourceStream.CopyTo($entryStream)
+    }
+    finally {
+        $sourceStream.Dispose()
+        $entryStream.Dispose()
+    }
+}
+

--- a/src/private/package/AddNovaZipTextEntry.ps1
+++ b/src/private/package/AddNovaZipTextEntry.ps1
@@ -1,0 +1,18 @@
+function Add-NovaZipTextEntry {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][System.IO.Compression.ZipArchive]$Archive,
+        [Parameter(Mandatory)][string]$EntryPath,
+        [Parameter(Mandatory)][string]$Content
+    )
+
+    $entry = $Archive.CreateEntry($EntryPath, [System.IO.Compression.CompressionLevel]::Optimal)
+    $streamWriter = [System.IO.StreamWriter]::new($entry.Open(),[System.Text.UTF8Encoding]::new($false))
+    try {
+        $streamWriter.Write($Content)
+    }
+    finally {
+        $streamWriter.Dispose()
+    }
+}
+

--- a/src/private/package/AssertNovaPackageMetadata.ps1
+++ b/src/private/package/AssertNovaPackageMetadata.ps1
@@ -5,7 +5,7 @@ function Assert-NovaPackageMetadata {
         [Parameter(Mandatory)][pscustomobject]$PackageMetadata
     )
 
-    foreach ($requiredField in @('Id', 'Version', 'Description', 'OutputDirectory', 'PackageFileName', 'PackagePath')) {
+    foreach ($requiredField in @('Type', 'Id', 'Version', 'Description', 'OutputDirectory', 'PackageFileName', 'PackagePath')) {
         if ( [string]::IsNullOrWhiteSpace($PackageMetadata.$requiredField)) {
             throw "Missing package metadata value: $requiredField"
         }

--- a/src/private/package/AssertNovaPackageMetadata.ps1
+++ b/src/private/package/AssertNovaPackageMetadata.ps1
@@ -5,11 +5,7 @@ function Assert-NovaPackageMetadata {
         [Parameter(Mandatory)][pscustomobject]$PackageMetadata
     )
 
-    if (-not $PackageMetadata.Enabled) {
-        throw 'Package.Enabled is false in project.json. Enable packaging before running Pack-NovaModule.'
-    }
-
-    foreach ($requiredField in @('Id', 'Version', 'Description', 'PackagePath')) {
+    foreach ($requiredField in @('Id', 'Version', 'Description', 'OutputDirectory', 'PackageFileName', 'PackagePath')) {
         if ( [string]::IsNullOrWhiteSpace($PackageMetadata.$requiredField)) {
             throw "Missing package metadata value: $requiredField"
         }

--- a/src/private/package/AssertNovaPackageMetadata.ps1
+++ b/src/private/package/AssertNovaPackageMetadata.ps1
@@ -1,0 +1,22 @@
+function Assert-NovaPackageMetadata {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Package metadata is the established domain term validated by this helper.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$PackageMetadata
+    )
+
+    if (-not $PackageMetadata.Enabled) {
+        throw 'Package.Enabled is false in project.json. Enable packaging before running Pack-NovaModule.'
+    }
+
+    foreach ($requiredField in @('Id', 'Version', 'Description', 'PackagePath')) {
+        if ( [string]::IsNullOrWhiteSpace($PackageMetadata.$requiredField)) {
+            throw "Missing package metadata value: $requiredField"
+        }
+    }
+
+    if (@($PackageMetadata.Authors).Count -eq 0) {
+        throw 'Missing package metadata value: Authors'
+    }
+}
+

--- a/src/private/package/AssertNovaPackageOutputDirectoryCanBeCleared.ps1
+++ b/src/private/package/AssertNovaPackageOutputDirectoryCanBeCleared.ps1
@@ -1,0 +1,19 @@
+function Assert-NovaPackageOutputDirectoryCanBeCleared {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
+        [Parameter(Mandatory)][string]$OutputDirectory
+    )
+
+    $resolvedOutputDirectory = [System.IO.Path]::GetFullPath($OutputDirectory)
+    if ($resolvedOutputDirectory -eq [System.IO.Path]::GetPathRoot($resolvedOutputDirectory)) {
+        throw 'Package.OutputDirectory.Path cannot be a filesystem root when Package.OutputDirectory.Clean is true.'
+    }
+
+    foreach ($protectedPath in @($ProjectInfo.ProjectRoot, $ProjectInfo.OutputModuleDir)) {
+        if (Test-NovaPathContainsPath -ParentPath $resolvedOutputDirectory -ChildPath $protectedPath) {
+            throw "Package.OutputDirectory.Path cannot be cleaned because it would remove required project content: $protectedPath"
+        }
+    }
+}
+

--- a/src/private/package/ClearNovaPackageOutputDirectory.ps1
+++ b/src/private/package/ClearNovaPackageOutputDirectory.ps1
@@ -1,0 +1,14 @@
+function Clear-NovaPackageOutputDirectory {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Pack-NovaModule performs the user-facing ShouldProcess confirmation before calling this internal cleanup helper.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
+        [Parameter(Mandatory)][string]$OutputDirectory
+    )
+
+    Assert-NovaPackageOutputDirectoryCanBeCleared -ProjectInfo $ProjectInfo -OutputDirectory $OutputDirectory
+    if (Test-Path -LiteralPath $OutputDirectory) {
+        Remove-Item -LiteralPath $OutputDirectory -Recurse -Force
+    }
+}
+

--- a/src/private/package/GetNovaManifestValue.ps1
+++ b/src/private/package/GetNovaManifestValue.ps1
@@ -1,0 +1,19 @@
+function Get-NovaManifestValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$Manifest,
+        [Parameter(Mandatory)][string]$Name
+    )
+
+    if ($Manifest -is [System.Collections.IDictionary]) {
+        return $Manifest[$Name]
+    }
+
+    $property = $Manifest.PSObject.Properties[$Name]
+    if ($null -eq $property) {
+        return $null
+    }
+
+    return $property.Value
+}
+

--- a/src/private/package/GetNovaPackageAuthorList.ps1
+++ b/src/private/package/GetNovaPackageAuthorList.ps1
@@ -1,0 +1,30 @@
+function Get-NovaPackageAuthorList {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]$AuthorValue
+    )
+
+    if ($null -eq $AuthorValue) {
+        return @()
+    }
+
+    if ($AuthorValue -is [string]) {
+        if ( [string]::IsNullOrWhiteSpace($AuthorValue)) {
+            return @()
+        }
+
+        return @($AuthorValue.Trim())
+    }
+
+    if ($AuthorValue -isnot [System.Collections.IEnumerable]) {
+        throw 'Package.Authors must be a string or an array of strings.'
+    }
+
+    return @(
+    $AuthorValue |
+            ForEach-Object {"$( $_ )".Trim()} |
+            Where-Object {-not [string]::IsNullOrWhiteSpace($_)} |
+            Select-Object -Unique
+    )
+}
+

--- a/src/private/package/GetNovaPackageContentItemList.ps1
+++ b/src/private/package/GetNovaPackageContentItemList.ps1
@@ -1,0 +1,27 @@
+function Get-NovaPackageContentItemList {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
+        [Parameter(Mandatory)][pscustomobject]$PackageMetadata
+    )
+
+    if (-not (Test-Path -LiteralPath $ProjectInfo.OutputModuleDir)) {
+        throw "Built module output not found: $( $ProjectInfo.OutputModuleDir ). Run Invoke-NovaBuild before packaging."
+    }
+
+    $sourceFiles = @(Get-ChildItem -LiteralPath $ProjectInfo.OutputModuleDir -File -Recurse | Sort-Object FullName)
+    if ($sourceFiles.Count -eq 0) {
+        throw "Built module output has no files to package: $( $ProjectInfo.OutputModuleDir )"
+    }
+
+    return @(
+    $sourceFiles | ForEach-Object {
+        $relativePath = Get-NormalizedRelativePath -Root $ProjectInfo.OutputModuleDir -FullName $_.FullName
+        [pscustomobject]@{
+            SourcePath = $_.FullName
+            PackagePath = "$( $PackageMetadata.ContentRoot )/$relativePath"
+        }
+    }
+    )
+}
+

--- a/src/private/package/GetNovaPackageFileName.ps1
+++ b/src/private/package/GetNovaPackageFileName.ps1
@@ -1,0 +1,19 @@
+function Get-NovaPackageFileName {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
+        [Parameter(Mandatory)][string]$PackageId
+    )
+
+    $packageFileName = "$( $ProjectInfo.Package.PackageFileName )".Trim()
+    if ( [string]::IsNullOrWhiteSpace($packageFileName)) {
+        $packageFileName = "$PackageId.$( $ProjectInfo.Version ).nupkg"
+    }
+
+    if (-not $packageFileName.EndsWith('.nupkg', [System.StringComparison]::OrdinalIgnoreCase)) {
+        $packageFileName = "$packageFileName.nupkg"
+    }
+
+    return $packageFileName
+}
+

--- a/src/private/package/GetNovaPackageFileName.ps1
+++ b/src/private/package/GetNovaPackageFileName.ps1
@@ -2,18 +2,24 @@ function Get-NovaPackageFileName {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
-        [Parameter(Mandatory)][string]$PackageId
+        [Parameter(Mandatory)][string]$PackageId,
+        [Parameter(Mandatory)][string]$PackageType
     )
 
+    $packageType = ConvertTo-NovaPackageType -Type $PackageType
     $packageFileName = "$( $ProjectInfo.Package.PackageFileName )".Trim()
     if ( [string]::IsNullOrWhiteSpace($packageFileName)) {
-        $packageFileName = "$PackageId.$( $ProjectInfo.Version ).nupkg"
+        $packageFileName = "$PackageId.$( $ProjectInfo.Version )"
     }
 
-    if (-not $packageFileName.EndsWith('.nupkg', [System.StringComparison]::OrdinalIgnoreCase)) {
-        $packageFileName = "$packageFileName.nupkg"
+    $packageFileName = $packageFileName -replace '(?i)(?:\.nupkg|\.zip)$', ''
+    $fileExtension = if ($packageType -eq 'Zip') {
+        '.zip'
+    }
+    else {
+        '.nupkg'
     }
 
-    return $packageFileName
+    return "$packageFileName$fileExtension"
 }
 

--- a/src/private/package/GetNovaPackageMetadata.ps1
+++ b/src/private/package/GetNovaPackageMetadata.ps1
@@ -1,0 +1,30 @@
+function Get-NovaPackageMetadata {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Package metadata is the established domain term returned by this helper.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo
+    )
+
+    $packageId = "$( $ProjectInfo.Package.Id )".Trim()
+    $authors = Get-NovaPackageAuthorList -AuthorValue $ProjectInfo.Package.Authors
+    $tags = @($ProjectInfo.Manifest.Tags | Where-Object {-not [string]::IsNullOrWhiteSpace("$_")})
+    $packageFileName = Get-NovaPackageFileName -ProjectInfo $ProjectInfo -PackageId $packageId
+    $outputDirectory = Get-NovaPackageOutputDirectory -ProjectInfo $ProjectInfo
+
+    return [pscustomobject]@{
+        Enabled = [bool]$ProjectInfo.Package.Enabled
+        Id = $packageId
+        Version = "$( $ProjectInfo.Version )".Trim()
+        Authors = $authors
+        Description = "$( $ProjectInfo.Package.Description )".Trim()
+        Tags = $tags
+        ProjectUrl = "$( $ProjectInfo.Manifest.ProjectUri )".Trim()
+        ReleaseNotes = "$( $ProjectInfo.Manifest.ReleaseNotes )".Trim()
+        LicenseUrl = "$( $ProjectInfo.Manifest.LicenseUri )".Trim()
+        PackageFileName = $packageFileName
+        OutputDirectory = $outputDirectory
+        PackagePath = [System.IO.Path]::Join($outputDirectory, $packageFileName)
+        ContentRoot = "content/$( $ProjectInfo.ProjectName )"
+    }
+}
+

--- a/src/private/package/GetNovaPackageMetadata.ps1
+++ b/src/private/package/GetNovaPackageMetadata.ps1
@@ -2,18 +2,45 @@ function Get-NovaPackageMetadata {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Package metadata is the established domain term returned by this helper.')]
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][pscustomobject]$ProjectInfo
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
+        [string]$PackageType
     )
 
     $manifest = $ProjectInfo.Manifest
+    $packageSettings = $ProjectInfo.Package
+    $configuredPackageTypes = if ($packageSettings -is [System.Collections.IDictionary]) {
+        @($packageSettings['Types'])
+    }
+    else {
+        @($packageSettings.Types)
+    }
+    $defaultPackageType = @($configuredPackageTypes | Where-Object {$_} | Select-Object -First 1)
+    $packageType = if ( [string]::IsNullOrWhiteSpace($PackageType)) {
+        if ( [string]::IsNullOrWhiteSpace("$( $defaultPackageType )")) {
+            'NuGet'
+        }
+        else {
+            ConvertTo-NovaPackageType -Type "$( $defaultPackageType )"
+        }
+    }
+    else {
+        ConvertTo-NovaPackageType -Type $PackageType
+    }
     $packageId = "$( $ProjectInfo.Package.Id )".Trim()
     $authors = Get-NovaPackageAuthorList -AuthorValue $ProjectInfo.Package.Authors
     $tags = @(@(Get-NovaManifestValue -Manifest $manifest -Name 'Tags') | Where-Object {-not [string]::IsNullOrWhiteSpace("$_")})
-    $packageFileName = Get-NovaPackageFileName -ProjectInfo $ProjectInfo -PackageId $packageId
+    $packageFileName = Get-NovaPackageFileName -ProjectInfo $ProjectInfo -PackageId $packageId -PackageType $packageType
     $outputDirectory = Get-NovaPackageOutputDirectory -ProjectInfo $ProjectInfo
     $cleanOutputDirectory = [bool]$ProjectInfo.Package.OutputDirectory.Clean
+    $contentRoot = if ($packageType -eq 'Zip') {
+        "$( $ProjectInfo.ProjectName )"
+    }
+    else {
+        "content/$( $ProjectInfo.ProjectName )"
+    }
 
     return [pscustomobject]@{
+        Type = $packageType
         Id = $packageId
         Version = "$( $ProjectInfo.Version )".Trim()
         Authors = $authors
@@ -26,7 +53,7 @@ function Get-NovaPackageMetadata {
         OutputDirectory = $outputDirectory
         CleanOutputDirectory = $cleanOutputDirectory
         PackagePath = [System.IO.Path]::Join($outputDirectory, $packageFileName)
-        ContentRoot = "content/$( $ProjectInfo.ProjectName )"
+        ContentRoot = $contentRoot
     }
 }
 

--- a/src/private/package/GetNovaPackageMetadata.ps1
+++ b/src/private/package/GetNovaPackageMetadata.ps1
@@ -5,9 +5,10 @@ function Get-NovaPackageMetadata {
         [Parameter(Mandatory)][pscustomobject]$ProjectInfo
     )
 
+    $manifest = $ProjectInfo.Manifest
     $packageId = "$( $ProjectInfo.Package.Id )".Trim()
     $authors = Get-NovaPackageAuthorList -AuthorValue $ProjectInfo.Package.Authors
-    $tags = @($ProjectInfo.Manifest.Tags | Where-Object {-not [string]::IsNullOrWhiteSpace("$_")})
+    $tags = @(@(Get-NovaManifestValue -Manifest $manifest -Name 'Tags') | Where-Object {-not [string]::IsNullOrWhiteSpace("$_")})
     $packageFileName = Get-NovaPackageFileName -ProjectInfo $ProjectInfo -PackageId $packageId
     $outputDirectory = Get-NovaPackageOutputDirectory -ProjectInfo $ProjectInfo
     $cleanOutputDirectory = [bool]$ProjectInfo.Package.OutputDirectory.Clean
@@ -18,9 +19,9 @@ function Get-NovaPackageMetadata {
         Authors = $authors
         Description = "$( $ProjectInfo.Package.Description )".Trim()
         Tags = $tags
-        ProjectUrl = "$( $ProjectInfo.Manifest.ProjectUri )".Trim()
-        ReleaseNotes = "$( $ProjectInfo.Manifest.ReleaseNotes )".Trim()
-        LicenseUrl = "$( $ProjectInfo.Manifest.LicenseUri )".Trim()
+        ProjectUrl = "$( Get-NovaManifestValue -Manifest $manifest -Name 'ProjectUri' )".Trim()
+        ReleaseNotes = "$( Get-NovaManifestValue -Manifest $manifest -Name 'ReleaseNotes' )".Trim()
+        LicenseUrl = "$( Get-NovaManifestValue -Manifest $manifest -Name 'LicenseUri' )".Trim()
         PackageFileName = $packageFileName
         OutputDirectory = $outputDirectory
         CleanOutputDirectory = $cleanOutputDirectory

--- a/src/private/package/GetNovaPackageMetadata.ps1
+++ b/src/private/package/GetNovaPackageMetadata.ps1
@@ -10,9 +10,9 @@ function Get-NovaPackageMetadata {
     $tags = @($ProjectInfo.Manifest.Tags | Where-Object {-not [string]::IsNullOrWhiteSpace("$_")})
     $packageFileName = Get-NovaPackageFileName -ProjectInfo $ProjectInfo -PackageId $packageId
     $outputDirectory = Get-NovaPackageOutputDirectory -ProjectInfo $ProjectInfo
+    $cleanOutputDirectory = [bool]$ProjectInfo.Package.OutputDirectory.Clean
 
     return [pscustomobject]@{
-        Enabled = [bool]$ProjectInfo.Package.Enabled
         Id = $packageId
         Version = "$( $ProjectInfo.Version )".Trim()
         Authors = $authors
@@ -23,6 +23,7 @@ function Get-NovaPackageMetadata {
         LicenseUrl = "$( $ProjectInfo.Manifest.LicenseUri )".Trim()
         PackageFileName = $packageFileName
         OutputDirectory = $outputDirectory
+        CleanOutputDirectory = $cleanOutputDirectory
         PackagePath = [System.IO.Path]::Join($outputDirectory, $packageFileName)
         ContentRoot = "content/$( $ProjectInfo.ProjectName )"
     }

--- a/src/private/package/GetNovaPackageMetadataElement.ps1
+++ b/src/private/package/GetNovaPackageMetadataElement.ps1
@@ -1,0 +1,15 @@
+function Get-NovaPackageMetadataElement {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [AllowNull()][string]$Value
+    )
+
+    if ( [string]::IsNullOrWhiteSpace($Value)) {
+        return $null
+    }
+
+    $escapedValue = [System.Security.SecurityElement]::Escape($Value)
+    return "    <$Name>$escapedValue</$Name>"
+}
+

--- a/src/private/package/GetNovaPackageMetadataList.ps1
+++ b/src/private/package/GetNovaPackageMetadataList.ps1
@@ -1,0 +1,26 @@
+function Get-NovaPackageMetadataList {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Package metadata list is the domain term represented by this helper.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo
+    )
+
+    $packageSettings = $ProjectInfo.Package
+    $configuredPackageTypes = if ($packageSettings -is [System.Collections.IDictionary]) {
+        @($packageSettings['Types'])
+    }
+    else {
+        @($packageSettings.Types)
+    }
+
+    $packageTypeList = @($configuredPackageTypes | Where-Object {$_})
+    if ($packageTypeList.Count -eq 0) {
+        $packageTypeList = @('NuGet')
+    }
+
+    return @(
+    $packageTypeList | ForEach-Object {
+        Get-NovaPackageMetadata -ProjectInfo $ProjectInfo -PackageType $_
+    }
+    )
+}

--- a/src/private/package/GetNovaPackageOutputDirectory.ps1
+++ b/src/private/package/GetNovaPackageOutputDirectory.ps1
@@ -4,7 +4,13 @@ function Get-NovaPackageOutputDirectory {
         [Parameter(Mandatory)][pscustomobject]$ProjectInfo
     )
 
-    $outputDirectory = "$( $ProjectInfo.Package.OutputDirectory )".Trim()
+    $outputDirectory = if ($ProjectInfo.Package.OutputDirectory -is [string]) {
+        "$( $ProjectInfo.Package.OutputDirectory )".Trim()
+    }
+    else {
+        "$( $ProjectInfo.Package.OutputDirectory.Path )".Trim()
+    }
+
     if ( [System.IO.Path]::IsPathRooted($outputDirectory)) {
         return $outputDirectory
     }

--- a/src/private/package/GetNovaPackageOutputDirectory.ps1
+++ b/src/private/package/GetNovaPackageOutputDirectory.ps1
@@ -1,0 +1,14 @@
+function Get-NovaPackageOutputDirectory {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo
+    )
+
+    $outputDirectory = "$( $ProjectInfo.Package.OutputDirectory )".Trim()
+    if ( [System.IO.Path]::IsPathRooted($outputDirectory)) {
+        return $outputDirectory
+    }
+
+    return [System.IO.Path]::Join($ProjectInfo.ProjectRoot, $outputDirectory)
+}
+

--- a/src/private/package/InitializeNovaPackageOutputDirectory.ps1
+++ b/src/private/package/InitializeNovaPackageOutputDirectory.ps1
@@ -1,0 +1,17 @@
+function Initialize-NovaPackageOutputDirectory {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Pack-NovaModule performs the user-facing ShouldProcess confirmation before calling this internal preparation helper.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
+        [Parameter(Mandatory)][pscustomobject]$PackageMetadata
+    )
+
+    if ($PackageMetadata.CleanOutputDirectory) {
+        Clear-NovaPackageOutputDirectory -ProjectInfo $ProjectInfo -OutputDirectory $PackageMetadata.OutputDirectory
+    }
+
+    if (-not (Test-Path -LiteralPath $PackageMetadata.OutputDirectory)) {
+        $null = New-Item -ItemType Directory -Path $PackageMetadata.OutputDirectory -Force
+    }
+}
+

--- a/src/private/package/InitializeNovaPackageOutputDirectory.ps1
+++ b/src/private/package/InitializeNovaPackageOutputDirectory.ps1
@@ -3,8 +3,13 @@ function Initialize-NovaPackageOutputDirectory {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
-        [Parameter(Mandatory)][pscustomobject]$PackageMetadata
+        [Alias('PackageMetadata')][Parameter(Mandatory)][object[]]$PackageMetadataList
     )
+
+    $packageMetadata = @($PackageMetadataList)[0]
+    if ($null -eq $packageMetadata) {
+        throw 'Package metadata list cannot be empty.'
+    }
 
     if ($PackageMetadata.CleanOutputDirectory) {
         Clear-NovaPackageOutputDirectory -ProjectInfo $ProjectInfo -OutputDirectory $PackageMetadata.OutputDirectory

--- a/src/private/package/InvokeNovaPackageArchiveCreation.ps1
+++ b/src/private/package/InvokeNovaPackageArchiveCreation.ps1
@@ -1,0 +1,20 @@
+function Invoke-NovaPackageArchiveCreation {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Pack-NovaModule performs the user-facing ShouldProcess confirmation before calling internal archive creation helpers.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$PackagePath,
+        [Parameter(Mandatory)][scriptblock]$EntryWriter
+    )
+
+    Remove-Item -LiteralPath $PackagePath -Force -ErrorAction SilentlyContinue
+    $fileStream = [System.IO.File]::Open($PackagePath, [System.IO.FileMode]::CreateNew)
+    $archive = [System.IO.Compression.ZipArchive]::new($fileStream, [System.IO.Compression.ZipArchiveMode]::Create, $false)
+    try {
+        & $EntryWriter $archive
+    }
+    finally {
+        $archive.Dispose()
+        $fileStream.Dispose()
+    }
+}
+

--- a/src/private/package/NewNovaNuGetPackageArtifact.ps1
+++ b/src/private/package/NewNovaNuGetPackageArtifact.ps1
@@ -1,0 +1,25 @@
+function New-NovaNuGetPackageArtifact {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Pack-NovaModule performs the user-facing ShouldProcess confirmation before calling this internal writer.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
+        [Parameter(Mandatory)][pscustomobject]$PackageMetadata
+    )
+
+    $fileEntries = Get-NovaPackageContentItemList -ProjectInfo $ProjectInfo -PackageMetadata $PackageMetadata
+    $corePropertiesPath = "package/services/metadata/core-properties/$([System.Guid]::NewGuid().ToString('N') ).psmdcp"
+    $nuspecFileName = "$( $PackageMetadata.Id ).nuspec"
+
+    Invoke-NovaPackageArchiveCreation -PackagePath $PackageMetadata.PackagePath -EntryWriter {
+        param($Archive)
+
+        Add-NovaZipTextEntry -Archive $Archive -EntryPath '_rels/.rels' -Content (New-NovaPackageRelationshipsXml -NuspecFileName $nuspecFileName -CorePropertiesPath $corePropertiesPath)
+        Add-NovaZipTextEntry -Archive $Archive -EntryPath $nuspecFileName -Content (New-NovaPackageNuspecXml -PackageMetadata $PackageMetadata)
+        Add-NovaZipTextEntry -Archive $Archive -EntryPath '[Content_Types].xml' -Content (New-NovaPackageContentTypesXml -FileEntries $fileEntries)
+        Add-NovaZipTextEntry -Archive $Archive -EntryPath $corePropertiesPath -Content (New-NovaPackageCorePropertiesXml -PackageMetadata $PackageMetadata)
+        foreach ($fileEntry in $fileEntries) {
+            Add-NovaZipFileEntry -Archive $Archive -EntryPath $fileEntry.PackagePath -SourcePath $fileEntry.SourcePath
+        }
+    }
+}
+

--- a/src/private/package/NewNovaPackageArtifact.ps1
+++ b/src/private/package/NewNovaPackageArtifact.ps1
@@ -1,0 +1,44 @@
+function New-NovaPackageArtifact {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Pack-NovaModule performs the user-facing ShouldProcess confirmation before calling this internal helper.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
+        [Parameter(Mandatory)][pscustomobject]$PackageMetadata
+    )
+
+    Assert-NovaPackageMetadata -PackageMetadata $PackageMetadata
+    $fileEntries = Get-NovaPackageContentItemList -ProjectInfo $ProjectInfo -PackageMetadata $PackageMetadata
+    $corePropertiesPath = "package/services/metadata/core-properties/$([System.Guid]::NewGuid().ToString('N') ).psmdcp"
+    $nuspecFileName = "$( $PackageMetadata.Id ).nuspec"
+
+    if (-not (Test-Path -LiteralPath $PackageMetadata.OutputDirectory)) {
+        $null = New-Item -ItemType Directory -Path $PackageMetadata.OutputDirectory -Force
+    }
+
+    Remove-Item -LiteralPath $PackageMetadata.PackagePath -Force -ErrorAction SilentlyContinue
+    $fileStream = [System.IO.File]::Open($PackageMetadata.PackagePath, [System.IO.FileMode]::CreateNew)
+    $archive = [System.IO.Compression.ZipArchive]::new($fileStream, [System.IO.Compression.ZipArchiveMode]::Create, $false)
+    try {
+        Add-NovaZipTextEntry -Archive $archive -EntryPath '_rels/.rels' -Content (New-NovaPackageRelationshipsXml -NuspecFileName $nuspecFileName -CorePropertiesPath $corePropertiesPath)
+        Add-NovaZipTextEntry -Archive $archive -EntryPath $nuspecFileName -Content (New-NovaPackageNuspecXml -PackageMetadata $PackageMetadata)
+        Add-NovaZipTextEntry -Archive $archive -EntryPath '[Content_Types].xml' -Content (New-NovaPackageContentTypesXml -FileEntries $fileEntries)
+        Add-NovaZipTextEntry -Archive $archive -EntryPath $corePropertiesPath -Content (New-NovaPackageCorePropertiesXml -PackageMetadata $PackageMetadata)
+        foreach ($fileEntry in $fileEntries) {
+            Add-NovaZipFileEntry -Archive $archive -EntryPath $fileEntry.PackagePath -SourcePath $fileEntry.SourcePath
+        }
+    }
+    finally {
+        $archive.Dispose()
+        $fileStream.Dispose()
+    }
+
+    return [pscustomobject]@{
+        Id = $PackageMetadata.Id
+        Version = $PackageMetadata.Version
+        PackageFileName = $PackageMetadata.PackageFileName
+        PackagePath = $PackageMetadata.PackagePath
+        OutputDirectory = $PackageMetadata.OutputDirectory
+        SourceModuleDirectory = $ProjectInfo.OutputModuleDir
+    }
+}
+

--- a/src/private/package/NewNovaPackageArtifact.ps1
+++ b/src/private/package/NewNovaPackageArtifact.ps1
@@ -11,9 +11,7 @@ function New-NovaPackageArtifact {
     $corePropertiesPath = "package/services/metadata/core-properties/$([System.Guid]::NewGuid().ToString('N') ).psmdcp"
     $nuspecFileName = "$( $PackageMetadata.Id ).nuspec"
 
-    if (-not (Test-Path -LiteralPath $PackageMetadata.OutputDirectory)) {
-        $null = New-Item -ItemType Directory -Path $PackageMetadata.OutputDirectory -Force
-    }
+    Initialize-NovaPackageOutputDirectory -ProjectInfo $ProjectInfo -PackageMetadata $PackageMetadata
 
     Remove-Item -LiteralPath $PackageMetadata.PackagePath -Force -ErrorAction SilentlyContinue
     $fileStream = [System.IO.File]::Open($PackageMetadata.PackagePath, [System.IO.FileMode]::CreateNew)

--- a/src/private/package/NewNovaPackageArtifact.ps1
+++ b/src/private/package/NewNovaPackageArtifact.ps1
@@ -3,34 +3,29 @@ function New-NovaPackageArtifact {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
-        [Parameter(Mandatory)][pscustomobject]$PackageMetadata
+        [Parameter(Mandatory)][pscustomobject]$PackageMetadata,
+        [switch]$OutputDirectoryReady
     )
 
     Assert-NovaPackageMetadata -PackageMetadata $PackageMetadata
-    $fileEntries = Get-NovaPackageContentItemList -ProjectInfo $ProjectInfo -PackageMetadata $PackageMetadata
-    $corePropertiesPath = "package/services/metadata/core-properties/$([System.Guid]::NewGuid().ToString('N') ).psmdcp"
-    $nuspecFileName = "$( $PackageMetadata.Id ).nuspec"
-
-    Initialize-NovaPackageOutputDirectory -ProjectInfo $ProjectInfo -PackageMetadata $PackageMetadata
-
-    Remove-Item -LiteralPath $PackageMetadata.PackagePath -Force -ErrorAction SilentlyContinue
-    $fileStream = [System.IO.File]::Open($PackageMetadata.PackagePath, [System.IO.FileMode]::CreateNew)
-    $archive = [System.IO.Compression.ZipArchive]::new($fileStream, [System.IO.Compression.ZipArchiveMode]::Create, $false)
-    try {
-        Add-NovaZipTextEntry -Archive $archive -EntryPath '_rels/.rels' -Content (New-NovaPackageRelationshipsXml -NuspecFileName $nuspecFileName -CorePropertiesPath $corePropertiesPath)
-        Add-NovaZipTextEntry -Archive $archive -EntryPath $nuspecFileName -Content (New-NovaPackageNuspecXml -PackageMetadata $PackageMetadata)
-        Add-NovaZipTextEntry -Archive $archive -EntryPath '[Content_Types].xml' -Content (New-NovaPackageContentTypesXml -FileEntries $fileEntries)
-        Add-NovaZipTextEntry -Archive $archive -EntryPath $corePropertiesPath -Content (New-NovaPackageCorePropertiesXml -PackageMetadata $PackageMetadata)
-        foreach ($fileEntry in $fileEntries) {
-            Add-NovaZipFileEntry -Archive $archive -EntryPath $fileEntry.PackagePath -SourcePath $fileEntry.SourcePath
-        }
+    if (-not $OutputDirectoryReady) {
+        Initialize-NovaPackageOutputDirectory -ProjectInfo $ProjectInfo -PackageMetadata $PackageMetadata
     }
-    finally {
-        $archive.Dispose()
-        $fileStream.Dispose()
+
+    switch ($PackageMetadata.Type) {
+        'NuGet' {
+            New-NovaNuGetPackageArtifact -ProjectInfo $ProjectInfo -PackageMetadata $PackageMetadata
+        }
+        'Zip' {
+            New-NovaZipPackageArtifact -ProjectInfo $ProjectInfo -PackageMetadata $PackageMetadata
+        }
+        default {
+            throw "Unsupported package type: $( $PackageMetadata.Type )"
+        }
     }
 
     return [pscustomobject]@{
+        Type = $PackageMetadata.Type
         Id = $PackageMetadata.Id
         Version = $PackageMetadata.Version
         PackageFileName = $PackageMetadata.PackageFileName

--- a/src/private/package/NewNovaPackageArtifacts.ps1
+++ b/src/private/package/NewNovaPackageArtifacts.ps1
@@ -1,0 +1,25 @@
+function New-NovaPackageArtifacts {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Pack-NovaModule performs the user-facing ShouldProcess confirmation before calling this internal helper.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Package artifacts is the established domain term for the requested collection.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
+        [Parameter(Mandatory)][object[]]$PackageMetadataList
+    )
+
+    $resolvedPackageMetadataList = @($PackageMetadataList)
+    if ($resolvedPackageMetadataList.Count -eq 0) {
+        return @()
+    }
+
+    foreach ($packageMetadata in $resolvedPackageMetadataList) {
+        Assert-NovaPackageMetadata -PackageMetadata $packageMetadata
+    }
+
+    Initialize-NovaPackageOutputDirectory -ProjectInfo $ProjectInfo -PackageMetadataList $resolvedPackageMetadataList
+    return @(
+    $resolvedPackageMetadataList | ForEach-Object {
+        New-NovaPackageArtifact -ProjectInfo $ProjectInfo -PackageMetadata $_ -OutputDirectoryReady
+    }
+    )
+}

--- a/src/private/package/NewNovaPackageContentTypesXml.ps1
+++ b/src/private/package/NewNovaPackageContentTypesXml.ps1
@@ -1,0 +1,41 @@
+function New-NovaPackageContentTypesXml {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'This helper only returns XML text and does not mutate external state.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject[]]$FileEntries
+    )
+
+    $defaultMap = [ordered]@{
+        rels = 'application/vnd.openxmlformats-package.relationships+xml'
+        psmdcp = 'application/vnd.openxmlformats-package.core-properties+xml'
+        nuspec = 'application/octet'
+    }
+    $overridePartList = [System.Collections.Generic.List[string]]::new()
+
+    foreach ($fileEntry in $FileEntries) {
+        $extension = [System.IO.Path]::GetExtension($fileEntry.PackagePath)
+        if ( [string]::IsNullOrWhiteSpace($extension)) {
+            $overridePartList.Add("/$( $fileEntry.PackagePath )")
+            continue
+        }
+
+        $defaultMap[$extension.TrimStart('.').ToLowerInvariant()] = 'application/octet'
+    }
+
+    $xmlLines = @(
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+    )
+
+    foreach ($extension in $defaultMap.Keys) {
+        $xmlLines += '  <Default Extension="{0}" ContentType="{1}" />' -f $extension, $defaultMap[$extension]
+    }
+
+    foreach ($partName in $overridePartList | Sort-Object -Unique) {
+        $xmlLines += '  <Override PartName="{0}" ContentType="application/octet" />' -f $partName
+    }
+
+    $xmlLines += '</Types>'
+    return $xmlLines -join [Environment]::NewLine
+}
+

--- a/src/private/package/NewNovaPackageCorePropertiesXml.ps1
+++ b/src/private/package/NewNovaPackageCorePropertiesXml.ps1
@@ -1,0 +1,26 @@
+function New-NovaPackageCorePropertiesXml {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'This helper only returns XML text and does not mutate external state.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$PackageMetadata
+    )
+
+    $creator = [System.Security.SecurityElement]::Escape((@($PackageMetadata.Authors) -join ', '))
+    $description = [System.Security.SecurityElement]::Escape($PackageMetadata.Description)
+    $identifier = [System.Security.SecurityElement]::Escape($PackageMetadata.Id)
+    $version = [System.Security.SecurityElement]::Escape($PackageMetadata.Version)
+    $keywords = [System.Security.SecurityElement]::Escape((@($PackageMetadata.Tags) -join ' '))
+
+    return @(
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<coreProperties xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.openxmlformats.org/package/2006/metadata/core-properties">'
+        "  <dc:creator>$creator</dc:creator>"
+        "  <dc:description>$description</dc:description>"
+        "  <dc:identifier>$identifier</dc:identifier>"
+        "  <version>$version</version>"
+        "  <keywords>$keywords</keywords>"
+        '  <lastModifiedBy>NovaModuleTools</lastModifiedBy>'
+        '</coreProperties>'
+    ) -join [Environment]::NewLine
+}
+

--- a/src/private/package/NewNovaPackageNuspecXml.ps1
+++ b/src/private/package/NewNovaPackageNuspecXml.ps1
@@ -1,0 +1,28 @@
+function New-NovaPackageNuspecXml {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'This helper only returns XML text and does not mutate external state.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$PackageMetadata
+    )
+
+    $metadataLines = @(
+        '  <metadata>'
+        (Get-NovaPackageMetadataElement -Name 'id' -Value $PackageMetadata.Id)
+        (Get-NovaPackageMetadataElement -Name 'version' -Value $PackageMetadata.Version)
+        (Get-NovaPackageMetadataElement -Name 'authors' -Value (@($PackageMetadata.Authors) -join ', '))
+        (Get-NovaPackageMetadataElement -Name 'description' -Value $PackageMetadata.Description)
+        (Get-NovaPackageMetadataElement -Name 'projectUrl' -Value $PackageMetadata.ProjectUrl)
+        (Get-NovaPackageMetadataElement -Name 'releaseNotes' -Value $PackageMetadata.ReleaseNotes)
+        (Get-NovaPackageMetadataElement -Name 'licenseUrl' -Value $PackageMetadata.LicenseUrl)
+        (Get-NovaPackageMetadataElement -Name 'tags' -Value (@($PackageMetadata.Tags) -join ' '))
+        '  </metadata>'
+    ) | Where-Object {$null -ne $_}
+
+    return @(
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">'
+        $metadataLines
+        '</package>'
+    ) -join [Environment]::NewLine
+}
+

--- a/src/private/package/NewNovaPackageRelationshipsXml.ps1
+++ b/src/private/package/NewNovaPackageRelationshipsXml.ps1
@@ -1,0 +1,17 @@
+function New-NovaPackageRelationshipsXml {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'This helper only returns XML text and does not mutate external state.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$NuspecFileName,
+        [Parameter(Mandatory)][string]$CorePropertiesPath
+    )
+
+    return @(
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+        ('  <Relationship Type="{0}" Target="/{1}" Id="RManifest" />' -f 'http://schemas.microsoft.com/packaging/2010/07/manifest', $NuspecFileName)
+        ('  <Relationship Type="{0}" Target="/{1}" Id="RCoreProperties" />' -f 'http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties', $CorePropertiesPath)
+        '</Relationships>'
+    ) -join [Environment]::NewLine
+}
+

--- a/src/private/package/NewNovaZipPackageArtifact.ps1
+++ b/src/private/package/NewNovaZipPackageArtifact.ps1
@@ -1,0 +1,18 @@
+function New-NovaZipPackageArtifact {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Pack-NovaModule performs the user-facing ShouldProcess confirmation before calling this internal writer.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
+        [Parameter(Mandatory)][pscustomobject]$PackageMetadata
+    )
+
+    $fileEntries = Get-NovaPackageContentItemList -ProjectInfo $ProjectInfo -PackageMetadata $PackageMetadata
+    Invoke-NovaPackageArchiveCreation -PackagePath $PackageMetadata.PackagePath -EntryWriter {
+        param($Archive)
+
+        foreach ($fileEntry in $fileEntries) {
+            Add-NovaZipFileEntry -Archive $Archive -EntryPath $fileEntry.PackagePath -SourcePath $fileEntry.SourcePath
+        }
+    }
+}
+

--- a/src/private/package/TestNovaPathContainsPath.ps1
+++ b/src/private/package/TestNovaPathContainsPath.ps1
@@ -1,0 +1,16 @@
+function Test-NovaPathContainsPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ParentPath,
+        [Parameter(Mandatory)][string]$ChildPath
+    )
+
+    $normalizedParentPath = ([System.IO.Path]::GetFullPath($ParentPath)).TrimEnd('/', '\')
+    $normalizedChildPath = [System.IO.Path]::GetFullPath($ChildPath)
+    if ($normalizedChildPath -eq $normalizedParentPath) {
+        return $true
+    }
+
+    return $normalizedChildPath.StartsWith("$normalizedParentPath$( [System.IO.Path]::DirectorySeparatorChar )", [System.StringComparison]::OrdinalIgnoreCase)
+}
+

--- a/src/private/shared/ConvertToNovaPackageType.ps1
+++ b/src/private/shared/ConvertToNovaPackageType.ps1
@@ -1,0 +1,25 @@
+function ConvertTo-NovaPackageType {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Type
+    )
+
+    switch ( $Type.Trim().ToLowerInvariant()) {
+        'nuget' {
+            return 'NuGet'
+        }
+        '.nupkg' {
+            return 'NuGet'
+        }
+        'zip' {
+            return 'Zip'
+        }
+        '.zip' {
+            return 'Zip'
+        }
+        default {
+            throw "Unsupported Package.Types value: $Type. Supported values: NuGet, Zip, .nupkg, .zip."
+        }
+    }
+}
+

--- a/src/private/shared/GetNovaProjectPackageOutputDirectorySettingsTable.ps1
+++ b/src/private/shared/GetNovaProjectPackageOutputDirectorySettingsTable.ps1
@@ -1,0 +1,23 @@
+function Get-NovaProjectPackageOutputDirectorySettingsTable {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Output directory settings is the domain term represented by this helper.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][System.Collections.IDictionary]$PackageSettings
+    )
+
+    $outputDirectoryValue = if ( $PackageSettings.Contains('OutputDirectory')) {
+        $PackageSettings['OutputDirectory']
+    }
+    else {
+        $null
+    }
+
+    if ($outputDirectoryValue -is [System.Collections.IDictionary]) {
+        return [ordered]@{} + $outputDirectoryValue
+    }
+
+    return [ordered]@{
+        Path = $outputDirectoryValue
+    }
+}
+

--- a/src/private/shared/GetNovaProjectPackageSettingsTable.ps1
+++ b/src/private/shared/GetNovaProjectPackageSettingsTable.ps1
@@ -1,0 +1,16 @@
+function Get-NovaProjectPackageSettingsTable {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Package settings is the domain term represented by this helper.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][hashtable]$ProjectData
+    )
+
+    if (-not ($ProjectData.ContainsKey('Package') -and $ProjectData['Package'] -is [hashtable])) {
+        return [ordered]@{}
+    }
+
+    $packageSettings = [ordered]@{} + $ProjectData['Package']
+    $null = $packageSettings.Remove('Enabled')
+    return $packageSettings
+}
+

--- a/src/private/shared/GetNovaResolvedProjectManifestSettings.ps1
+++ b/src/private/shared/GetNovaResolvedProjectManifestSettings.ps1
@@ -1,0 +1,14 @@
+function Get-NovaResolvedProjectManifestSettings {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Manifest settings is the domain term represented by this resolver.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][hashtable]$ProjectData
+    )
+
+    if ($ProjectData.ContainsKey('Manifest') -and $ProjectData['Manifest'] -is [hashtable]) {
+        return [ordered]@{} + $ProjectData['Manifest']
+    }
+
+    return [ordered]@{}
+}
+

--- a/src/private/shared/GetNovaResolvedProjectPackageOutputDirectorySettings.ps1
+++ b/src/private/shared/GetNovaResolvedProjectPackageOutputDirectorySettings.ps1
@@ -1,0 +1,19 @@
+function Get-NovaResolvedProjectPackageOutputDirectorySettings {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Output directory settings is the domain term represented by this resolver.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][System.Collections.IDictionary]$PackageSettings,
+        [Parameter(Mandatory)][string]$ProjectRoot
+    )
+
+    $outputDirectorySettings = Get-NovaProjectPackageOutputDirectorySettingsTable -PackageSettings $PackageSettings
+    Set-NovaPackageSettingDefault -PackageSettings $outputDirectorySettings -Name 'Path' -Value 'artifacts/packages' -TreatWhitespaceAsMissing
+    if (-not [System.IO.Path]::IsPathRooted("$( $outputDirectorySettings['Path'] )")) {
+        $null = $outputDirectorySettings['Path'] = [System.IO.Path]::Join($ProjectRoot, "$( $outputDirectorySettings['Path'] )")
+    }
+
+    Set-NovaPackageSettingDefault -PackageSettings $outputDirectorySettings -Name 'Clean' -Value $true
+    $outputDirectorySettings['Clean'] = [bool]$outputDirectorySettings['Clean']
+    return $outputDirectorySettings
+}
+

--- a/src/private/shared/GetNovaResolvedProjectPackageSettings.ps1
+++ b/src/private/shared/GetNovaResolvedProjectPackageSettings.ps1
@@ -7,20 +7,9 @@ function Get-NovaResolvedProjectPackageSettings {
         [Parameter(Mandatory)][string]$ProjectRoot
     )
 
-    $packageSettings = if ($ProjectData.ContainsKey('Package') -and $ProjectData['Package'] -is [hashtable]) {
-        [ordered]@{} + $ProjectData['Package']
-    }
-    else {
-        [ordered]@{}
-    }
-
-    Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'Enabled' -Value $true
+    $packageSettings = Get-NovaProjectPackageSettingsTable -ProjectData $ProjectData
+    $packageSettings['OutputDirectory'] = Get-NovaResolvedProjectPackageOutputDirectorySettings -PackageSettings $packageSettings -ProjectRoot $ProjectRoot
     Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'Id' -Value $ProjectData['ProjectName'] -TreatWhitespaceAsMissing
-    Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'OutputDirectory' -Value 'artifacts/packages' -TreatWhitespaceAsMissing
-
-    if (-not [System.IO.Path]::IsPathRooted("$( $packageSettings['OutputDirectory'] )")) {
-        $null = $packageSettings['OutputDirectory'] = [System.IO.Path]::Join($ProjectRoot, "$( $packageSettings['OutputDirectory'] )")
-    }
 
     Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'PackageFileName' -Value "$( $packageSettings['Id'] ).$( $ProjectData['Version'] ).nupkg" -TreatWhitespaceAsMissing
     Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'Authors' -Value $ManifestSettings['Author']

--- a/src/private/shared/GetNovaResolvedProjectPackageSettings.ps1
+++ b/src/private/shared/GetNovaResolvedProjectPackageSettings.ps1
@@ -8,6 +8,7 @@ function Get-NovaResolvedProjectPackageSettings {
     )
 
     $packageSettings = Get-NovaProjectPackageSettingsTable -ProjectData $ProjectData
+    $packageSettings['Types'] = @(Get-NovaResolvedProjectPackageTypeList -PackageSettings $packageSettings)
     $packageSettings['OutputDirectory'] = Get-NovaResolvedProjectPackageOutputDirectorySettings -PackageSettings $packageSettings -ProjectRoot $ProjectRoot
     Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'Id' -Value $ProjectData['ProjectName'] -TreatWhitespaceAsMissing
 

--- a/src/private/shared/GetNovaResolvedProjectPackageSettings.ps1
+++ b/src/private/shared/GetNovaResolvedProjectPackageSettings.ps1
@@ -1,0 +1,31 @@
+function Get-NovaResolvedProjectPackageSettings {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Package settings is the domain term represented by this resolver.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][hashtable]$ProjectData,
+        [Parameter(Mandatory)][hashtable]$ManifestSettings,
+        [Parameter(Mandatory)][string]$ProjectRoot
+    )
+
+    $packageSettings = if ($ProjectData.ContainsKey('Package') -and $ProjectData['Package'] -is [hashtable]) {
+        [ordered]@{} + $ProjectData['Package']
+    }
+    else {
+        [ordered]@{}
+    }
+
+    Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'Enabled' -Value $true
+    Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'Id' -Value $ProjectData['ProjectName'] -TreatWhitespaceAsMissing
+    Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'OutputDirectory' -Value 'artifacts/packages' -TreatWhitespaceAsMissing
+
+    if (-not [System.IO.Path]::IsPathRooted("$( $packageSettings['OutputDirectory'] )")) {
+        $null = $packageSettings['OutputDirectory'] = [System.IO.Path]::Join($ProjectRoot, "$( $packageSettings['OutputDirectory'] )")
+    }
+
+    Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'PackageFileName' -Value "$( $packageSettings['Id'] ).$( $ProjectData['Version'] ).nupkg" -TreatWhitespaceAsMissing
+    Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'Authors' -Value $ManifestSettings['Author']
+    Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'Description' -Value $ProjectData['Description'] -TreatWhitespaceAsMissing
+
+    return $packageSettings
+}
+

--- a/src/private/shared/GetNovaResolvedProjectPackageTypeList.ps1
+++ b/src/private/shared/GetNovaResolvedProjectPackageTypeList.ps1
@@ -1,0 +1,33 @@
+function Get-NovaResolvedProjectPackageTypeList {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Package type list is the domain term represented by this resolver.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][System.Collections.IDictionary]$PackageSettings
+    )
+
+    $typeValues = if ($PackageSettings.Contains('Types') -and $null -ne $PackageSettings['Types']) {
+        @($PackageSettings['Types'])
+    }
+    else {
+        @()
+    }
+
+    $resolvedTypeList = @()
+    foreach ($typeValue in $typeValues) {
+        if ( [string]::IsNullOrWhiteSpace("$( $typeValue )")) {
+            continue
+        }
+
+        $resolvedType = ConvertTo-NovaPackageType -Type "$( $typeValue )"
+        if ($resolvedType -notin $resolvedTypeList) {
+            $resolvedTypeList += $resolvedType
+        }
+    }
+
+    if ($resolvedTypeList.Count -eq 0) {
+        return @('NuGet')
+    }
+
+    return $resolvedTypeList
+}
+

--- a/src/private/shared/SetNovaPackageSettingDefault.ps1
+++ b/src/private/shared/SetNovaPackageSettingDefault.ps1
@@ -1,0 +1,20 @@
+function Set-NovaPackageSettingDefault {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'This helper only mutates an in-memory metadata dictionary and does not change external state.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][System.Collections.IDictionary]$PackageSettings,
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)]$Value,
+        [switch]$TreatWhitespaceAsMissing
+    )
+
+    $hasValue = $PackageSettings.Contains($Name)
+    if ($hasValue -and $TreatWhitespaceAsMissing) {
+        $hasValue = -not [string]::IsNullOrWhiteSpace("$( $PackageSettings[$Name] )")
+    }
+
+    if (-not $hasValue) {
+        $null = $PackageSettings[$Name] = $Value
+    }
+}
+

--- a/src/public/GetNovaProjectInfo.ps1
+++ b/src/public/GetNovaProjectInfo.ps1
@@ -14,6 +14,10 @@ function Get-NovaProjectInfo {
 
     $jsonData = Read-ProjectJsonData -ProjectJsonPath $projectJson
 
+    if ($Version) {
+        return $jsonData.Version
+    }
+
     $Out = @{}
     $Out['ProjectJSON'] = $ProjectJson
 
@@ -42,6 +46,9 @@ function Get-NovaProjectInfo {
     $Out.ProjectJson = $projectJson
     $Out.PSTypeName = 'MTProjectInfo'
     $ProjectName = $jsonData.ProjectName
+    $manifestSettings = Get-NovaResolvedProjectManifestSettings -ProjectData $Out
+    $Out['Manifest'] = $manifestSettings
+    $Out['Package'] = Get-NovaResolvedProjectPackageSettings -ProjectData $Out -ManifestSettings $manifestSettings -ProjectRoot $ProjectRoot
 
     ## Folders
     $Out['ProjectRoot'] = $ProjectRoot
@@ -56,10 +63,5 @@ function Get-NovaProjectInfo {
     $Out['ModuleFilePSM1'] = [System.IO.Path]::Join($Out.OutputModuleDir, "$ProjectName.psm1")
     $Out['ManifestFilePSD1'] = [System.IO.Path]::Join($Out.OutputModuleDir, "$ProjectName.psd1")
 
-    $projectInfo = [pscustomobject]$out
-    if ($Version) {
-        return $projectInfo.Version
-    }
-
-    return $projectInfo
+    return [pscustomobject]$out
 }

--- a/src/public/InvokeNovaCli.ps1
+++ b/src/public/InvokeNovaCli.ps1
@@ -25,6 +25,9 @@ function Invoke-NovaCli {
         'test' {
             return Test-NovaBuild @mutatingCommonParameters
         }
+        'pack' {
+            return Pack-NovaModule @mutatingCommonParameters
+        }
         'init' {
             if ($WhatIfPreference) {
                 throw "The 'nova init' CLI command does not support -WhatIf. Run 'nova init' or 'nova init -Path <path>' without -WhatIf."
@@ -49,16 +52,7 @@ function Invoke-NovaCli {
             return Invoke-NovaRelease -PublishOption $options @mutatingCommonParameters
         }
         'notification' {
-            $notificationAction = ConvertFrom-NovaNotificationCliArgument -Arguments $Arguments
-            if ($notificationAction -eq 'status') {
-                return Get-NovaUpdateNotificationPreference @commonParameters
-            }
-
-            if ($notificationAction -eq 'enable') {
-                return Set-NovaUpdateNotificationPreference -EnablePrereleaseNotifications @mutatingCommonParameters
-            }
-
-            return Set-NovaUpdateNotificationPreference -DisablePrereleaseNotifications @mutatingCommonParameters
+            return Invoke-NovaCliNotificationCommand -Arguments $Arguments -CommonParameters $commonParameters -MutatingCommonParameters $mutatingCommonParameters
         }
         '--version' {
             $moduleName = $ExecutionContext.SessionState.Module.Name

--- a/src/public/PackNovaModule.ps1
+++ b/src/public/PackNovaModule.ps1
@@ -6,28 +6,39 @@ function Pack-NovaModule {
     $moduleContext = $ExecutionContext.SessionState.Module
     $workflowParams = Get-NovaShouldProcessForwardingParameter -WhatIfEnabled:$WhatIfPreference
     $projectInfo = Get-NovaProjectInfo
-    $packageMetadata = Get-NovaPackageMetadata -ProjectInfo $projectInfo
-    Assert-NovaPackageMetadata -PackageMetadata $packageMetadata
+    $packageMetadataList = @(Get-NovaPackageMetadataList -ProjectInfo $projectInfo)
+    foreach ($packageMetadata in $packageMetadataList) {
+        Assert-NovaPackageMetadata -PackageMetadata $packageMetadata
+    }
 
     Invoke-NovaBuild @workflowParams
     Test-NovaBuild @workflowParams
 
-    if (-not $PSCmdlet.ShouldProcess($packageMetadata.PackagePath, 'Create NuGet package from built module output')) {
+    $packagePathList = @($packageMetadataList.PackagePath)
+    $packageTarget = $packagePathList -join ', '
+    $packageAction = if ($packageMetadataList.Count -eq 1) {
+        "Create $( $packageMetadataList[0].Type ) package from built module output"
+    }
+    else {
+        'Create package artifacts from built module output'
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($packageTarget, $packageAction)) {
         return
     }
 
-    $packageHelper = Get-Command -Name New-NovaPackageArtifact -CommandType Function -ErrorAction SilentlyContinue
+    $packageHelper = Get-Command -Name New-NovaPackageArtifacts -CommandType Function -ErrorAction SilentlyContinue
     if ($null -ne $packageHelper) {
-        return New-NovaPackageArtifact -ProjectInfo $projectInfo -PackageMetadata $packageMetadata
+        return New-NovaPackageArtifacts -ProjectInfo $projectInfo -PackageMetadataList $packageMetadataList
     }
 
     $packagingModule = Import-Module $moduleContext.Path -Force -DisableNameChecking -PassThru
     $packageCreation = {
-        param($ProjectInfo, $PackageMetadata)
+        param($ProjectInfo, $PackageMetadataList)
 
-        New-NovaPackageArtifact -ProjectInfo $ProjectInfo -PackageMetadata $PackageMetadata
+        New-NovaPackageArtifacts -ProjectInfo $ProjectInfo -PackageMetadataList $PackageMetadataList
     }
 
-    return & $packagingModule $packageCreation $projectInfo $packageMetadata
+    return & $packagingModule $packageCreation $projectInfo $packageMetadataList
 }
 

--- a/src/public/PackNovaModule.ps1
+++ b/src/public/PackNovaModule.ps1
@@ -1,0 +1,33 @@
+function Pack-NovaModule {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseApprovedVerbs', '', Justification = 'Pack is the required public workflow verb and matches the nova pack CLI command.')]
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param()
+
+    $moduleContext = $ExecutionContext.SessionState.Module
+    $workflowParams = Get-NovaShouldProcessForwardingParameter -WhatIfEnabled:$WhatIfPreference
+    $projectInfo = Get-NovaProjectInfo
+    $packageMetadata = Get-NovaPackageMetadata -ProjectInfo $projectInfo
+    Assert-NovaPackageMetadata -PackageMetadata $packageMetadata
+
+    Invoke-NovaBuild @workflowParams
+    Test-NovaBuild @workflowParams
+
+    if (-not $PSCmdlet.ShouldProcess($packageMetadata.PackagePath, 'Create NuGet package from built module output')) {
+        return
+    }
+
+    $packageHelper = Get-Command -Name New-NovaPackageArtifact -CommandType Function -ErrorAction SilentlyContinue
+    if ($null -ne $packageHelper) {
+        return New-NovaPackageArtifact -ProjectInfo $projectInfo -PackageMetadata $packageMetadata
+    }
+
+    $packagingModule = Import-Module $moduleContext.Path -Force -DisableNameChecking -PassThru
+    $packageCreation = {
+        param($ProjectInfo, $PackageMetadata)
+
+        New-NovaPackageArtifact -ProjectInfo $ProjectInfo -PackageMetadata $PackageMetadata
+    }
+
+    return & $packagingModule $packageCreation $projectInfo $packageMetadata
+}
+

--- a/src/resources/ProjectTemplate.json
+++ b/src/resources/ProjectTemplate.json
@@ -11,6 +11,9 @@
         "ProjectUri": ""
     },
   "Package": {
+    "Types": [
+      "NuGet"
+    ],
     "OutputDirectory": {
       "Path": "artifacts/packages",
       "Clean": true

--- a/src/resources/ProjectTemplate.json
+++ b/src/resources/ProjectTemplate.json
@@ -11,8 +11,10 @@
         "ProjectUri": ""
     },
   "Package": {
-    "Enabled": true,
-    "OutputDirectory": "artifacts/packages"
+    "OutputDirectory": {
+      "Path": "artifacts/packages",
+      "Clean": true
+    }
   },
     "Pester": {
         "TestResult": {

--- a/src/resources/ProjectTemplate.json
+++ b/src/resources/ProjectTemplate.json
@@ -10,6 +10,10 @@
         "Tags": [],
         "ProjectUri": ""
     },
+  "Package": {
+    "Enabled": true,
+    "OutputDirectory": "artifacts/packages"
+  },
     "Pester": {
         "TestResult": {
             "Enabled": true,

--- a/src/resources/Schema-Build.json
+++ b/src/resources/Schema-Build.json
@@ -65,14 +65,26 @@
       "Package": {
         "type": "object",
         "properties": {
-          "Enabled": {
-            "type": "boolean"
-          },
           "Id": {
             "type": "string"
           },
           "OutputDirectory": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "Path": {
+                    "type": "string"
+                  },
+                  "Clean": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            ]
           },
           "PackageFileName": {
             "type": "string"

--- a/src/resources/Schema-Build.json
+++ b/src/resources/Schema-Build.json
@@ -61,6 +61,39 @@
                 "PowerShellHostVersion",
                 "GUID"
             ]
+        },
+      "Package": {
+        "type": "object",
+        "properties": {
+          "Enabled": {
+            "type": "boolean"
+          },
+          "Id": {
+            "type": "string"
+          },
+          "OutputDirectory": {
+            "type": "string"
+          },
+          "PackageFileName": {
+            "type": "string"
+          },
+          "Authors": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          },
+          "Description": {
+            "type": "string"
+          }
+        }
         }
     },
     "required": [

--- a/src/resources/Schema-Build.json
+++ b/src/resources/Schema-Build.json
@@ -68,6 +68,13 @@
           "Id": {
             "type": "string"
           },
+          "Types": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^(?:[Nn][Uu][Gg][Ee][Tt]|[Zz][Ii][Pp]|\\.[Nn][Uu][Pp][Kk][Gg]|\\.[Zz][Ii][Pp])$"
+            }
+          },
           "OutputDirectory": {
             "anyOf": [
               {

--- a/src/resources/cli/NovaCliHelp.txt
+++ b/src/resources/cli/NovaCliHelp.txt
@@ -10,6 +10,7 @@ work with the current project
    version    Show the current project version, or use -Installed for the locally installed project module version
    build      Build the module into the dist folder
    test       Run Pester tests for the project
+   pack       Build, test, and package the module as a .nupkg artifact
    bump       Update the module version in project.json
    update     Update the installed NovaModuleTools module using the stored prerelease preference
    notification Show or change prerelease self-update eligibility
@@ -35,6 +36,7 @@ Examples:
    nova version -Installed
    nova build
    nova test
+   nova pack
    nova bump -WhatIf
    nova update
    nova notification

--- a/src/resources/cli/NovaCliHelp.txt
+++ b/src/resources/cli/NovaCliHelp.txt
@@ -10,7 +10,7 @@ work with the current project
    version    Show the current project version, or use -Installed for the locally installed project module version
    build      Build the module into the dist folder
    test       Run Pester tests for the project
-   pack       Build, test, and package the module as a .nupkg artifact
+   pack       Build, test, and package the module as configured package artifact(s)
    bump       Update the module version in project.json
    update     Update the installed NovaModuleTools module using the stored prerelease preference
    notification Show or change prerelease self-update eligibility

--- a/src/resources/example/README.md
+++ b/src/resources/example/README.md
@@ -71,6 +71,9 @@ After `Pack-NovaModule`, the package artifact is written to:
 src/resources/example/artifacts/packages/
 ```
 
+The example project sets `Package.Types` to `NuGet`, so the generated file is a `.nupkg` by default. Change
+`Package.Types` to `['Zip']` when you only want a `.zip`, or `['NuGet', 'Zip']` when you want both package formats.
+
 You can then import it and call:
 
 ```powershell

--- a/src/resources/example/README.md
+++ b/src/resources/example/README.md
@@ -13,6 +13,7 @@ It is meant to help a new user understand the smallest useful setup that can:
 
 - `project.json` – the NovaModuleTools project definition
     - includes a `Preamble` example that is written at the top of the built `.psm1`
+  - includes a `Package` example so new users can see where generic package settings belong
   - intentionally keeps common top-level settings visible, including `CopyResourcesToModuleRoot`, so new users can
     see the available configuration keys in one place
 - `src/public/Get-ExampleGreeting.ps1` – a public function exported from the built module
@@ -34,6 +35,7 @@ PS> Import-Module ./dist/NovaModuleTools -Force
 PS> Set-Location ./src/resources/example
 PS> Invoke-NovaBuild
 PS> Test-NovaBuild
+PS> Pack-NovaModule
 PS> $project = Get-NovaProjectInfo
 PS> Import-Module $project.OutputModuleDir -Force
 PS> Get-ExampleGreeting
@@ -49,6 +51,7 @@ PS> $module = Get-Module NovaModuleTools -ListAvailable | Select-Object -First 1
 PS> Set-Location (Join-Path $module.ModuleBase 'resources/example')
 PS> Invoke-NovaBuild
 PS> Test-NovaBuild
+PS> Pack-NovaModule
 PS> $project = Get-NovaProjectInfo
 PS> Import-Module $project.OutputModuleDir -Force
 PS> Get-ExampleGreeting
@@ -60,6 +63,12 @@ After `Invoke-NovaBuild`, the built module is written to:
 
 ```text
 src/resources/example/dist/<ProjectName>
+```
+
+After `Pack-NovaModule`, the package artifact is written to:
+
+```text
+src/resources/example/artifacts/packages/
 ```
 
 You can then import it and call:

--- a/src/resources/example/project.json
+++ b/src/resources/example/project.json
@@ -22,8 +22,10 @@
     "ProjectUri": "https://www.novamoduletools.com/"
   },
   "Package": {
-    "Enabled": true,
-    "OutputDirectory": "artifacts/packages"
+    "OutputDirectory": {
+      "Path": "artifacts/packages",
+      "Clean": true
+    }
   },
   "Pester": {
     "TestResult": {

--- a/src/resources/example/project.json
+++ b/src/resources/example/project.json
@@ -21,6 +21,10 @@
     ],
     "ProjectUri": "https://www.novamoduletools.com/"
   },
+  "Package": {
+    "Enabled": true,
+    "OutputDirectory": "artifacts/packages"
+  },
   "Pester": {
     "TestResult": {
       "Enabled": true,

--- a/src/resources/example/project.json
+++ b/src/resources/example/project.json
@@ -22,6 +22,9 @@
     "ProjectUri": "https://www.novamoduletools.com/"
   },
   "Package": {
+    "Types": [
+      "NuGet"
+    ],
     "OutputDirectory": {
       "Path": "artifacts/packages",
       "Clean": true

--- a/src/resources/nova
+++ b/src/resources/nova
@@ -41,7 +41,7 @@ foreach ($argument in $Arguments) {
 
 $Arguments = @($remainingArguments)
 
-Import-Module NovaModuleTools -Force
+Import-Module NovaModuleTools -Force -DisableNameChecking
 
 $invokeParameters = @{
     Command = $Command

--- a/tests/NovaCommandModel.ReleasePublish.Tests.ps1
+++ b/tests/NovaCommandModel.ReleasePublish.Tests.ps1
@@ -317,9 +317,11 @@ Describe 'Nova command model - release and publish behavior' {
                         LicenseUri = 'https://example.test/license'
                     }
                     Package = [ordered]@{
-                        Enabled = $true
                         Id = 'NovaModuleTools'
-                        OutputDirectory = '/tmp/project/artifacts/packages'
+                        OutputDirectory = [ordered]@{
+                            Path = '/tmp/project/artifacts/packages'
+                            Clean = $true
+                        }
                         PackageFileName = 'NovaModuleTools.1.2.3.nupkg'
                         Authors = 'Test Author'
                         Description = 'Package test'
@@ -359,9 +361,11 @@ Describe 'Nova command model - release and publish behavior' {
                         LicenseUri = 'https://example.test/license'
                     }
                     Package = [ordered]@{
-                        Enabled = $true
                         Id = 'NovaModuleTools'
-                        OutputDirectory = '/tmp/project/artifacts/packages'
+                        OutputDirectory = [ordered]@{
+                            Path = '/tmp/project/artifacts/packages'
+                            Clean = $true
+                        }
                         PackageFileName = 'NovaModuleTools.1.2.3.nupkg'
                         Authors = 'Test Author'
                         Description = 'Package test'
@@ -408,9 +412,11 @@ Describe 'Nova command model - release and publish behavior' {
                         LicenseUri = ''
                     }
                     Package = [ordered]@{
-                        Enabled = $true
                         Id = 'NovaModuleTools'
-                        OutputDirectory = '/tmp/project/artifacts/packages'
+                        OutputDirectory = [ordered]@{
+                            Path = '/tmp/project/artifacts/packages'
+                            Clean = $true
+                        }
                         PackageFileName = 'NovaModuleTools.1.2.3.nupkg'
                         Authors = 'Test Author'
                         Description = 'Package test'
@@ -444,9 +450,11 @@ Describe 'Nova command model - release and publish behavior' {
                     LicenseUri = 'https://example.test/license'
                 }
                 Package = [ordered]@{
-                    Enabled = $true
                     Id = 'PackageProject'
-                    OutputDirectory = '/tmp/project/artifacts/packages'
+                    OutputDirectory = [ordered]@{
+                        Path = '/tmp/project/artifacts/packages'
+                        Clean = $true
+                    }
                     PackageFileName = 'PackageProject.2.3.4.nupkg'
                     Authors = 'Author One'
                     Description = 'Top-level description'
@@ -464,6 +472,7 @@ Describe 'Nova command model - release and publish behavior' {
             $result.ReleaseNotes | Should -Be 'https://example.test/release-notes'
             $result.LicenseUrl | Should -Be 'https://example.test/license'
             $result.OutputDirectory | Should -Be '/tmp/project/artifacts/packages'
+            $result.CleanOutputDirectory | Should -BeTrue
             $result.PackagePath | Should -Be '/tmp/project/artifacts/packages/PackageProject.2.3.4.nupkg'
         }
     }
@@ -485,9 +494,11 @@ Describe 'Nova command model - release and publish behavior' {
                         LicenseUri = ''
                     }
                     Package = [ordered]@{
-                        Enabled = $true
                         Id = 'NovaModuleTools'
-                        OutputDirectory = '/tmp/project/artifacts/packages'
+                        OutputDirectory = [ordered]@{
+                            Path = '/tmp/project/artifacts/packages'
+                            Clean = $true
+                        }
                         PackageFileName = 'NovaModuleTools.1.2.3.nupkg'
                         Authors = @()
                         Description = 'Package test'

--- a/tests/NovaCommandModel.ReleasePublish.Tests.ps1
+++ b/tests/NovaCommandModel.ReleasePublish.Tests.ps1
@@ -298,6 +298,211 @@ Describe 'Nova command model - release and publish behavior' {
         }
     }
 
+    It 'Pack-NovaModule runs build, test, and package creation in order' {
+        InModuleScope $script:moduleName {
+            $script:steps = @()
+
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    ProjectName = 'NovaModuleTools'
+                    Version = '1.2.3'
+                    ProjectRoot = '/tmp/project'
+                    OutputModuleDir = '/tmp/dist/NovaModuleTools'
+                    Description = 'Package test'
+                    Manifest = [ordered]@{
+                        Author = 'Test Author'
+                        Tags = @('Nova', 'PowerShell')
+                        ProjectUri = 'https://example.test/project'
+                        ReleaseNotes = 'https://example.test/release-notes'
+                        LicenseUri = 'https://example.test/license'
+                    }
+                    Package = [ordered]@{
+                        Enabled = $true
+                        Id = 'NovaModuleTools'
+                        OutputDirectory = '/tmp/project/artifacts/packages'
+                        PackageFileName = 'NovaModuleTools.1.2.3.nupkg'
+                        Authors = 'Test Author'
+                        Description = 'Package test'
+                    }
+                }
+            }
+            Mock Invoke-NovaBuild {$script:steps += 'build'}
+            Mock Test-NovaBuild {$script:steps += 'test'}
+            Mock New-NovaPackageArtifact {
+                $script:steps += 'pack'
+                [pscustomobject]@{PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'}
+            }
+
+            $result = Pack-NovaModule
+
+            $script:steps -join ',' | Should -Be 'build,test,pack'
+            $result.PackagePath | Should -Be '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'
+        }
+    }
+
+    It 'Pack-NovaModule reimports the current module when package helpers were unloaded during tests' {
+        InModuleScope $script:moduleName {
+            $script:steps = @()
+
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    ProjectName = 'NovaModuleTools'
+                    Version = '1.2.3'
+                    ProjectRoot = '/tmp/project'
+                    OutputModuleDir = '/tmp/dist/NovaModuleTools'
+                    Description = 'Package test'
+                    Manifest = [ordered]@{
+                        Author = 'Test Author'
+                        Tags = @('Nova', 'PowerShell')
+                        ProjectUri = 'https://example.test/project'
+                        ReleaseNotes = 'https://example.test/release-notes'
+                        LicenseUri = 'https://example.test/license'
+                    }
+                    Package = [ordered]@{
+                        Enabled = $true
+                        Id = 'NovaModuleTools'
+                        OutputDirectory = '/tmp/project/artifacts/packages'
+                        PackageFileName = 'NovaModuleTools.1.2.3.nupkg'
+                        Authors = 'Test Author'
+                        Description = 'Package test'
+                    }
+                }
+            }
+            Mock Invoke-NovaBuild {$script:steps += 'build'}
+            Mock Test-NovaBuild {$script:steps += 'test'}
+            Mock Get-Command {
+                $null
+            } -ParameterFilter {$Name -eq 'New-NovaPackageArtifact' -and $CommandType -eq 'Function'}
+            Mock Import-Module {
+                $ExecutionContext.SessionState.Module
+            } -ParameterFilter {$Name -eq $ExecutionContext.SessionState.Module.Path -and $PassThru}
+            Mock New-NovaPackageArtifact {
+                $script:steps += 'pack'
+                [pscustomobject]@{PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'}
+            }
+
+            $result = Pack-NovaModule
+
+            $script:steps -join ',' | Should -Be 'build,test,pack'
+            $result.PackagePath | Should -Be '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'
+            Assert-MockCalled Import-Module -Times 1 -ParameterFilter {$Name -eq $ExecutionContext.SessionState.Module.Path -and $PassThru}
+        }
+    }
+
+    It 'Pack-NovaModule -WhatIf forwards preview mode through build and test without creating a package' {
+        InModuleScope $script:moduleName {
+            $script:steps = @()
+
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    ProjectName = 'NovaModuleTools'
+                    Version = '1.2.3'
+                    ProjectRoot = '/tmp/project'
+                    OutputModuleDir = '/tmp/dist/NovaModuleTools'
+                    Description = 'Package test'
+                    Manifest = [ordered]@{
+                        Author = 'Test Author'
+                        Tags = @()
+                        ProjectUri = ''
+                        ReleaseNotes = ''
+                        LicenseUri = ''
+                    }
+                    Package = [ordered]@{
+                        Enabled = $true
+                        Id = 'NovaModuleTools'
+                        OutputDirectory = '/tmp/project/artifacts/packages'
+                        PackageFileName = 'NovaModuleTools.1.2.3.nupkg'
+                        Authors = 'Test Author'
+                        Description = 'Package test'
+                    }
+                }
+            }
+            Mock Invoke-NovaBuild {$script:steps += "build:$WhatIfPreference"}
+            Mock Test-NovaBuild {$script:steps += "test:$WhatIfPreference"}
+            Mock New-NovaPackageArtifact {$script:steps += 'pack'}
+
+            $result = Pack-NovaModule -WhatIf
+
+            $result | Should -BeNullOrEmpty
+            $script:steps -join ',' | Should -Be 'build:True,test:True'
+            Assert-MockCalled New-NovaPackageArtifact -Times 0
+        }
+    }
+
+    It 'Get-NovaPackageMetadata reuses project.json and Manifest metadata by default' {
+        InModuleScope $script:moduleName {
+            $projectInfo = [pscustomobject]@{
+                ProjectName = 'PackageProject'
+                Version = '2.3.4'
+                ProjectRoot = '/tmp/project'
+                Description = 'Top-level description'
+                Manifest = [ordered]@{
+                    Author = 'Author One'
+                    Tags = @('Nova', 'Packaging')
+                    ProjectUri = 'https://example.test/project'
+                    ReleaseNotes = 'https://example.test/release-notes'
+                    LicenseUri = 'https://example.test/license'
+                }
+                Package = [ordered]@{
+                    Enabled = $true
+                    Id = 'PackageProject'
+                    OutputDirectory = '/tmp/project/artifacts/packages'
+                    PackageFileName = 'PackageProject.2.3.4.nupkg'
+                    Authors = 'Author One'
+                    Description = 'Top-level description'
+                }
+            }
+
+            $result = Get-NovaPackageMetadata -ProjectInfo $projectInfo
+
+            $result.Id | Should -Be 'PackageProject'
+            $result.Version | Should -Be '2.3.4'
+            $result.Authors | Should -Be @('Author One')
+            $result.Description | Should -Be 'Top-level description'
+            $result.Tags | Should -Be @('Nova', 'Packaging')
+            $result.ProjectUrl | Should -Be 'https://example.test/project'
+            $result.ReleaseNotes | Should -Be 'https://example.test/release-notes'
+            $result.LicenseUrl | Should -Be 'https://example.test/license'
+            $result.OutputDirectory | Should -Be '/tmp/project/artifacts/packages'
+            $result.PackagePath | Should -Be '/tmp/project/artifacts/packages/PackageProject.2.3.4.nupkg'
+        }
+    }
+
+    It 'Pack-NovaModule fails with a clear message when package metadata is missing' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    ProjectName = 'NovaModuleTools'
+                    Version = '1.2.3'
+                    ProjectRoot = '/tmp/project'
+                    OutputModuleDir = '/tmp/dist/NovaModuleTools'
+                    Description = 'Package test'
+                    Manifest = [ordered]@{
+                        Author = ''
+                        Tags = @()
+                        ProjectUri = ''
+                        ReleaseNotes = ''
+                        LicenseUri = ''
+                    }
+                    Package = [ordered]@{
+                        Enabled = $true
+                        Id = 'NovaModuleTools'
+                        OutputDirectory = '/tmp/project/artifacts/packages'
+                        PackageFileName = 'NovaModuleTools.1.2.3.nupkg'
+                        Authors = @()
+                        Description = 'Package test'
+                    }
+                }
+            }
+            Mock Invoke-NovaBuild {throw 'should not build'}
+            Mock Test-NovaBuild {throw 'should not test'}
+
+            {Pack-NovaModule} | Should -Throw 'Missing package metadata value: Authors'
+            Assert-MockCalled Invoke-NovaBuild -Times 0
+            Assert-MockCalled Test-NovaBuild -Times 0
+        }
+    }
+
     It 'Get-ResourceFilePath prefers project src resources during build' {
         InModuleScope $script:moduleName {
             $expected = [System.IO.Path]::GetFullPath('/tmp/project/src/resources/Schema-Build.json')

--- a/tests/NovaCommandModel.ReleasePublish.Tests.ps1
+++ b/tests/NovaCommandModel.ReleasePublish.Tests.ps1
@@ -477,6 +477,37 @@ Describe 'Nova command model - release and publish behavior' {
         }
     }
 
+    It 'Get-NovaPackageMetadata keeps schema-optional manifest fields empty when they are omitted' {
+        InModuleScope $script:moduleName {
+            $projectInfo = [pscustomobject]@{
+                ProjectName = 'PackageProject'
+                Version = '2.3.4'
+                ProjectRoot = '/tmp/project'
+                Description = 'Top-level description'
+                Manifest = [ordered]@{
+                    Author = 'Author One'
+                }
+                Package = [ordered]@{
+                    Id = 'PackageProject'
+                    OutputDirectory = [ordered]@{
+                        Path = '/tmp/project/artifacts/packages'
+                        Clean = $true
+                    }
+                    PackageFileName = 'PackageProject.2.3.4.nupkg'
+                    Authors = 'Author One'
+                    Description = 'Top-level description'
+                }
+            }
+
+            $result = Get-NovaPackageMetadata -ProjectInfo $projectInfo
+
+            $result.Tags | Should -Be @()
+            $result.ProjectUrl | Should -Be ''
+            $result.ReleaseNotes | Should -Be ''
+            $result.LicenseUrl | Should -Be ''
+        }
+    }
+
     It 'Pack-NovaModule fails with a clear message when package metadata is missing' {
         InModuleScope $script:moduleName {
             Mock Get-NovaProjectInfo {

--- a/tests/NovaCommandModel.ReleasePublish.Tests.ps1
+++ b/tests/NovaCommandModel.ReleasePublish.Tests.ps1
@@ -298,7 +298,7 @@ Describe 'Nova command model - release and publish behavior' {
         }
     }
 
-    It 'Pack-NovaModule runs build, test, and package creation in order' {
+    It 'Pack-NovaModule runs build, test, and package creation in order for all requested package types' {
         InModuleScope $script:moduleName {
             $script:steps = @()
 
@@ -318,6 +318,7 @@ Describe 'Nova command model - release and publish behavior' {
                     }
                     Package = [ordered]@{
                         Id = 'NovaModuleTools'
+                        Types = @('NuGet', 'Zip')
                         OutputDirectory = [ordered]@{
                             Path = '/tmp/project/artifacts/packages'
                             Clean = $true
@@ -330,15 +331,22 @@ Describe 'Nova command model - release and publish behavior' {
             }
             Mock Invoke-NovaBuild {$script:steps += 'build'}
             Mock Test-NovaBuild {$script:steps += 'test'}
-            Mock New-NovaPackageArtifact {
+            Mock New-NovaPackageArtifacts {
                 $script:steps += 'pack'
-                [pscustomobject]@{PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'}
+                @(
+                    [pscustomobject]@{Type = 'NuGet'; PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'}
+                    [pscustomobject]@{Type = 'Zip'; PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.zip'}
+                )
             }
 
-            $result = Pack-NovaModule
+            $result = @(Pack-NovaModule)
 
             $script:steps -join ',' | Should -Be 'build,test,pack'
-            $result.PackagePath | Should -Be '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'
+            $result.Type | Should -Be @('NuGet', 'Zip')
+            $result.PackagePath | Should -Be @(
+                '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg',
+                '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.zip'
+            )
         }
     }
 
@@ -362,6 +370,7 @@ Describe 'Nova command model - release and publish behavior' {
                     }
                     Package = [ordered]@{
                         Id = 'NovaModuleTools'
+                        Types = @('NuGet', 'Zip')
                         OutputDirectory = [ordered]@{
                             Path = '/tmp/project/artifacts/packages'
                             Clean = $true
@@ -376,19 +385,22 @@ Describe 'Nova command model - release and publish behavior' {
             Mock Test-NovaBuild {$script:steps += 'test'}
             Mock Get-Command {
                 $null
-            } -ParameterFilter {$Name -eq 'New-NovaPackageArtifact' -and $CommandType -eq 'Function'}
+            } -ParameterFilter {$Name -eq 'New-NovaPackageArtifacts' -and $CommandType -eq 'Function'}
             Mock Import-Module {
                 $ExecutionContext.SessionState.Module
             } -ParameterFilter {$Name -eq $ExecutionContext.SessionState.Module.Path -and $PassThru}
-            Mock New-NovaPackageArtifact {
+            Mock New-NovaPackageArtifacts {
                 $script:steps += 'pack'
-                [pscustomobject]@{PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'}
+                @(
+                    [pscustomobject]@{Type = 'NuGet'; PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'}
+                    [pscustomobject]@{Type = 'Zip'; PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.zip'}
+                )
             }
 
-            $result = Pack-NovaModule
+            $result = @(Pack-NovaModule)
 
             $script:steps -join ',' | Should -Be 'build,test,pack'
-            $result.PackagePath | Should -Be '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'
+            $result.Type | Should -Be @('NuGet', 'Zip')
             Assert-MockCalled Import-Module -Times 1 -ParameterFilter {$Name -eq $ExecutionContext.SessionState.Module.Path -and $PassThru}
         }
     }
@@ -425,13 +437,13 @@ Describe 'Nova command model - release and publish behavior' {
             }
             Mock Invoke-NovaBuild {$script:steps += "build:$WhatIfPreference"}
             Mock Test-NovaBuild {$script:steps += "test:$WhatIfPreference"}
-            Mock New-NovaPackageArtifact {$script:steps += 'pack'}
+            Mock New-NovaPackageArtifacts {$script:steps += 'pack'}
 
             $result = Pack-NovaModule -WhatIf
 
             $result | Should -BeNullOrEmpty
             $script:steps -join ',' | Should -Be 'build:True,test:True'
-            Assert-MockCalled New-NovaPackageArtifact -Times 0
+            Assert-MockCalled New-NovaPackageArtifacts -Times 0
         }
     }
 
@@ -451,6 +463,7 @@ Describe 'Nova command model - release and publish behavior' {
                 }
                 Package = [ordered]@{
                     Id = 'PackageProject'
+                    Types = @('NuGet')
                     OutputDirectory = [ordered]@{
                         Path = '/tmp/project/artifacts/packages'
                         Clean = $true
@@ -463,6 +476,7 @@ Describe 'Nova command model - release and publish behavior' {
 
             $result = Get-NovaPackageMetadata -ProjectInfo $projectInfo
 
+            $result.Type | Should -Be 'NuGet'
             $result.Id | Should -Be 'PackageProject'
             $result.Version | Should -Be '2.3.4'
             $result.Authors | Should -Be @('Author One')
@@ -474,6 +488,41 @@ Describe 'Nova command model - release and publish behavior' {
             $result.OutputDirectory | Should -Be '/tmp/project/artifacts/packages'
             $result.CleanOutputDirectory | Should -BeTrue
             $result.PackagePath | Should -Be '/tmp/project/artifacts/packages/PackageProject.2.3.4.nupkg'
+        }
+    }
+
+    It 'Get-NovaPackageMetadataList returns one metadata object per requested package type' {
+        InModuleScope $script:moduleName {
+            $projectInfo = [pscustomobject]@{
+                ProjectName = 'PackageProject'
+                Version = '2.3.4'
+                ProjectRoot = '/tmp/project'
+                Description = 'Top-level description'
+                Manifest = [ordered]@{
+                    Author = 'Author One'
+                    Tags = @('Nova', 'Packaging')
+                }
+                Package = [ordered]@{
+                    Id = 'PackageProject'
+                    Types = @('NuGet', 'Zip')
+                    OutputDirectory = [ordered]@{
+                        Path = '/tmp/project/artifacts/packages'
+                        Clean = $true
+                    }
+                    PackageFileName = 'PackageProject.2.3.4.nupkg'
+                    Authors = 'Author One'
+                    Description = 'Top-level description'
+                }
+            }
+
+            $result = @(Get-NovaPackageMetadataList -ProjectInfo $projectInfo)
+
+            $result.Type | Should -Be @('NuGet', 'Zip')
+            $result.PackageFileName | Should -Be @('PackageProject.2.3.4.nupkg', 'PackageProject.2.3.4.zip')
+            $result.PackagePath | Should -Be @(
+                '/tmp/project/artifacts/packages/PackageProject.2.3.4.nupkg',
+                '/tmp/project/artifacts/packages/PackageProject.2.3.4.zip'
+            )
         }
     }
 
@@ -489,6 +538,7 @@ Describe 'Nova command model - release and publish behavior' {
                 }
                 Package = [ordered]@{
                     Id = 'PackageProject'
+                    Types = @('NuGet')
                     OutputDirectory = [ordered]@{
                         Path = '/tmp/project/artifacts/packages'
                         Clean = $true

--- a/tests/NovaCommandModel.StandaloneCli.Tests.ps1
+++ b/tests/NovaCommandModel.StandaloneCli.Tests.ps1
@@ -81,6 +81,7 @@ Describe 'Nova command model - standalone CLI behavior' {
             $helpText | Should -Match 'usage: nova \[--version\] \[--help\] <command> \[<args>\]'
             ($helpText -match 'notification\s+Show or change prerelease self-update eligibility') | Should -BeTrue
             $helpText | Should -Match 'version\s+Show the current project version, or use -Installed for the locally installed project module version'
+            $helpText | Should -Match 'pack\s+Build, test, and package the module as a \.nupkg artifact'
             $versionText | Should -Be "$script:moduleName $installedModuleVersion"
             $projectVersionText | Should -Be $expectedProjectVersionText
         }
@@ -284,7 +285,32 @@ function Invoke-TestCliVerbose {
             $result | Should -Match 'version\s+Show the current project version, or use -Installed for the locally installed project module version'
             $result | Should -Match 'nova version -Installed'
             $result | Should -Match '--version\s+Show the installed NovaModuleTools module name and version'
+            $result | Should -Match 'pack\s+Build, test, and package the module as a \.nupkg artifact'
             $result | Should -Match 'publish\s+Build, test, and publish the module locally or to a repository'
+        }
+    }
+
+    It 'Invoke-NovaCli pack routes to Pack-NovaModule' {
+        InModuleScope $script:moduleName {
+            Mock Pack-NovaModule {
+                [pscustomobject]@{PackagePath = '/tmp/artifacts/packages/NovaModuleTools.1.2.3.nupkg'}
+            }
+
+            $result = Invoke-NovaCli pack
+
+            $result.PackagePath | Should -Be '/tmp/artifacts/packages/NovaModuleTools.1.2.3.nupkg'
+        }
+    }
+
+    It 'Invoke-NovaCli pack forwards WhatIf to Pack-NovaModule' {
+        InModuleScope $script:moduleName {
+            Mock Pack-NovaModule {
+                [pscustomobject]@{WhatIfSeen = $WhatIfPreference}
+            }
+
+            $result = Invoke-NovaCli pack -WhatIf
+
+            $result.WhatIfSeen | Should -BeTrue
         }
     }
 

--- a/tests/NovaCommandModel.StandaloneCli.Tests.ps1
+++ b/tests/NovaCommandModel.StandaloneCli.Tests.ps1
@@ -81,7 +81,7 @@ Describe 'Nova command model - standalone CLI behavior' {
             $helpText | Should -Match 'usage: nova \[--version\] \[--help\] <command> \[<args>\]'
             ($helpText -match 'notification\s+Show or change prerelease self-update eligibility') | Should -BeTrue
             $helpText | Should -Match 'version\s+Show the current project version, or use -Installed for the locally installed project module version'
-            $helpText | Should -Match 'pack\s+Build, test, and package the module as a \.nupkg artifact'
+            $helpText | Should -Match 'pack\s+Build, test, and package the module as configured package artifact\(s\)'
             $versionText | Should -Be "$script:moduleName $installedModuleVersion"
             $projectVersionText | Should -Be $expectedProjectVersionText
         }
@@ -285,7 +285,7 @@ function Invoke-TestCliVerbose {
             $result | Should -Match 'version\s+Show the current project version, or use -Installed for the locally installed project module version'
             $result | Should -Match 'nova version -Installed'
             $result | Should -Match '--version\s+Show the installed NovaModuleTools module name and version'
-            $result | Should -Match 'pack\s+Build, test, and package the module as a \.nupkg artifact'
+            $result | Should -Match 'pack\s+Build, test, and package the module as configured package artifact\(s\)'
             $result | Should -Match 'publish\s+Build, test, and publish the module locally or to a repository'
         }
     }
@@ -293,12 +293,15 @@ function Invoke-TestCliVerbose {
     It 'Invoke-NovaCli pack routes to Pack-NovaModule' {
         InModuleScope $script:moduleName {
             Mock Pack-NovaModule {
-                [pscustomobject]@{PackagePath = '/tmp/artifacts/packages/NovaModuleTools.1.2.3.nupkg'}
+                @(
+                    [pscustomobject]@{Type = 'NuGet'; PackagePath = '/tmp/artifacts/packages/NovaModuleTools.1.2.3.nupkg'}
+                )
             }
 
-            $result = Invoke-NovaCli pack
+            $result = @(Invoke-NovaCli pack)
 
-            $result.PackagePath | Should -Be '/tmp/artifacts/packages/NovaModuleTools.1.2.3.nupkg'
+            $result.Type | Should -Be @('NuGet')
+            $result.PackagePath | Should -Be @('/tmp/artifacts/packages/NovaModuleTools.1.2.3.nupkg')
         }
     }
 

--- a/tests/NovaCommandModel.TestSupport.ps1
+++ b/tests/NovaCommandModel.TestSupport.ps1
@@ -152,6 +152,10 @@ function Write-TestNovaCliProjectJson {
     "Tags": [],
     "ProjectUri": ""
   },
+  "Package": {
+    "Enabled": true,
+    "OutputDirectory": "artifacts/packages"
+  },
   "Pester": {
     "TestResult": {
       "Enabled": true,

--- a/tests/NovaCommandModel.TestSupport.ps1
+++ b/tests/NovaCommandModel.TestSupport.ps1
@@ -153,6 +153,9 @@ function Write-TestNovaCliProjectJson {
     "ProjectUri": ""
   },
   "Package": {
+    "Types": [
+      "NuGet"
+    ],
     "OutputDirectory": {
       "Path": "artifacts/packages",
       "Clean": true

--- a/tests/NovaCommandModel.TestSupport.ps1
+++ b/tests/NovaCommandModel.TestSupport.ps1
@@ -153,8 +153,10 @@ function Write-TestNovaCliProjectJson {
     "ProjectUri": ""
   },
   "Package": {
-    "Enabled": true,
-    "OutputDirectory": "artifacts/packages"
+    "OutputDirectory": {
+      "Path": "artifacts/packages",
+      "Clean": true
+    }
   },
   "Pester": {
     "TestResult": {

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -125,6 +125,7 @@ Describe 'Nova command model - project, help, and build behavior' {
             $projectInfo = Get-NovaProjectInfo -Path $projectRoot
 
             $projectInfo.Package.Id | Should -Be 'DefaultPackageProject'
+            $projectInfo.Package.Types | Should -Be @('NuGet')
             $projectInfo.Package.OutputDirectory.Path | Should -Be ([System.IO.Path]::Join($projectRoot, 'artifacts/packages'))
             $projectInfo.Package.OutputDirectory.Clean | Should -BeTrue
             $projectInfo.Package.PackageFileName | Should -Be 'DefaultPackageProject.0.0.1.nupkg'
@@ -155,8 +156,71 @@ Describe 'Nova command model - project, help, and build behavior' {
 
             $projectInfo = Get-NovaProjectInfo -Path $projectRoot
 
+            $projectInfo.Package.Types | Should -Be @('NuGet')
             $projectInfo.Package.OutputDirectory.Path | Should -Be ([System.IO.Path]::Join($projectRoot, 'custom/packages'))
             $projectInfo.Package.OutputDirectory.Clean | Should -BeTrue
+        }
+    }
+
+    It 'Get-NovaProjectInfo resolves Package.Types scenarios correctly' -ForEach @(
+        @{
+            Name = 'defaults empty arrays to NuGet'
+            ProjectRootName = 'empty-package-types'
+            ProjectName = 'EmptyTypesProject'
+            Description = 'Empty package types test'
+            Version = '0.0.3'
+            Guid = '66666666-6666-6666-6666-666666666666'
+            Types = @()
+            ExpectedTypes = @('NuGet')
+        }
+        @{
+            Name = 'normalizes aliases, casing, and duplicates'
+            ProjectRootName = 'normalized-package-types'
+            ProjectName = 'NormalizedTypesProject'
+            Description = 'Normalized package types test'
+            Version = '0.0.4'
+            Guid = '77777777-7777-7777-7777-777777777777'
+            Types = @('zip', '.NUPKG', 'NuGet', '.zip')
+            ExpectedTypes = @('Zip', 'NuGet')
+        }
+        @{
+            Name = 'rejects unsupported values'
+            ProjectRootName = 'invalid-package-types'
+            ProjectName = 'InvalidTypesProject'
+            Description = 'Invalid package types test'
+            Version = '0.0.5'
+            Guid = '88888888-8888-8888-8888-888888888888'
+            Types = @('Tar')
+            ErrorMessage = 'Unsupported Package.Types value: Tar*'
+        }
+    ) {
+        InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+            param($TestCase)
+
+            $projectRoot = Join-Path $TestDrive $TestCase.ProjectRootName
+            New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+            $projectJson = ([ordered]@{
+                ProjectName = $TestCase.ProjectName
+                Description = $TestCase.Description
+                Version = $TestCase.Version
+                Manifest = [ordered]@{
+                    Author = 'Test Author'
+                    PowerShellHostVersion = '7.4'
+                    GUID = $TestCase.Guid
+                }
+                Package = [ordered]@{
+                    Types = $TestCase.Types
+                }
+            } | ConvertTo-Json -Depth 5)
+
+            Set-Content -LiteralPath (Join-Path $projectRoot 'project.json') -Value $projectJson -Encoding utf8
+
+            if ( $TestCase.ContainsKey('ErrorMessage')) {
+                {Get-NovaProjectInfo -Path $projectRoot} | Should -Throw $TestCase.ErrorMessage
+                return
+            }
+
+            (Get-NovaProjectInfo -Path $projectRoot).Package.Types | Should -Be $TestCase.ExpectedTypes
         }
     }
 

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -124,12 +124,39 @@ Describe 'Nova command model - project, help, and build behavior' {
 
             $projectInfo = Get-NovaProjectInfo -Path $projectRoot
 
-            $projectInfo.Package.Enabled | Should -BeTrue
             $projectInfo.Package.Id | Should -Be 'DefaultPackageProject'
-            $projectInfo.Package.OutputDirectory | Should -Be ([System.IO.Path]::Join($projectRoot, 'artifacts/packages'))
+            $projectInfo.Package.OutputDirectory.Path | Should -Be ([System.IO.Path]::Join($projectRoot, 'artifacts/packages'))
+            $projectInfo.Package.OutputDirectory.Clean | Should -BeTrue
             $projectInfo.Package.PackageFileName | Should -Be 'DefaultPackageProject.0.0.1.nupkg'
             $projectInfo.Package.Authors | Should -Be 'Test Author'
             $projectInfo.Package.Description | Should -Be 'Default package option test'
+        }
+    }
+
+    It 'Get-NovaProjectInfo normalizes the legacy Package.OutputDirectory string to the new object shape' {
+        InModuleScope $script:moduleName {
+            $projectRoot = Join-Path $TestDrive 'legacy-package-output-directory'
+            New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+            $projectJson = ([ordered]@{
+                ProjectName = 'LegacyPackageProject'
+                Description = 'Legacy package option test'
+                Version = '0.0.2'
+                Manifest = [ordered]@{
+                    Author = 'Legacy Author'
+                    PowerShellHostVersion = '7.4'
+                    GUID = '55555555-5555-5555-5555-555555555555'
+                }
+                Package = [ordered]@{
+                    OutputDirectory = 'custom/packages'
+                }
+            } | ConvertTo-Json -Depth 5)
+
+            Set-Content -LiteralPath (Join-Path $projectRoot 'project.json') -Value $projectJson -Encoding utf8
+
+            $projectInfo = Get-NovaProjectInfo -Path $projectRoot
+
+            $projectInfo.Package.OutputDirectory.Path | Should -Be ([System.IO.Path]::Join($projectRoot, 'custom/packages'))
+            $projectInfo.Package.OutputDirectory.Clean | Should -BeTrue
         }
     }
 

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -105,6 +105,34 @@ Describe 'Nova command model - project, help, and build behavior' {
         }
     }
 
+    It 'Get-NovaProjectInfo exposes Package defaults when omitted' {
+        InModuleScope $script:moduleName {
+            $projectRoot = Join-Path $TestDrive 'default-package-option'
+            New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+            $projectJson = ([ordered]@{
+                ProjectName = 'DefaultPackageProject'
+                Description = 'Default package option test'
+                Version = '0.0.1'
+                Manifest = [ordered]@{
+                    Author = 'Test Author'
+                    PowerShellHostVersion = '7.4'
+                    GUID = '44444444-4444-4444-4444-444444444444'
+                }
+            } | ConvertTo-Json -Depth 5)
+
+            Set-Content -LiteralPath (Join-Path $projectRoot 'project.json') -Value $projectJson -Encoding utf8
+
+            $projectInfo = Get-NovaProjectInfo -Path $projectRoot
+
+            $projectInfo.Package.Enabled | Should -BeTrue
+            $projectInfo.Package.Id | Should -Be 'DefaultPackageProject'
+            $projectInfo.Package.OutputDirectory | Should -Be ([System.IO.Path]::Join($projectRoot, 'artifacts/packages'))
+            $projectInfo.Package.PackageFileName | Should -Be 'DefaultPackageProject.0.0.1.nupkg'
+            $projectInfo.Package.Authors | Should -Be 'Test Author'
+            $projectInfo.Package.Description | Should -Be 'Default package option test'
+        }
+    }
+
     It 'build output includes the generated external help file' {
         Test-Path -LiteralPath $script:helpXmlPath | Should -BeTrue
     }
@@ -198,6 +226,7 @@ Describe 'Nova command model - project, help, and build behavior' {
     It 'Get-Help surfaces native WhatIf and Confirm support for mutating public commands' {
         foreach ($commandName in @(
             'Invoke-NovaBuild',
+            'Pack-NovaModule',
             'Test-NovaBuild',
             'Publish-NovaModule',
             'Invoke-NovaRelease',
@@ -222,11 +251,13 @@ Describe 'Nova command model - project, help, and build behavior' {
             Mock Build-Manifest {}
             Mock Build-Help {}
             Mock Copy-ProjectResource {}
+            Mock New-NovaPackageArtifact {}
             Mock Invoke-NovaBuildUpdateNotification {}
 
             Invoke-NovaBuild
 
             Assert-MockCalled Build-Module -Times 1
+            Assert-MockCalled New-NovaPackageArtifact -Times 0
             Assert-MockCalled Invoke-NovaBuildUpdateNotification -Times 1
         }
     }

--- a/tests/RemainingHelperCoverage.TestSupport.ps1
+++ b/tests/RemainingHelperCoverage.TestSupport.ps1
@@ -37,3 +37,59 @@ function Assert-TestNovaPackageArtifactContent {
     }
 }
 
+function Initialize-TestNovaPackageProjectLayout {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ProjectRoot
+    )
+
+    $outputModuleDir = Join-Path $ProjectRoot 'dist/PackageProject'
+    $packageOutputDir = Join-Path $ProjectRoot 'artifacts/packages'
+    $resourceDir = Join-Path $outputModuleDir 'resources'
+    New-Item -ItemType Directory -Path $resourceDir -Force | Out-Null
+    '@{}' | Set-Content -LiteralPath (Join-Path $outputModuleDir 'PackageProject.psd1') -Encoding utf8
+    'function Get-TestPackage { }' | Set-Content -LiteralPath (Join-Path $outputModuleDir 'PackageProject.psm1') -Encoding utf8
+    '#!/usr/bin/env pwsh' | Set-Content -LiteralPath (Join-Path $resourceDir 'nova') -Encoding utf8
+
+    return [pscustomobject]@{
+        ProjectRoot = $ProjectRoot
+        OutputModuleDir = $outputModuleDir
+        PackageOutputDir = $packageOutputDir
+    }
+}
+
+function Get-TestNovaPackageProjectInfo {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ProjectRoot,
+        [Parameter(Mandatory)][string]$OutputModuleDir,
+        [Parameter(Mandatory)][string]$PackageOutputDir,
+        [Parameter(Mandatory)][bool]$CleanOutputDirectory
+    )
+
+    return [pscustomobject]@{
+        ProjectName = 'PackageProject'
+        Version = '2.3.4'
+        ProjectRoot = $ProjectRoot
+        OutputModuleDir = $OutputModuleDir
+        Description = 'Package project description'
+        Manifest = [ordered]@{
+            Author = 'Author One'
+            Tags = @('Nova', 'Packaging')
+            ProjectUri = 'https://example.test/project'
+            ReleaseNotes = 'https://example.test/release-notes'
+            LicenseUri = 'https://example.test/license'
+        }
+        Package = [ordered]@{
+            Id = 'PackageProject'
+            OutputDirectory = [ordered]@{
+                Path = $PackageOutputDir
+                Clean = $CleanOutputDirectory
+            }
+            PackageFileName = 'PackageProject.2.3.4.nupkg'
+            Authors = @('Author One', 'Author Two')
+            Description = 'Package project description'
+        }
+    }
+}
+

--- a/tests/RemainingHelperCoverage.TestSupport.ps1
+++ b/tests/RemainingHelperCoverage.TestSupport.ps1
@@ -61,29 +61,36 @@ function Initialize-TestNovaPackageProjectLayout {
 function Get-TestNovaPackageProjectInfo {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][string]$ProjectRoot,
-        [Parameter(Mandatory)][string]$OutputModuleDir,
-        [Parameter(Mandatory)][string]$PackageOutputDir,
-        [Parameter(Mandatory)][bool]$CleanOutputDirectory
+        [Parameter(Mandatory)][pscustomobject]$Layout,
+        [Parameter(Mandatory)][bool]$CleanOutputDirectory,
+        [switch]$OmitOptionalManifestMetadata
     )
+
+    $manifest = [ordered]@{
+        Author = 'Author One'
+        Tags = @('Nova', 'Packaging')
+        ProjectUri = 'https://example.test/project'
+        ReleaseNotes = 'https://example.test/release-notes'
+        LicenseUri = 'https://example.test/license'
+    }
+    if ($OmitOptionalManifestMetadata) {
+        $null = $manifest.Remove('Tags')
+        $null = $manifest.Remove('ProjectUri')
+        $null = $manifest.Remove('ReleaseNotes')
+        $null = $manifest.Remove('LicenseUri')
+    }
 
     return [pscustomobject]@{
         ProjectName = 'PackageProject'
         Version = '2.3.4'
-        ProjectRoot = $ProjectRoot
-        OutputModuleDir = $OutputModuleDir
+        ProjectRoot = $Layout.ProjectRoot
+        OutputModuleDir = $Layout.OutputModuleDir
         Description = 'Package project description'
-        Manifest = [ordered]@{
-            Author = 'Author One'
-            Tags = @('Nova', 'Packaging')
-            ProjectUri = 'https://example.test/project'
-            ReleaseNotes = 'https://example.test/release-notes'
-            LicenseUri = 'https://example.test/license'
-        }
+        Manifest = $manifest
         Package = [ordered]@{
             Id = 'PackageProject'
             OutputDirectory = [ordered]@{
-                Path = $PackageOutputDir
+                Path = $Layout.PackageOutputDir
                 Clean = $CleanOutputDirectory
             }
             PackageFileName = 'PackageProject.2.3.4.nupkg'

--- a/tests/RemainingHelperCoverage.TestSupport.ps1
+++ b/tests/RemainingHelperCoverage.TestSupport.ps1
@@ -1,0 +1,39 @@
+function Assert-TestNovaPackageArtifactContent {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$PackagePath
+    )
+
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($PackagePath)
+    try {
+        $entryNames = @($archive.Entries | ForEach-Object FullName)
+        $entryNames | Should -Contain '_rels/.rels'
+        $entryNames | Should -Contain '[Content_Types].xml'
+        $entryNames | Should -Contain 'PackageProject.nuspec'
+        $entryNames | Should -Contain 'content/PackageProject/PackageProject.psd1'
+        $entryNames | Should -Contain 'content/PackageProject/PackageProject.psm1'
+        $entryNames | Should -Contain 'content/PackageProject/resources/nova'
+        @($entryNames | Where-Object {$_ -like 'package/services/metadata/core-properties/*.psmdcp'}).Count | Should -Be 1
+
+        $nuspecText = [System.IO.StreamReader]::new(($archive.GetEntry('PackageProject.nuspec')).Open()).ReadToEnd()
+        $contentTypesText = [System.IO.StreamReader]::new(($archive.GetEntry('[Content_Types].xml')).Open()).ReadToEnd()
+        $relsText = [System.IO.StreamReader]::new(($archive.GetEntry('_rels/.rels')).Open()).ReadToEnd()
+
+        $nuspecText | Should -Match '<id>PackageProject</id>'
+        $nuspecText | Should -Match '<version>2.3.4</version>'
+        $nuspecText | Should -Match '<authors>Author One, Author Two</authors>'
+        $nuspecText | Should -Match '<projectUrl>https://example.test/project</projectUrl>'
+        $nuspecText | Should -Match '<releaseNotes>https://example.test/release-notes</releaseNotes>'
+        $nuspecText | Should -Match '<licenseUrl>https://example.test/license</licenseUrl>'
+        $contentTypesText | Should -Match 'Extension="nuspec"'
+        $contentTypesText | Should -Match 'Extension="psd1"'
+        $contentTypesText | Should -Match 'Extension="psm1"'
+        $contentTypesText | Should -Match 'PartName="/content/PackageProject/resources/nova"'
+        $relsText | Should -Match 'http://schemas.microsoft.com/packaging/2010/07/manifest'
+        $relsText | Should -Match 'Target="/PackageProject.nuspec"'
+    }
+    finally {
+        $archive.Dispose()
+    }
+}
+

--- a/tests/RemainingHelperCoverage.TestSupport.ps1
+++ b/tests/RemainingHelperCoverage.TestSupport.ps1
@@ -37,6 +37,27 @@ function Assert-TestNovaPackageArtifactContent {
     }
 }
 
+function Assert-TestNovaZipPackageArtifactContent {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$PackagePath
+    )
+
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($PackagePath)
+    try {
+        $entryNames = @($archive.Entries | ForEach-Object FullName)
+        $entryNames | Should -Contain 'PackageProject/PackageProject.psd1'
+        $entryNames | Should -Contain 'PackageProject/PackageProject.psm1'
+        $entryNames | Should -Contain 'PackageProject/resources/nova'
+        $entryNames | Should -Not -Contain 'PackageProject.nuspec'
+        $entryNames | Should -Not -Contain '_rels/.rels'
+        $entryNames | Should -Not -Contain '[Content_Types].xml'
+    }
+    finally {
+        $archive.Dispose()
+    }
+}
+
 function Initialize-TestNovaPackageProjectLayout {
     [CmdletBinding()]
     param(
@@ -63,6 +84,7 @@ function Get-TestNovaPackageProjectInfo {
     param(
         [Parameter(Mandatory)][pscustomobject]$Layout,
         [Parameter(Mandatory)][bool]$CleanOutputDirectory,
+        [string[]]$PackageTypes = @('NuGet'),
         [switch]$OmitOptionalManifestMetadata
     )
 
@@ -89,6 +111,7 @@ function Get-TestNovaPackageProjectInfo {
         Manifest = $manifest
         Package = [ordered]@{
             Id = 'PackageProject'
+            Types = @($PackageTypes)
             OutputDirectory = [ordered]@{
                 Path = $Layout.PackageOutputDir
                 Clean = $CleanOutputDirectory

--- a/tests/RemainingHelperCoverage.Tests.ps1
+++ b/tests/RemainingHelperCoverage.Tests.ps1
@@ -1,6 +1,8 @@
 $script:remainingHelperCoverageTestSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'RemainingHelperCoverage.TestSupport.ps1')).Path
 $global:remainingHelperCoverageTestSupportFunctionNameList = @(
-    'Assert-TestNovaPackageArtifactContent'
+    'Assert-TestNovaPackageArtifactContent',
+    'Initialize-TestNovaPackageProjectLayout',
+    'Get-TestNovaPackageProjectInfo'
 )
 
 . $script:remainingHelperCoverageTestSupportPath
@@ -12,7 +14,11 @@ foreach ($functionName in $global:remainingHelperCoverageTestSupportFunctionName
 
 BeforeAll {
     $remainingHelperCoverageTestSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'RemainingHelperCoverage.TestSupport.ps1')).Path
-    $remainingHelperCoverageTestSupportFunctionNameList = @('Assert-TestNovaPackageArtifactContent')
+    $remainingHelperCoverageTestSupportFunctionNameList = @(
+        'Assert-TestNovaPackageArtifactContent',
+        'Initialize-TestNovaPackageProjectLayout',
+        'Get-TestNovaPackageProjectInfo'
+    )
 
     . $remainingHelperCoverageTestSupportPath
 
@@ -278,50 +284,12 @@ Locale: en-US
     }
 
     It 'New-NovaPackageArtifact writes a NuGet-compatible package structure with project metadata and built files' {
-        $projectRoot = Join-Path $TestDrive 'package-project'
-        $outputModuleDir = Join-Path $projectRoot 'dist/PackageProject'
-        $packageOutputDir = Join-Path $projectRoot 'artifacts/packages'
-        $manifestPath = Join-Path $outputModuleDir 'PackageProject.psd1'
-        $modulePath = Join-Path $outputModuleDir 'PackageProject.psm1'
-        $resourceDir = Join-Path $outputModuleDir 'resources'
-        $resourcePath = Join-Path $resourceDir 'nova'
-        $packagePath = $null
-
-        New-Item -ItemType Directory -Path $resourceDir -Force | Out-Null
-        '@{}' | Set-Content -LiteralPath $manifestPath -Encoding utf8
-        'function Get-TestPackage { }' | Set-Content -LiteralPath $modulePath -Encoding utf8
-        '#!/usr/bin/env pwsh' | Set-Content -LiteralPath $resourcePath -Encoding utf8
+        $layout = Initialize-TestNovaPackageProjectLayout -ProjectRoot (Join-Path $TestDrive 'package-project')
 
         $packagePath = InModuleScope $script:moduleName -Parameters @{
-            ProjectRoot = $projectRoot
-            OutputModuleDir = $outputModuleDir
-            PackageOutputDir = $packageOutputDir
+            ProjectInfo = (Get-TestNovaPackageProjectInfo -ProjectRoot $layout.ProjectRoot -OutputModuleDir $layout.OutputModuleDir -PackageOutputDir $layout.PackageOutputDir -CleanOutputDirectory $true)
         } {
-            param($ProjectRoot, $OutputModuleDir, $PackageOutputDir)
-
-            $projectInfo = [pscustomobject]@{
-                ProjectName = 'PackageProject'
-                Version = '2.3.4'
-                ProjectRoot = $ProjectRoot
-                OutputModuleDir = $OutputModuleDir
-                Description = 'Package project description'
-                Manifest = [ordered]@{
-                    Author = 'Author One'
-                    Tags = @('Nova', 'Packaging')
-                    ProjectUri = 'https://example.test/project'
-                    ReleaseNotes = 'https://example.test/release-notes'
-                    LicenseUri = 'https://example.test/license'
-                }
-                Package = [ordered]@{
-                    Enabled = $true
-                    Id = 'PackageProject'
-                    OutputDirectory = $PackageOutputDir
-                    PackageFileName = 'PackageProject.2.3.4.nupkg'
-                    Authors = @('Author One', 'Author Two')
-                    Description = 'Package project description'
-                }
-            }
-
+            param($ProjectInfo)
             $packageMetadata = Get-NovaPackageMetadata -ProjectInfo $projectInfo
             $result = New-NovaPackageArtifact -ProjectInfo $projectInfo -PackageMetadata $packageMetadata
 
@@ -331,5 +299,26 @@ Locale: en-US
 
         $packagePath | Should -Not -BeNullOrEmpty
         Assert-TestNovaPackageArtifactContent -PackagePath $packagePath
+    }
+
+    It 'New-NovaPackageArtifact honors Package.OutputDirectory.Clean when stale package files exist' -ForEach @(
+        @{Name = 'clean output directory'; CleanOutputDirectory = $true; ExpectedStaleFile = $false}
+        @{Name = 'preserve output directory'; CleanOutputDirectory = $false; ExpectedStaleFile = $true}
+    ) {
+        $layout = Initialize-TestNovaPackageProjectLayout -ProjectRoot (Join-Path $TestDrive $_.Name.Replace(' ', '-'))
+        $staleFilePath = Join-Path $layout.PackageOutputDir 'stale.txt'
+        New-Item -ItemType Directory -Path $layout.PackageOutputDir -Force | Out-Null
+        'stale' | Set-Content -LiteralPath $staleFilePath -Encoding utf8
+
+        InModuleScope $script:moduleName -Parameters @{
+            ProjectInfo = (Get-TestNovaPackageProjectInfo -ProjectRoot $layout.ProjectRoot -OutputModuleDir $layout.OutputModuleDir -PackageOutputDir $layout.PackageOutputDir -CleanOutputDirectory $_.CleanOutputDirectory)
+        } {
+            param($ProjectInfo)
+
+            $packageMetadata = Get-NovaPackageMetadata -ProjectInfo $ProjectInfo
+            $null = New-NovaPackageArtifact -ProjectInfo $ProjectInfo -PackageMetadata $packageMetadata
+        }
+
+        Test-Path -LiteralPath $staleFilePath | Should -Be $_.ExpectedStaleFile
     }
 }

--- a/tests/RemainingHelperCoverage.Tests.ps1
+++ b/tests/RemainingHelperCoverage.Tests.ps1
@@ -1,6 +1,7 @@
 $script:remainingHelperCoverageTestSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'RemainingHelperCoverage.TestSupport.ps1')).Path
 $global:remainingHelperCoverageTestSupportFunctionNameList = @(
     'Assert-TestNovaPackageArtifactContent',
+    'Assert-TestNovaZipPackageArtifactContent',
     'Initialize-TestNovaPackageProjectLayout',
     'Get-TestNovaPackageProjectInfo'
 )
@@ -16,6 +17,7 @@ BeforeAll {
     $remainingHelperCoverageTestSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'RemainingHelperCoverage.TestSupport.ps1')).Path
     $remainingHelperCoverageTestSupportFunctionNameList = @(
         'Assert-TestNovaPackageArtifactContent',
+        'Assert-TestNovaZipPackageArtifactContent',
         'Initialize-TestNovaPackageProjectLayout',
         'Get-TestNovaPackageProjectInfo'
     )
@@ -140,6 +142,45 @@ Describe 'Coverage for remaining manifest, JSON, and help-locale helpers' {
             Assert-MockCalled Test-Json -Times 1 -ParameterFilter {
                 $Path -eq 'project.json' -and $Schema -eq '{"title":"build"}'
             }
+        }
+    }
+
+    It 'Test-ProjectSchema accepts Package.Types aliases case-insensitively and rejects unsupported values' -ForEach @(
+        @{Name = 'accepts mixed-case aliases'; Types = @('.NuPkg', 'ZIP'); Expected = $true; Throws = $false; ErrorMessage = $null}
+        @{Name = 'rejects unsupported type'; Types = @('Tar'); Expected = $null; Throws = $true; ErrorMessage = '*The JSON is not valid with the schema*'}
+    ) {
+        $projectRoot = Join-Path $TestDrive $_.Name.Replace(' ', '-')
+        New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+        $projectJson = ([ordered]@{
+            ProjectName = 'SchemaTypesProject'
+            Description = 'Schema package types test'
+            Version = '0.0.1'
+            Manifest = [ordered]@{
+                Author = 'Test Author'
+                PowerShellHostVersion = '7.4'
+                GUID = '99999999-9999-9999-9999-999999999999'
+            }
+            Package = [ordered]@{
+                Types = $_.Types
+            }
+        } | ConvertTo-Json -Depth 5)
+        Set-Content -LiteralPath (Join-Path $projectRoot 'project.json') -Value $projectJson -Encoding utf8
+
+        Push-Location $projectRoot
+        try {
+            InModuleScope $script:moduleName -Parameters @{Expected = $_.Expected; Throws = $_.Throws; ErrorMessage = $_.ErrorMessage} {
+                param($Expected, $Throws, $ErrorMessage)
+
+                if ($Throws) {
+                    {Test-ProjectSchema -Schema Build} | Should -Throw $ErrorMessage
+                    return
+                }
+
+                Test-ProjectSchema -Schema Build | Should -Be $Expected
+            }
+        }
+        finally {
+            Pop-Location
         }
     }
 
@@ -283,21 +324,33 @@ Locale: en-US
         }
     }
 
-    It 'New-NovaPackageArtifact writes a NuGet-compatible package structure with project metadata and built files' {
-        $layout = Initialize-TestNovaPackageProjectLayout -ProjectRoot (Join-Path $TestDrive 'package-project')
+    It 'New-NovaPackageArtifact writes the expected package structure for <ExpectedType>' -ForEach @(
+        @{ProjectRootName = 'package-project'; PackageTypes = @('NuGet'); RequestedPackageType = 'NuGet'; ExpectedType = 'NuGet'}
+        @{ProjectRootName = 'zip-package-project'; PackageTypes = @('Zip'); RequestedPackageType = 'Zip'; ExpectedType = 'Zip'}
+    ) {
+        $layout = Initialize-TestNovaPackageProjectLayout -ProjectRoot (Join-Path $TestDrive $_.ProjectRootName)
 
         $packagePath = InModuleScope $script:moduleName -Parameters @{
-            ProjectInfo = (Get-TestNovaPackageProjectInfo -Layout $layout -CleanOutputDirectory $true)
+            ProjectInfo = (Get-TestNovaPackageProjectInfo -Layout $layout -CleanOutputDirectory $true -PackageTypes $_.PackageTypes)
+            RequestedPackageType = $_.RequestedPackageType
+            ExpectedType = $_.ExpectedType
         } {
-            param($ProjectInfo)
-            $packageMetadata = Get-NovaPackageMetadata -ProjectInfo $projectInfo
-            $result = New-NovaPackageArtifact -ProjectInfo $projectInfo -PackageMetadata $packageMetadata
+            param($ProjectInfo, $RequestedPackageType, $ExpectedType)
 
+            $packageMetadata = Get-NovaPackageMetadata -ProjectInfo $ProjectInfo -PackageType $RequestedPackageType
+            $result = New-NovaPackageArtifact -ProjectInfo $ProjectInfo -PackageMetadata $packageMetadata
+
+            $result.Type | Should -Be $ExpectedType
             Test-Path -LiteralPath $result.PackagePath | Should -BeTrue
             $result.PackagePath
         }
 
         $packagePath | Should -Not -BeNullOrEmpty
+        if ($_.ExpectedType -eq 'Zip') {
+            Assert-TestNovaZipPackageArtifactContent -PackagePath $packagePath
+            return
+        }
+
         Assert-TestNovaPackageArtifactContent -PackagePath $packagePath
     }
 
@@ -320,6 +373,28 @@ Locale: en-US
         }
 
         Test-Path -LiteralPath $staleFilePath | Should -Be $_.ExpectedStaleFile
+    }
+
+    It 'New-NovaPackageArtifacts creates both configured package types after a single output-directory initialization' {
+        $layout = Initialize-TestNovaPackageProjectLayout -ProjectRoot (Join-Path $TestDrive 'multi-package-project')
+        $staleFilePath = Join-Path $layout.PackageOutputDir 'stale.txt'
+        New-Item -ItemType Directory -Path $layout.PackageOutputDir -Force | Out-Null
+        'stale' | Set-Content -LiteralPath $staleFilePath -Encoding utf8
+
+        $result = InModuleScope $script:moduleName -Parameters @{
+            ProjectInfo = (Get-TestNovaPackageProjectInfo -Layout $layout -CleanOutputDirectory $true -PackageTypes @('NuGet', 'Zip'))
+        } {
+            param($ProjectInfo)
+
+            $packageMetadataList = @(Get-NovaPackageMetadataList -ProjectInfo $ProjectInfo)
+            @(New-NovaPackageArtifacts -ProjectInfo $ProjectInfo -PackageMetadataList $packageMetadataList)
+        }
+
+        $result.Type | Should -Be @('NuGet', 'Zip')
+        $result.PackageFileName | Should -Be @('PackageProject.2.3.4.nupkg', 'PackageProject.2.3.4.zip')
+        Test-Path -LiteralPath $staleFilePath | Should -BeFalse
+        Assert-TestNovaPackageArtifactContent -PackagePath $result[0].PackagePath
+        Assert-TestNovaZipPackageArtifactContent -PackagePath $result[1].PackagePath
     }
 
     It 'New-NovaPackageArtifact omits schema-optional manifest URI elements when they are not provided' {

--- a/tests/RemainingHelperCoverage.Tests.ps1
+++ b/tests/RemainingHelperCoverage.Tests.ps1
@@ -1,4 +1,26 @@
+$script:remainingHelperCoverageTestSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'RemainingHelperCoverage.TestSupport.ps1')).Path
+$global:remainingHelperCoverageTestSupportFunctionNameList = @(
+    'Assert-TestNovaPackageArtifactContent'
+)
+
+. $script:remainingHelperCoverageTestSupportPath
+
+foreach ($functionName in $global:remainingHelperCoverageTestSupportFunctionNameList) {
+    $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
+    Set-Item -Path "function:global:$functionName" -Value $scriptBlock
+}
+
 BeforeAll {
+    $remainingHelperCoverageTestSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'RemainingHelperCoverage.TestSupport.ps1')).Path
+    $remainingHelperCoverageTestSupportFunctionNameList = @('Assert-TestNovaPackageArtifactContent')
+
+    . $remainingHelperCoverageTestSupportPath
+
+    foreach ($functionName in $remainingHelperCoverageTestSupportFunctionNameList) {
+        $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
+        Set-Item -Path "function:global:$functionName" -Value $scriptBlock
+    }
+
     $here = Split-Path -Parent $PSCommandPath
     $script:repoRoot = Split-Path -Parent $here
     $script:moduleName = (Get-Content -LiteralPath (Join-Path $script:repoRoot 'project.json') -Raw | ConvertFrom-Json).ProjectName
@@ -246,5 +268,68 @@ Locale: en-US
 
             {Get-NovaHelpLocale -HelpMarkdownFiles $helpFiles} | Should -Throw 'Multiple help locales found in docs metadata*'
         }
+    }
+
+    It 'Get-NovaPackageAuthorList normalizes string and array author values' {
+        InModuleScope $script:moduleName {
+            Get-NovaPackageAuthorList -AuthorValue 'Author One' | Should -Be @('Author One')
+            Get-NovaPackageAuthorList -AuthorValue @('Author One', ' Author Two ', 'Author One') | Should -Be @('Author One', 'Author Two')
+        }
+    }
+
+    It 'New-NovaPackageArtifact writes a NuGet-compatible package structure with project metadata and built files' {
+        $projectRoot = Join-Path $TestDrive 'package-project'
+        $outputModuleDir = Join-Path $projectRoot 'dist/PackageProject'
+        $packageOutputDir = Join-Path $projectRoot 'artifacts/packages'
+        $manifestPath = Join-Path $outputModuleDir 'PackageProject.psd1'
+        $modulePath = Join-Path $outputModuleDir 'PackageProject.psm1'
+        $resourceDir = Join-Path $outputModuleDir 'resources'
+        $resourcePath = Join-Path $resourceDir 'nova'
+        $packagePath = $null
+
+        New-Item -ItemType Directory -Path $resourceDir -Force | Out-Null
+        '@{}' | Set-Content -LiteralPath $manifestPath -Encoding utf8
+        'function Get-TestPackage { }' | Set-Content -LiteralPath $modulePath -Encoding utf8
+        '#!/usr/bin/env pwsh' | Set-Content -LiteralPath $resourcePath -Encoding utf8
+
+        $packagePath = InModuleScope $script:moduleName -Parameters @{
+            ProjectRoot = $projectRoot
+            OutputModuleDir = $outputModuleDir
+            PackageOutputDir = $packageOutputDir
+        } {
+            param($ProjectRoot, $OutputModuleDir, $PackageOutputDir)
+
+            $projectInfo = [pscustomobject]@{
+                ProjectName = 'PackageProject'
+                Version = '2.3.4'
+                ProjectRoot = $ProjectRoot
+                OutputModuleDir = $OutputModuleDir
+                Description = 'Package project description'
+                Manifest = [ordered]@{
+                    Author = 'Author One'
+                    Tags = @('Nova', 'Packaging')
+                    ProjectUri = 'https://example.test/project'
+                    ReleaseNotes = 'https://example.test/release-notes'
+                    LicenseUri = 'https://example.test/license'
+                }
+                Package = [ordered]@{
+                    Enabled = $true
+                    Id = 'PackageProject'
+                    OutputDirectory = $PackageOutputDir
+                    PackageFileName = 'PackageProject.2.3.4.nupkg'
+                    Authors = @('Author One', 'Author Two')
+                    Description = 'Package project description'
+                }
+            }
+
+            $packageMetadata = Get-NovaPackageMetadata -ProjectInfo $projectInfo
+            $result = New-NovaPackageArtifact -ProjectInfo $projectInfo -PackageMetadata $packageMetadata
+
+            Test-Path -LiteralPath $result.PackagePath | Should -BeTrue
+            $result.PackagePath
+        }
+
+        $packagePath | Should -Not -BeNullOrEmpty
+        Assert-TestNovaPackageArtifactContent -PackagePath $packagePath
     }
 }

--- a/tests/RemainingHelperCoverage.Tests.ps1
+++ b/tests/RemainingHelperCoverage.Tests.ps1
@@ -287,7 +287,7 @@ Locale: en-US
         $layout = Initialize-TestNovaPackageProjectLayout -ProjectRoot (Join-Path $TestDrive 'package-project')
 
         $packagePath = InModuleScope $script:moduleName -Parameters @{
-            ProjectInfo = (Get-TestNovaPackageProjectInfo -ProjectRoot $layout.ProjectRoot -OutputModuleDir $layout.OutputModuleDir -PackageOutputDir $layout.PackageOutputDir -CleanOutputDirectory $true)
+            ProjectInfo = (Get-TestNovaPackageProjectInfo -Layout $layout -CleanOutputDirectory $true)
         } {
             param($ProjectInfo)
             $packageMetadata = Get-NovaPackageMetadata -ProjectInfo $projectInfo
@@ -311,7 +311,7 @@ Locale: en-US
         'stale' | Set-Content -LiteralPath $staleFilePath -Encoding utf8
 
         InModuleScope $script:moduleName -Parameters @{
-            ProjectInfo = (Get-TestNovaPackageProjectInfo -ProjectRoot $layout.ProjectRoot -OutputModuleDir $layout.OutputModuleDir -PackageOutputDir $layout.PackageOutputDir -CleanOutputDirectory $_.CleanOutputDirectory)
+            ProjectInfo = (Get-TestNovaPackageProjectInfo -Layout $layout -CleanOutputDirectory $_.CleanOutputDirectory)
         } {
             param($ProjectInfo)
 
@@ -320,5 +320,22 @@ Locale: en-US
         }
 
         Test-Path -LiteralPath $staleFilePath | Should -Be $_.ExpectedStaleFile
+    }
+
+    It 'New-NovaPackageArtifact omits schema-optional manifest URI elements when they are not provided' {
+        $layout = Initialize-TestNovaPackageProjectLayout -ProjectRoot (Join-Path $TestDrive 'package-project-without-optional-manifest-metadata')
+        $packagePath = InModuleScope $script:moduleName -Parameters @{
+            ProjectInfo = (Get-TestNovaPackageProjectInfo -Layout $layout -CleanOutputDirectory $true -OmitOptionalManifestMetadata)
+        } {
+            param($ProjectInfo)
+
+            $packageMetadata = Get-NovaPackageMetadata -ProjectInfo $ProjectInfo
+            (New-NovaPackageNuspecXml -PackageMetadata $packageMetadata)
+        }
+
+        $packagePath | Should -Not -Match '<projectUrl>'
+        $packagePath | Should -Not -Match '<releaseNotes>'
+        $packagePath | Should -Not -Match '<licenseUrl>'
+        $packagePath | Should -Not -Match '<tags>'
     }
 }


### PR DESCRIPTION
## Summary

- Added `Package.Types` support to `project.json` so packaging can create `NuGet` (`.nupkg`), `Zip` (`.zip`), or both artifact types from the same project.
- Normalized package type handling to accept case-insensitive values and aliases:
  - `NuGet`
  - `Zip`
  - `.nupkg`
  - `.zip`
- Defaulted missing, null, or empty `Package.Types` to `NuGet`.
- Updated packaging internals so output directory initialization and cleanup happens once per pack run even when multiple artifact types are requested.
- Updated schema validation, scaffolding/example resources, command help, CLI help text, README, changelog, and tests for the new configuration and behavior.

- This change was needed so packaging is no longer hard-coded to NuGet output and can support multiple approved package formats while keeping `project.json` validation and runtime behavior aligned.

- Follow-up work / issue link:
  - No linked issue number was provided.
  - Follow-up candidate: consider whether additional package formats should be introduced through the same normalized `Package.Types` pipeline.

## Affected area

- [x] `nova` CLI or command routing
- [x] Public PowerShell cmdlet behavior
- [x] Scaffolding or `project.json` handling
- [x] Build, test, or quality flow
- [x] Publish or release automation
- [ ] Documentation only
- [x] `src/resources/example/`
- [x] Other

## Review guidance

- Start with the main pack workflow:
  - `src/public/PackNovaModule.ps1`
  - `src/private/package/GetNovaPackageMetadata.ps1`
  - `src/private/package/GetNovaPackageMetadataList.ps1`
  - `src/private/package/NewNovaPackageArtifacts.ps1`
  - `src/private/package/NewNovaPackageArtifact.ps1`
- Then review config normalization and schema:
  - `src/private/shared/GetNovaResolvedProjectPackageSettings.ps1`
  - `src/private/shared/ConvertToNovaPackageType.ps1`
  - `src/private/shared/GetNovaResolvedProjectPackageTypeList.ps1`
  - `src/resources/Schema-Build.json`
- Finally review test coverage:
  - `tests/NovaCommandModel.ReleasePublish.Tests.ps1`
  - `tests/NovaCommandModel.Tests.ps1`
  - `tests/RemainingHelperCoverage.Tests.ps1`

- Trade-offs / notes:
  - `Pack-NovaModule` now returns one artifact metadata object per generated package instead of assuming a single package output.
  - The implementation keeps the pack logic maintainable by splitting NuGet and Zip writers into small helpers instead of branching inside one large function.
  - Only the two approved package types are supported right now; adding more formats should extend the normalization + metadata-list pattern rather than special-casing in the public command.

## Validation

- [x] `Invoke-NovaBuild`
- [ ] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [x] `Test-NovaBuild`
- [ ] Not run because this change is docs-only or otherwise does not affect executable behavior

Validation notes:

```text
Focused build + targeted suites:
- Import-Module NovaModuleTools -Force -DisableNameChecking
- Invoke-NovaBuild
- Remove-Module NovaModuleTools -ErrorAction SilentlyContinue
- Import-Module ./dist/NovaModuleTools -Force -DisableNameChecking
- Invoke-Pester -Path ./tests/NovaCommandModel.Tests.ps1,./tests/NovaCommandModel.ReleasePublish.Tests.ps1,./tests/NovaCommandModel.StandaloneCli.Tests.ps1,./tests/RemainingHelperCoverage.Tests.ps1 -Output Detailed
- Result: Tests Passed: 87, Failed: 0

Refactored test follow-up:
- Invoke-Pester -Path ./tests/NovaCommandModel.Tests.ps1,./tests/RemainingHelperCoverage.Tests.ps1 -Output Detailed
- Result: Tests Passed: 52, Failed: 0

Real mixed-format packaging validation:
- Ran Pack-NovaModule against a temporary example project configured with Package.Types = @('NuGet', 'Zip')
- Produced:
  - NovaExampleModule.0.1.0.nupkg
  - NovaExampleModule.0.1.0.zip
- Exit: 0

Full repository workflow:
- pwsh -NoLogo -NoProfile -File ./run.ps1
- Result: Tests Passed: 257, Failed: 0
- Exit: 0

Additional checks:
- git --no-pager diff --check
- Passed
- Code Health pre-commit safeguard
- Passed

Not run:
- ./scripts/build/Invoke-ScriptAnalyzerCI.ps1 was not run in this validation pass
```

## Documentation and release follow-up

- [x] `README.md` reviewed and updated if contributor workflow, architecture, or automation changed
- [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [x] `docs/NovaModuleTools/en-US/` help updated if a public command changed
- [x] `docs/*.html` updated if end-user guidance changed
- [x] `src/resources/example/` reviewed and updated if the real-world project layout or workflow changed
- [ ] No documentation or example updates were needed

## Compatibility and risk

- [x] No breaking change
- [ ] Breaking change
- [ ] Security-sensitive change

Risk, rollout, or rollback notes:

```text
Compatibility impact:
- Existing projects that omit Package.Types keep the same default NuGet behavior.
- Package.OutputDirectory.Path / Clean behavior is preserved.
- Case-insensitive aliases (.nupkg / .zip) are normalized to canonical internal values.

Behavioral change to note:
- Pack-NovaModule can now return multiple artifact metadata objects when both package types are selected.

Rollback:
- Revert the Package.Types normalization/schema/runtime changes and the package artifact fan-out helpers.
- Projects without Package.Types would continue to behave as NuGet-only after rollback.
```

> [!IMPORTANT]
> Do not use a public pull request to disclose a vulnerability before coordinated handling.
> Use the private reporting path in `SECURITY.md` for new security issues.