### PR TITLE
Feature/85 write technical documentation that developers actually use

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
       - develop
+  schedule:
+    - cron: '0 6,14,22 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -11,7 +11,6 @@ name: PSScriptAnalyzer
 
 on:
   push:
-    branches: [ "develop" ]
   pull_request:
     branches: [ "develop" ]
   schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,8 +69,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 
 - Split documentation into contributor-focused repository docs and task-oriented GitHub Pages user guides.
-- Add and expand the public site with getting started, core workflows, working with modules, troubleshooting, advanced
-  usage, license, and release notes pages.
+- Expand the public site into a fuller developer end-user manual with rewritten getting started, core workflows, working
+  with modules, troubleshooting, concepts, release notes, and license pages plus new reference-style pages for
+  commands, `project.json`, packaging/delivery, and versioning/update behavior.
 - Refresh public `Get-Help` content and examples for the Nova commands, including CLI usage and preview/confirmation
   scenarios.
 - Refresh `.github/pull_request_template.md` so pull requests now call out the current Nova workflows, CI/release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Improve page spacing, card padding, code-block separation, and responsive layout density so the documentation is
       easier to scan and less visually cramped.
 - Change the public docs header navigation from a dense link row to a menu button so readers can choose pages from a
-  simpler page picker across the site.
+  simpler page picker across the site while keeping the License page available from legal/footer links instead of the
+  primary menu.
 - Refresh public `Get-Help` content and examples for the Nova commands, including CLI usage and preview/confirmation
   scenarios.
 - Refresh `.github/pull_request_template.md` so pull requests now call out the current Nova workflows, CI/release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expand the public site into a fuller developer end-user manual with rewritten getting started, core workflows, working
   with modules, troubleshooting, concepts, release notes, and license pages plus new reference-style pages for
   commands, `project.json`, packaging/delivery, and versioning/update behavior.
+    - Improve page spacing, card padding, code-block separation, and responsive layout density so the documentation is
+      easier to scan and less visually cramped.
+- Change the public docs header navigation from a dense link row to a menu button so readers can choose pages from a
+  simpler page picker across the site.
 - Refresh public `Get-Help` content and examples for the Nova commands, including CLI usage and preview/confirmation
   scenarios.
 - Refresh `.github/pull_request_template.md` so pull requests now call out the current Nova workflows, CI/release

--- a/docs/advanced.html
+++ b/docs/advanced.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
-    <title>NovaModuleTools — Advanced PowerShell module usage and CI workflows</title>
-    <meta content="Go beyond the default NovaModuleTools workflow with PowerShell module CI/CD integration, versioning expectations, and project.json customization."
+    <title>NovaModuleTools — Concepts and mental models for structured PowerShell module development</title>
+    <meta content="Understand how NovaModuleTools thinks about a PowerShell module project, why it builds into dist, how project settings shape generated output, and how the main workflows fit together."
           name="description">
     <meta content="index,follow,max-image-preview:large" name="robots">
     <meta content="#0b1020" name="theme-color">
@@ -12,22 +12,24 @@
     <link href="./assets/icon.png" rel="icon" type="image/png">
     <link href="./assets/icon.png" rel="apple-touch-icon">
     <meta content="article" property="og:type">
-    <meta content="NovaModuleTools — Advanced PowerShell module usage and CI workflows" property="og:title">
-    <meta content="Learn advanced NovaModuleTools usage for PowerShell module CI/CD, project.json customization, and release workflows."
+    <meta content="NovaModuleTools — Concepts and mental models for structured PowerShell module development"
+          property="og:title">
+    <meta content="Build a mental model for how NovaModuleTools structures source files, generated output, project.json settings, and command workflows."
           property="og:description">
     <meta content="https://www.novamoduletools.com/advanced.html" property="og:url">
     <meta content="https://www.novamoduletools.com/assets/icon.png" property="og:image">
     <meta content="summary" name="twitter:card">
-    <meta content="NovaModuleTools — Advanced PowerShell module usage and CI workflows" name="twitter:title">
-    <meta content="Learn advanced NovaModuleTools usage for PowerShell module CI/CD, project.json customization, and release workflows."
+    <meta content="NovaModuleTools — Concepts and mental models for structured PowerShell module development"
+          name="twitter:title">
+    <meta content="Build a mental model for how NovaModuleTools structures source files, generated output, project.json settings, and command workflows."
           name="twitter:description">
     <link href="./assets/site.css" rel="stylesheet">
     <script type="application/ld+json">
         {
             "@context": "https://schema.org",
             "@type": "TechArticle",
-            "headline": "Advanced NovaModuleTools usage",
-            "description": "Advanced PowerShell module CI/CD and project.json customization with NovaModuleTools.",
+            "headline": "NovaModuleTools concepts guide",
+            "description": "Mental models and explanation content for NovaModuleTools.",
             "url": "https://www.novamoduletools.com/advanced.html"
         }
     </script>
@@ -42,86 +44,165 @@
         <nav aria-label="Primary" class="site-nav">
             <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
             <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
-            <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+            <a class="site-nav__link" href="./project-json-reference.html">project.json</a>
+            <a class="site-nav__link" href="./commands.html">Commands</a>
+            <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+            <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
             <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
-            <a class="site-nav__link site-nav__link--active" href="./advanced.html">Advanced</a>
+            <a class="site-nav__link site-nav__link--active" href="./advanced.html">Concepts</a>
         </nav>
     </div>
 </header>
 
 <main class="page-shell">
     <section class="guide-hero">
-        <p class="eyebrow">Advanced usage</p>
-        <h1>Adapt NovaModuleTools to larger workflows and more opinionated module projects</h1>
-        <p class="lead">Use these advanced options when you want to integrate NovaModuleTools into CI/CD or customize
-            how PowerShell module projects are built and tested.</p>
+        <p class="eyebrow">Explanation</p>
+        <h1>How NovaModuleTools thinks about your project</h1>
+        <p class="lead">Nova is easiest to use when you understand its model: source files are the inputs, the generated
+            module in <code>dist/</code> is the real runtime artifact, and <code>project.json</code> shapes every
+            workflow from build to release.</p>
     </section>
 
     <section class="guide-content guide-content--single">
         <section class="content-section">
-            <h2>Use the CLI or the PowerShell cmdlets directly</h2>
-            <p>Every core workflow is available both as a PowerShell command or <code>nova</code> alias, and through the
-                <code>nova</code> CLI surface. Choose the interface that fits your environment best.</p>
+            <h2>Nova treats your project as a buildable module, not a loose script folder</h2>
+            <p>That sounds simple, but it changes how you should work. Instead of importing individual files manually,
+                you let Nova build the project and then validate the generated result.</p>
+            <p>This is why the normal loop is <code>build → test → import from dist</code>. It keeps the behavior you
+                validate aligned with the behavior you package, publish, and release later.</p>
         </section>
 
         <section class="content-section">
-            <h2>Versioning behavior depends on commit history</h2>
-            <p><code>nova bump</code> reads Git history, not just <code>project.json</code>. If you want predictable
-                release automation, keep your commit messages intentional and make sure release jobs run in repositories
-                with full history and tags available.</p>
+            <h2>Your source tree and your built tree have different jobs</h2>
+            <div class="table-scroll">
+                <table>
+                    <thead>
+                    <tr>
+                        <th>Area</th>
+                        <th>Purpose</th>
+                        <th>How to think about it</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+                        <td><code>src/</code></td>
+                        <td>Authoring input</td>
+                        <td>Where you edit public functions, private helpers, classes, and resources.</td>
+                    </tr>
+                    <tr>
+                        <td><code>tests/</code></td>
+                        <td>Project validation</td>
+                        <td>Where Pester tests live for the current project workflow.</td>
+                    </tr>
+                    <tr>
+                        <td><code>docs/</code></td>
+                        <td>Help and site content</td>
+                        <td>PowerShell help markdown and the end-user site are both part of the finished project
+                            experience.
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><code>dist/&lt;ProjectName&gt;</code></td>
+                        <td>Generated runtime artifact</td>
+                        <td>This is the module you should import and validate.</td>
+                    </tr>
+                    <tr>
+                        <td><code>artifacts/</code></td>
+                        <td>Generated reports and package output</td>
+                        <td>This is where test results and package files go.</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
         </section>
 
         <section class="content-section">
-            <h2>Useful <code>project.json</code> settings</h2>
+            <h2><code>project.json</code> is not just metadata</h2>
+            <p>In Nova, <code>project.json</code> is the contract for how your project behaves. It is not only
+                descriptive. It actively controls:</p>
             <ul class="plain-list">
-                <li><strong><code>BuildRecursiveFolders</code></strong> — switch recursive discovery on or off for
-                    classes, private helpers, and tests
+                <li>recursive discovery</li>
+                <li>source markers in generated output</li>
+                <li>resource copy layout</li>
+                <li>duplicate function validation</li>
+                <li>package creation behavior</li>
+                <li>raw upload defaults</li>
+                <li>Pester output behavior</li>
+            </ul>
+            <p>This is why the configuration reference matters so much: small changes in <code>project.json</code> can
+                affect how the generated module behaves, how tests are discovered, and what delivery commands do later.
+            </p>
+        </section>
+
+        <section class="content-section">
+            <h2>Why package, upload, publish, and release are separate commands</h2>
+            <p>Nova keeps these commands separate so the workflow remains explicit:</p>
+            <ul class="plain-list">
+                <li><strong>pack</strong> creates artifacts</li>
+                <li><strong>upload</strong> sends existing artifacts to a raw endpoint</li>
+                <li><strong>publish</strong> publishes the module itself locally or to a PowerShell repository</li>
+                <li><strong>release</strong> orchestrates build, test, version bump, rebuild, and publish</li>
+            </ul>
+            <p>This separation reduces hidden side effects and makes CI/CD flows easier to reason about.</p>
+        </section>
+
+        <section class="content-section">
+            <h2>Why source markers and duplicate-function validation exist</h2>
+            <p>Two settings often surprise new users because they exist to protect maintainability, not just make builds
+                pass:</p>
+            <ul class="plain-list">
+                <li><code>SetSourcePath</code> adds <code># Source:</code> markers to the generated module so you can
+                    map errors back to the original files.
                 </li>
-                <li><strong><code>SetSourcePath</code></strong> — write source markers into the generated module to help
-                    debug parser and runtime issues
-                </li>
-                <li><strong><code>Preamble</code></strong> — add module-level setup lines before generated source
-                    content
-                </li>
-                <li><strong><code>FailOnDuplicateFunctionNames</code></strong> — fail the build if duplicate top-level
-                    function names are emitted
-                </li>
-                <li><strong><code>CopyResourcesToModuleRoot</code></strong> — copy resources directly into the built
-                    module root instead of a nested <code>resources/</code> folder
+                <li><code>FailOnDuplicateFunctionNames</code> stops the build when two top-level functions would collide
+                    in the generated module.
                 </li>
             </ul>
+            <p>These settings are enabled by default because they reduce debugging time and help keep the generated
+                module trustworthy.</p>
         </section>
 
         <section class="content-section">
-            <h2>CI/CD integration</h2>
-            <p>NovaModuleTools works well in build pipelines that follow the normal order:</p>
-            <ol class="plain-list plain-list--ordered">
-                <li>build the module</li>
-                <li>run tests</li>
-                <li>publish artifacts or release</li>
-            </ol>
-            <p>If your CI system needs standard report formats, generate JUnit and Cobertura outputs as part of the
-                NovaModuleTools workflow rather than reinventing test-report conversion yourself.</p>
+            <h2>Why the packaged example matters so much</h2>
+            <p>Many developer tools ship only a minimal hello-world sample. Nova ships a working example project that is
+                meant to act as a living reference for the full workflow.</p>
+            <p>The example is valuable because it shows the interaction between configuration, source files, tests,
+                resources, packaging, and upload settings all at once.</p>
+            <p>If you learn well by reading working code, the example project is one of the fastest ways to understand
+                Nova.</p>
         </section>
 
         <section class="content-section">
-            <h2>Use local publish before repository publish</h2>
-            <p>When you change manifest, resources, or module loading behavior, validate with local publish first:</p>
-            <pre><code>nova publish -local</code></pre>
-            <p>This helps catch packaging issues before a real repository publish or release run. In NovaModuleTools, a
-                successful local publish also reloads the published module from the local install path so the published
-                copy is immediately active for your next command.</p>
-            <p>Need the standard command order first? Return to <a class="text-link" href="./core-workflows.html">Core
-                Workflows</a>.</p>
+            <h2>How to use this site after you understand the mental model</h2>
+            <p>Once these concepts are clear, use the docs like this:</p>
+            <ul class="plain-list">
+                <li>go to <a class="text-link" href="./core-workflows.html">Core Workflows</a> for the normal daily loop
+                </li>
+                <li>go to <a class="text-link" href="./project-json-reference.html">project.json Reference</a> when
+                    changing configuration
+                </li>
+                <li>go to <a class="text-link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a> when
+                    deciding between pack, upload, publish, and release
+                </li>
+                <li>go to <a class="text-link" href="./troubleshooting.html">Troubleshooting</a> when the workflow
+                    outcome does not match your expectation
+                </li>
+            </ul>
         </section>
     </section>
 </main>
 
 <footer class="footer">
     <div class="footer__inner">
-        <p class="footer__legal">NovaModuleTools is distributed under the <a class="legal-link" href="./license.html">MIT
-            License</a> and publishes <a class="legal-link" href="./release-notes.html">Release Notes</a> on this
-            site.</p>
+        <h2>Once the model clicks, Nova becomes predictable</h2>
+        <p>That predictability is the real value: you know what the commands do, which file owns which settings, and
+            where to look when a workflow needs adjustment.</p>
+        <div class="hero__actions">
+            <a class="button button--primary" href="./project-json-reference.html">Open project.json Reference</a>
+            <a class="button button--secondary" href="./commands.html">Open Command Reference</a>
+        </div>
+        <p class="footer__legal">Also available: <a class="legal-link" href="./release-notes.html">Release Notes</a> and
+            the <a class="legal-link" href="./license.html">MIT License</a>.</p>
     </div>
 </footer>
 </body>

--- a/docs/advanced.html
+++ b/docs/advanced.html
@@ -41,16 +41,26 @@
             <img alt="" class="site-brand__icon" src="./assets/icon.png">
             <span class="site-brand__text">NovaModuleTools</span>
         </a>
-        <nav aria-label="Primary" class="site-nav">
-            <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
-            <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
-            <a class="site-nav__link" href="./project-json-reference.html">project.json</a>
-            <a class="site-nav__link" href="./commands.html">Commands</a>
-            <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
-            <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
-            <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
-            <a class="site-nav__link site-nav__link--active" href="./advanced.html">Concepts</a>
-        </nav>
+        <details class="site-menu">
+            <summary class="site-menu__button">
+                <span class="site-menu__button-label">Menu</span>
+                <span class="site-menu__current">Concepts</span>
+            </summary>
+            <nav aria-label="Primary" class="site-menu__panel">
+                <a class="site-nav__link" href="./index.html">Home</a>
+                <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
+                <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
+                <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+                <a class="site-nav__link" href="./project-json-reference.html">project.json Reference</a>
+                <a class="site-nav__link" href="./commands.html">Command Reference</a>
+                <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+                <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
+                <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
+                <a aria-current="page" class="site-nav__link site-nav__link--active" href="./advanced.html">Concepts</a>
+                <a class="site-nav__link" href="./release-notes.html">Release Notes</a>
+                <a class="site-nav__link" href="./license.html">License</a>
+            </nav>
+        </details>
     </div>
 </header>
 

--- a/docs/advanced.html
+++ b/docs/advanced.html
@@ -58,7 +58,6 @@
                 <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
                 <a aria-current="page" class="site-nav__link site-nav__link--active" href="./advanced.html">Concepts</a>
                 <a class="site-nav__link" href="./release-notes.html">Release Notes</a>
-                <a class="site-nav__link" href="./license.html">License</a>
             </nav>
         </details>
     </div>

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -24,7 +24,7 @@ html {
 body {
     margin: 0;
     font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-    line-height: 1.6;
+    line-height: 1.68;
     color: var(--text);
     background:
         radial-gradient(circle at top left, #1d2a5b 0%, transparent 34%),
@@ -77,25 +77,82 @@ a {
     align-items: center;
 }
 
-.site-nav {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
+.site-menu {
+    position: relative;
+}
+
+.site-menu[open] {
+    z-index: 20;
+}
+
+.site-menu__button {
+    list-style: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.9rem;
+    padding: 0.65rem 1rem;
+    border-radius: 18px;
+    border: 1px solid var(--outline);
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--text);
+    cursor: pointer;
+    box-shadow: var(--shadow);
+}
+
+.site-menu__button::-webkit-details-marker {
+    display: none;
+}
+
+.site-menu__button::after {
+    content: "▾";
+    color: var(--accent);
+    font-size: 0.95rem;
+}
+
+.site-menu[open] .site-menu__button::after {
+    content: "▴";
+}
+
+.site-menu__button-label {
+    font-weight: 800;
+    letter-spacing: 0.02em;
+}
+
+.site-menu__current {
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.site-menu__panel {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 0.9rem);
+    width: min(360px, calc(100vw - 2rem));
+    padding: 1rem;
+    display: grid;
+    gap: 0.45rem;
+    background: rgba(11, 16, 32, 0.96);
+    border: 1px solid var(--outline);
+    border-radius: 22px;
+    box-shadow: var(--shadow);
+    backdrop-filter: blur(18px);
 }
 
 .site-nav__link {
+    display: block;
     text-decoration: none;
     color: var(--muted);
-    padding: 0.45rem 0.85rem;
-    border-radius: 999px;
+    padding: 0.8rem 0.95rem;
+    border-radius: 14px;
     border: 1px solid transparent;
 }
 
 .site-nav__link:hover,
-.site-nav__link--active {
+.site-nav__link--active,
+.site-nav__link[aria-current="page"] {
     color: var(--text);
     border-color: var(--outline);
-    background: rgba(255, 255, 255, 0.06);
+    background: rgba(255, 255, 255, 0.08);
 }
 
 code,
@@ -105,13 +162,13 @@ pre {
 
 code {
     background: rgba(255, 255, 255, 0.08);
-    padding: 0.15rem 0.35rem;
+    padding: 0.18rem 0.42rem;
     border-radius: 8px;
 }
 
 pre {
-    margin: 0;
-    padding: 1rem 1.1rem;
+    margin: 1.4rem 0;
+    padding: 1.15rem 1.25rem;
     overflow-x: auto;
     background: #0c1329;
     border: 1px solid var(--outline);
@@ -126,7 +183,7 @@ pre code {
 .hero,
 .section,
 .footer {
-    padding: 2rem 1.5rem;
+    padding: 2.5rem 1.5rem;
 }
 
 .hero {
@@ -135,34 +192,35 @@ pre code {
     min-height: 100vh;
     display: grid;
     grid-template-columns: 1.15fr 0.85fr;
-    gap: 2rem;
+    gap: 3rem;
     align-items: center;
 }
 
 .page-shell {
     max-width: var(--max-width);
     margin: 0 auto;
-    padding: 2.5rem 1.5rem 5rem;
+    padding: 3.5rem 1.5rem 6rem;
 }
 
 .guide-hero {
-    margin-bottom: 2rem;
+    margin-bottom: 3rem;
+    max-width: 880px;
 }
 
 .content-grid {
     display: grid;
-    grid-template-columns: 280px minmax(0, 1fr);
-    gap: 1.5rem;
+    grid-template-columns: 300px minmax(0, 1fr);
+    gap: 2rem;
     align-items: start;
 }
 
 .guide-content {
     display: grid;
-    gap: 1.25rem;
+    gap: 1.75rem;
 }
 
 .guide-content--single {
-    max-width: 820px;
+    max-width: 900px;
 }
 
 .toc-card,
@@ -175,7 +233,7 @@ pre code {
 }
 
 .toc-card {
-    padding: 1.15rem;
+    padding: 1.35rem;
     position: sticky;
     top: 5.75rem;
 }
@@ -202,20 +260,35 @@ pre code {
 }
 
 .content-section {
-    padding: 1.35rem;
+    padding: 1.65rem 1.75rem;
+}
+
+.content-section > * + * {
+    margin-top: 1.25rem;
+}
+
+.content-section > h2 + *,
+.content-section > h3 + * {
+    margin-top: 1rem;
+}
+
+.guide-content .content-section > p,
+.guide-content .content-section > ul,
+.guide-content .content-section > ol {
+    max-width: 72ch;
 }
 
 .guide-grid {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 1.1rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.5rem;
 }
 
 .guide-links {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.9rem;
-    margin-top: 1rem;
+    gap: 1rem;
+    margin-top: 1.25rem;
 }
 
 .plain-list--ordered {
@@ -245,8 +318,8 @@ pre code {
 h1,
 h2,
 h3 {
-    margin: 0 0 1rem;
-    line-height: 1.12;
+    margin: 0 0 1.15rem;
+    line-height: 1.18;
 }
 
 h1 {
@@ -263,20 +336,20 @@ h3 {
 }
 
 p {
-    margin: 0 0 1rem;
+    margin: 0 0 1.05rem;
     color: var(--muted);
 }
 
 .lead {
     font-size: 1.1rem;
-    max-width: 62ch;
+    max-width: 68ch;
 }
 
 .hero__actions {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.9rem;
-    margin: 1.6rem 0;
+    gap: 1rem;
+    margin: 2rem 0;
 }
 
 .button {
@@ -327,7 +400,7 @@ p {
 
 .hero__panel {
     display: grid;
-    gap: 1rem;
+    gap: 1.35rem;
 }
 
 .panel-card,
@@ -345,7 +418,7 @@ p {
 }
 
 .panel-card {
-    padding: 1.2rem;
+    padding: 1.55rem;
 }
 
 .panel-step,
@@ -363,8 +436,8 @@ p {
 }
 
 .section {
-    padding-top: 4.5rem;
-    padding-bottom: 4.5rem;
+    padding-top: 5.5rem;
+    padding-bottom: 5.5rem;
 }
 
 .section--muted {
@@ -393,28 +466,28 @@ p {
 
 .section-heading {
     max-width: 760px;
-    margin-bottom: 2rem;
+    margin-bottom: 2.5rem;
 }
 
 .card-grid,
 .steps {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 1.1rem;
+    gap: 1.5rem;
 }
 
 .info-card,
 .step-card,
 .callout,
 .code-window {
-    padding: 1.35rem;
+    padding: 1.6rem;
 }
 
 .split {
     display: grid;
     grid-template-columns: 1.1fr 0.9fr;
-    gap: 1.4rem;
-    align-items: center;
+    gap: 2rem;
+    align-items: start;
 }
 
 .check-list,
@@ -425,20 +498,25 @@ p {
 
 .check-list li,
 .plain-list li {
-    margin-bottom: 0.7rem;
+    margin-bottom: 0.9rem;
+}
+
+.check-list li + li,
+.plain-list li + li {
+    margin-top: 0.2rem;
 }
 
 .callout h3,
 .cta-banner h3 {
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.75rem;
 }
 
 .cta-banner {
     display: flex;
-    gap: 1rem;
+    gap: 1.25rem;
     align-items: center;
     justify-content: space-between;
-    padding: 1.35rem;
+    padding: 1.6rem;
 }
 
 .faq-list {
@@ -447,7 +525,7 @@ p {
 }
 
 .faq-list details {
-    padding: 1rem 1.1rem;
+    padding: 1.25rem 1.3rem;
 }
 
 .faq-list summary {
@@ -492,11 +570,11 @@ p {
     border-radius: var(--radius);
     box-shadow: var(--shadow);
     backdrop-filter: blur(12px);
-    padding: 1.35rem;
+    padding: 1.7rem;
 }
 
 .license-copy {
-    margin-top: 1rem;
+    margin-top: 1.25rem;
 }
 
 .license-copy pre {
@@ -506,7 +584,7 @@ p {
 
 .release-notes-shell {
     display: grid;
-    gap: 1.25rem;
+    gap: 1.5rem;
     max-width: 900px;
 }
 
@@ -531,12 +609,12 @@ p {
     border-radius: var(--radius);
     box-shadow: var(--shadow);
     backdrop-filter: blur(12px);
-    padding: 1.35rem;
+    padding: 1.7rem;
 }
 
 .release-notes-content {
     display: grid;
-    gap: 1rem;
+    gap: 1.25rem;
 }
 
 .release-notes-content h2,
@@ -572,6 +650,10 @@ p {
 
 .table-scroll {
     overflow-x: auto;
+    margin: 1.5rem 0 1rem;
+    border: 1px solid var(--outline);
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.04);
 }
 
 table {
@@ -581,7 +663,7 @@ table {
 
 th,
 td {
-    padding: 0.8rem 0.9rem;
+    padding: 1rem 1.05rem;
     text-align: left;
     vertical-align: top;
     border-bottom: 1px solid var(--outline);
@@ -601,11 +683,11 @@ td {
     background: rgba(255, 255, 255, 0.06);
     border: 1px solid var(--outline);
     border-radius: 18px;
-    padding: 1rem 1.1rem;
+    padding: 1.35rem 1.45rem;
 }
 
 .notice {
-    margin: 1rem 0 0;
+    margin: 1.4rem 0 0;
 }
 
 .notice strong {
@@ -626,7 +708,7 @@ td {
 .command-card-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 1rem;
+    gap: 1.5rem;
 }
 
 .command-card h3 {
@@ -639,18 +721,28 @@ td {
 }
 
 .tiny-note {
-    margin-top: 1rem;
+    margin-top: 1.25rem;
     font-size: 0.95rem;
+}
+
+@media (max-width: 1180px) {
+    .content-grid,
+    .split,
+    .command-card-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .toc-card {
+        position: static;
+    }
 }
 
 @media (max-width: 960px) {
     .site-header__inner,
     .hero,
-    .split,
     .card-grid,
     .steps,
     .cta-banner,
-    .content-grid,
     .guide-grid {
         grid-template-columns: 1fr;
         flex-direction: column;
@@ -662,22 +754,18 @@ td {
         padding-bottom: 0.9rem;
     }
 
-    .toc-card {
-        position: static;
+    .site-menu__panel {
+        width: min(420px, calc(100vw - 2rem));
     }
 
     .hero {
         min-height: auto;
-        padding-top: 4rem;
-        padding-bottom: 2rem;
+        padding-top: 4.5rem;
+        padding-bottom: 3rem;
     }
 
     h1 {
         max-width: none;
-    }
-
-    .command-card-grid {
-        grid-template-columns: 1fr;
     }
 }
 
@@ -697,6 +785,21 @@ td {
     .site-header__inner {
         padding-left: 1rem;
         padding-right: 1rem;
+    }
+
+    .site-menu {
+        width: 100%;
+    }
+
+    .site-menu__button {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .site-menu__panel {
+        position: static;
+        width: 100%;
+        margin-top: 0.75rem;
     }
 
     .site-brand {

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -570,6 +570,79 @@ p {
     word-break: break-word;
 }
 
+.table-scroll {
+    overflow-x: auto;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+th,
+td {
+    padding: 0.8rem 0.9rem;
+    text-align: left;
+    vertical-align: top;
+    border-bottom: 1px solid var(--outline);
+}
+
+th {
+    color: var(--text);
+    font-weight: 700;
+}
+
+td {
+    color: var(--muted);
+}
+
+.notice,
+.command-card {
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid var(--outline);
+    border-radius: 18px;
+    padding: 1rem 1.1rem;
+}
+
+.notice {
+    margin: 1rem 0 0;
+}
+
+.notice strong {
+    display: block;
+    margin-bottom: 0.35rem;
+    color: var(--text);
+}
+
+.notice p {
+    margin-bottom: 0;
+}
+
+.notice--warning {
+    border-color: rgba(252, 211, 77, 0.35);
+    background: rgba(252, 211, 77, 0.08);
+}
+
+.command-card-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+}
+
+.command-card h3 {
+    margin-bottom: 0.75rem;
+}
+
+.command-card p:last-child,
+.command-card .plain-list:last-child {
+    margin-bottom: 0;
+}
+
+.tiny-note {
+    margin-top: 1rem;
+    font-size: 0.95rem;
+}
+
 @media (max-width: 960px) {
     .site-header__inner,
     .hero,
@@ -601,6 +674,10 @@ p {
 
     h1 {
         max-width: none;
+    }
+
+    .command-card-grid {
+        grid-template-columns: 1fr;
     }
 }
 

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -1,0 +1,386 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1" name="viewport">
+    <title>NovaModuleTools — Command reference for PowerShell cmdlets and the nova CLI</title>
+    <meta content="Reference for NovaModuleTools commands, including PowerShell cmdlets, nova CLI equivalents, common parameters, and when to use each workflow."
+          name="description">
+    <meta content="index,follow,max-image-preview:large" name="robots">
+    <meta content="#0b1020" name="theme-color">
+    <link href="https://www.novamoduletools.com/commands.html" rel="canonical">
+    <link href="./assets/icon.png" rel="icon" type="image/png">
+    <link href="./assets/icon.png" rel="apple-touch-icon">
+    <meta content="article" property="og:type">
+    <meta content="NovaModuleTools — Command reference for PowerShell cmdlets and the nova CLI" property="og:title">
+    <meta content="Use this reference to choose the right NovaModuleTools command, understand CLI equivalents, and find the key parameters for each workflow."
+          property="og:description">
+    <meta content="https://www.novamoduletools.com/commands.html" property="og:url">
+    <meta content="https://www.novamoduletools.com/assets/icon.png" property="og:image">
+    <meta content="summary" name="twitter:card">
+    <meta content="NovaModuleTools — Command reference for PowerShell cmdlets and the nova CLI" name="twitter:title">
+    <meta content="Use this reference to choose the right NovaModuleTools command, understand CLI equivalents, and find the key parameters for each workflow."
+          name="twitter:description">
+    <link href="./assets/site.css" rel="stylesheet">
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "TechArticle",
+            "headline": "NovaModuleTools command reference",
+            "description": "Reference for NovaModuleTools PowerShell cmdlets and nova CLI commands.",
+            "url": "https://www.novamoduletools.com/commands.html"
+        }
+    </script>
+</head>
+<body>
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-brand" href="./index.html">
+            <img alt="" class="site-brand__icon" src="./assets/icon.png">
+            <span class="site-brand__text">NovaModuleTools</span>
+        </a>
+        <nav aria-label="Primary" class="site-nav">
+            <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
+            <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
+            <a class="site-nav__link" href="./project-json-reference.html">project.json</a>
+            <a class="site-nav__link site-nav__link--active" href="./commands.html">Commands</a>
+            <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+            <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
+            <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
+            <a class="site-nav__link" href="./advanced.html">Concepts</a>
+        </nav>
+    </div>
+</header>
+
+<main class="page-shell">
+    <section class="guide-hero">
+        <p class="eyebrow">Reference</p>
+        <h1>Use the right command the first time</h1>
+        <p class="lead">NovaModuleTools exposes every major workflow as a PowerShell cmdlet and, in most cases, a
+            matching <code>nova</code> command. Use this page to choose the right entrypoint, understand the key
+            parameters, and jump to deeper task guides.</p>
+    </section>
+
+    <section class="content-grid">
+        <aside class="toc-card">
+            <h2>On this page</h2>
+            <ul class="toc-list">
+                <li><a href="#choose-surface">Choose cmdlet vs CLI</a></li>
+                <li><a href="#project-and-scaffold">Project and scaffold commands</a></li>
+                <li><a href="#build-and-test">Build and test commands</a></li>
+                <li><a href="#packaging-and-delivery">Packaging and delivery commands</a></li>
+                <li><a href="#versioning-and-release">Versioning and release commands</a></li>
+                <li><a href="#update-and-preferences">Update and preference commands</a></li>
+            </ul>
+        </aside>
+
+        <div class="guide-content">
+            <section class="content-section" id="choose-surface">
+                <h2>Choose cmdlet vs CLI</h2>
+                <p>Use PowerShell cmdlets when you want scriptable functions, structured output, or direct parameter
+                    names. Use <code>nova</code> when you want a command-line experience that feels consistent across
+                    day-to-day workflows.</p>
+                <div class="table-scroll">
+                    <table>
+                        <thead>
+                        <tr>
+                            <th>Use case</th>
+                            <th>Best entrypoint</th>
+                            <th>Why</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <td>Interactive local development inside <code>pwsh</code></td>
+                            <td><code>nova</code> alias or cmdlets</td>
+                            <td>After you import the module, both are available in the same session.</td>
+                        </tr>
+                        <tr>
+                            <td>Shell use on macOS/Linux</td>
+                            <td><code>nova</code> launcher</td>
+                            <td>Install it once with <code>Install-NovaCli</code> so you can run Nova from zsh or bash.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Reusable scripts and automation</td>
+                            <td>PowerShell cmdlets</td>
+                            <td>Cmdlets are easier to compose and return richer objects in PowerShell.</td>
+                        </tr>
+                        <tr>
+                            <td>Quick manual tasks</td>
+                            <td><code>nova</code></td>
+                            <td>The command names mirror the main workflow: <code>init → build → test → pack → upload →
+                                publish → release</code>.
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <p class="tiny-note">Important: <code>nova</code> inside PowerShell is an alias for
+                    <code>Invoke-NovaCli</code>. On macOS/Linux you can also install the standalone launcher with <code>Install-NovaCli</code>.
+                </p>
+            </section>
+
+            <section class="content-section" id="project-and-scaffold">
+                <h2>Project and scaffold commands</h2>
+                <div class="command-card-grid">
+                    <article class="command-card">
+                        <h3><code>New-NovaModule</code> / <code>nova init</code></h3>
+                        <p>Create a new project scaffold. Use <code>-Example</code> when you want a complete working
+                            sample instead of the minimal starter layout.</p>
+                        <ul class="plain-list">
+                            <li><strong>Best for:</strong> creating a new project</li>
+                            <li><strong>Key parameters:</strong> <code>-Path</code>, <code>-Example</code></li>
+                            <li><strong>Important CLI caveat:</strong> use <code>nova init -Path ~/Work</code>;
+                                positional paths are intentionally rejected
+                            </li>
+                        </ul>
+                        <pre><code>New-NovaModule -Path ~/Work
+nova init -Example -Path ~/Work</code></pre>
+                        <p><a class="text-link" href="./getting-started.html">See the scaffold tutorial</a></p>
+                    </article>
+
+                    <article class="command-card">
+                        <h3><code>Get-NovaProjectInfo</code> / <code>nova info</code></h3>
+                        <p>Read the current <code>project.json</code> and return resolved project metadata, defaults,
+                            and important paths such as <code>dist/</code> and <code>tests/</code>.</p>
+                        <ul class="plain-list">
+                            <li><strong>Best for:</strong> scripts, troubleshooting, and understanding resolved paths
+                            </li>
+                            <li><strong>Key parameters:</strong> <code>-Path</code>, <code>-Version</code></li>
+                            <li><strong>Output:</strong> a project object, or just the version string when you use
+                                <code>-Version</code></li>
+                        </ul>
+                        <pre><code>Get-NovaProjectInfo
+Get-NovaProjectInfo -Version
+nova info</code></pre>
+                        <p><a class="text-link" href="./project-json-reference.html">See project.json behavior</a></p>
+                    </article>
+                </div>
+            </section>
+
+            <section class="content-section" id="build-and-test">
+                <h2>Build and test commands</h2>
+                <div class="command-card-grid">
+                    <article class="command-card">
+                        <h3><code>Invoke-NovaBuild</code> / <code>nova build</code></h3>
+                        <p>Build the current project into <code>dist/&lt;ProjectName&gt;</code>, generate the manifest,
+                            generate external help, and copy project resources.</p>
+                        <ul class="plain-list">
+                            <li><strong>Best for:</strong> producing the real module you intend to import, test,
+                                package, or publish
+                            </li>
+                            <li><strong>Key switches:</strong> <code>-WhatIf</code>, <code>-Confirm</code></li>
+                            <li><strong>Notable behavior:</strong> respects <code>SetSourcePath</code>,
+                                <code>Preamble</code>, and duplicate function validation
+                            </li>
+                        </ul>
+                        <pre><code>Invoke-NovaBuild
+nova build -WhatIf</code></pre>
+                        <p><a class="text-link" href="./core-workflows.html#build">See the build workflow</a></p>
+                    </article>
+
+                    <article class="command-card">
+                        <h3><code>Test-NovaBuild</code> / <code>nova test</code></h3>
+                        <p>Run Pester against the current project configuration and write test results to <code>artifacts/TestResults.xml</code>.
+                        </p>
+                        <ul class="plain-list">
+                            <li><strong>Best for:</strong> validating the project test suite from the normal Nova
+                                workflow
+                            </li>
+                            <li><strong>Key parameters:</strong> <code>-TagFilter</code>, <code>-ExcludeTagFilter</code>,
+                                <code>-OutputVerbosity</code>, <code>-OutputRenderMode</code></li>
+                            <li><strong>Notable behavior:</strong> uses <code>BuildRecursiveFolders</code> to decide
+                                nested test discovery
+                            </li>
+                        </ul>
+                        <pre><code>Test-NovaBuild -TagFilter unit,fast
+nova test -WhatIf</code></pre>
+                        <p><a class="text-link" href="./core-workflows.html#test">See the test workflow</a></p>
+                    </article>
+                </div>
+            </section>
+
+            <section class="content-section" id="packaging-and-delivery">
+                <h2>Packaging and delivery commands</h2>
+                <div class="command-card-grid">
+                    <article class="command-card">
+                        <h3><code>Pack-NovaModule</code> / <code>nova pack</code></h3>
+                        <p>Build, test, and package the module. By default it creates a <code>.nupkg</code> in <code>artifacts/packages/</code>.
+                            Use <code>Package.Types</code> and related settings to customize the output.</p>
+                        <ul class="plain-list">
+                            <li><strong>Best for:</strong> creating package artifacts from the built module output</li>
+                            <li><strong>Key settings:</strong> <code>Package.Types</code>, <code>Package.Latest</code>,
+                                <code>Package.OutputDirectory</code></li>
+                            <li><strong>Output:</strong> one object per generated artifact</li>
+                        </ul>
+                        <pre><code>Pack-NovaModule
+nova pack</code></pre>
+                        <p><a class="text-link" href="./packaging-and-delivery.html#pack">See packaging details</a></p>
+                    </article>
+
+                    <article class="command-card">
+                        <h3><code>Upload-NovaPackage</code> / <code>nova upload</code></h3>
+                        <p>Upload existing package artifacts to a raw HTTP endpoint. This command does not build, test,
+                            or package anything first.</p>
+                        <ul class="plain-list">
+                            <li><strong>Best for:</strong> raw package repositories such as Nexus or Artifactory style
+                                endpoints
+                            </li>
+                            <li><strong>Key parameters:</strong> <code>-PackagePath</code>, <code>-PackageType</code>,
+                                <code>-Url</code>, <code>-Repository</code>, dynamic parameters for headers and auth
+                            </li>
+                            <li><strong>Notable behavior:</strong> uploads every matching versioned and
+                                <code>latest</code> artifact it resolves
+                            </li>
+                        </ul>
+                        <pre><code>Upload-NovaPackage -Repository LocalNexus
+nova upload -url https://packages.example/raw/ -token $env:NOVA_PACKAGE_TOKEN</code></pre>
+                        <p><a class="text-link" href="./packaging-and-delivery.html#upload">See raw upload details</a>
+                        </p>
+                    </article>
+
+                    <article class="command-card">
+                        <h3><code>Publish-NovaModule</code> / <code>nova publish</code></h3>
+                        <p>Build, test, and publish the module either locally or to a registered PowerShell
+                            repository.</p>
+                        <ul class="plain-list">
+                            <li><strong>Best for:</strong> PowerShell repository publishing or validating a local
+                                publish/install cycle
+                            </li>
+                            <li><strong>Key parameters:</strong> <code>-Local</code>, <code>-Repository</code>, <code>-ModuleDirectoryPath</code>,
+                                <code>-ApiKey</code></li>
+                            <li><strong>Notable behavior:</strong> local publish reloads the published module into the
+                                current PowerShell session
+                            </li>
+                        </ul>
+                        <pre><code>Publish-NovaModule -Local
+nova publish -repository PSGallery -apikey $env:PSGALLERY_API</code></pre>
+                        <p><a class="text-link" href="./packaging-and-delivery.html#publish">See publish details</a></p>
+                    </article>
+
+                    <article class="command-card">
+                        <h3><code>Invoke-NovaRelease</code> / <code>nova release</code></h3>
+                        <p>Run the full release flow: build, test, bump version, build again, and then publish.</p>
+                        <ul class="plain-list">
+                            <li><strong>Best for:</strong> an orchestrated release command when you want one workflow
+                                instead of separate steps
+                            </li>
+                            <li><strong>Key parameters:</strong> <code>-PublishOption</code>, <code>-Path</code></li>
+                            <li><strong>Important difference:</strong> local release does not reload the published
+                                module into the session after publishing
+                            </li>
+                        </ul>
+                        <pre><code>Invoke-NovaRelease -PublishOption @{ Local = $true }
+nova release -repository PSGallery -apikey $env:PSGALLERY_API</code></pre>
+                        <p><a class="text-link" href="./packaging-and-delivery.html#release">See release details</a></p>
+                    </article>
+                </div>
+            </section>
+
+            <section class="content-section" id="versioning-and-release">
+                <h2>Versioning and release commands</h2>
+                <div class="command-card-grid">
+                    <article class="command-card">
+                        <h3><code>Update-NovaModuleVersion</code> / <code>nova bump</code></h3>
+                        <p>Read Git history, choose the semantic version label, and update <code>project.json</code>.
+                        </p>
+                        <ul class="plain-list">
+                            <li><strong>Best for:</strong> Git-driven semantic version updates</li>
+                            <li><strong>Key parameter:</strong> <code>-Path</code></li>
+                            <li><strong>Notable behavior:</strong> falls back to a patch bump when the folder is not a
+                                Git repository, but throws when the repository exists and has no commits yet
+                            </li>
+                        </ul>
+                        <pre><code>Update-NovaModuleVersion -WhatIf
+nova bump -Confirm</code></pre>
+                        <p><a class="text-link" href="./versioning-and-updates.html#bump">See versioning rules</a></p>
+                    </article>
+
+                    <article class="command-card">
+                        <h3><code>nova version</code>, <code>nova version -Installed</code>, and <code>nova
+                            --version</code></h3>
+                        <p>These commands answer different questions, so use the one that matches your intent.</p>
+                        <ul class="plain-list">
+                            <li><strong><code>nova version</code>:</strong> current project version from <code>project.json</code>
+                            </li>
+                            <li><strong><code>nova version -Installed</code>:</strong> locally installed version of the
+                                current project/module
+                            </li>
+                            <li><strong><code>nova --version</code>:</strong> installed NovaModuleTools version</li>
+                        </ul>
+                        <pre><code>nova version
+nova version -Installed
+nova --version</code></pre>
+                        <p><a class="text-link" href="./versioning-and-updates.html#version-views">See version view
+                            differences</a></p>
+                    </article>
+                </div>
+            </section>
+
+            <section class="content-section" id="update-and-preferences">
+                <h2>Update and preference commands</h2>
+                <div class="command-card-grid">
+                    <article class="command-card">
+                        <h3><code>Update-NovaModuleTool</code> / <code>Update-NovaModuleTools</code> / <code>nova
+                            update</code></h3>
+                        <p>Self-update the installed NovaModuleTools module by using the stored prerelease
+                            preference.</p>
+                        <ul class="plain-list">
+                            <li><strong>Best for:</strong> keeping NovaModuleTools itself up to date</li>
+                            <li><strong>Key behavior:</strong> stable updates are always eligible; prerelease targets
+                                depend on your stored preference and require explicit confirmation
+                            </li>
+                            <li><strong>Output:</strong> plan/result information, plus a release notes link after
+                                success
+                            </li>
+                        </ul>
+                        <pre><code>Update-NovaModuleTool
+nova update</code></pre>
+                        <p><a class="text-link" href="./versioning-and-updates.html#self-update">See self-update
+                            behavior</a></p>
+                    </article>
+
+                    <article class="command-card">
+                        <h3><code>Get-NovaUpdateNotificationPreference</code>, <code>Set-NovaUpdateNotificationPreference</code>,
+                            and <code>nova notification</code></h3>
+                        <p>Inspect or change whether prerelease self-updates are eligible.</p>
+                        <ul class="plain-list">
+                            <li><strong>Best for:</strong> keeping production systems on stable releases, or opting into
+                                prerelease self-update targets on purpose
+                            </li>
+                            <li><strong>Key commands:</strong> <code>nova notification</code>, <code>nova notification
+                                -disable</code>, <code>nova notification -enable</code></li>
+                            <li><strong>Output:</strong> a preference object with the stored state and settings path
+                            </li>
+                        </ul>
+                        <pre><code>Get-NovaUpdateNotificationPreference
+Set-NovaUpdateNotificationPreference -DisablePrereleaseNotifications
+nova notification -enable</code></pre>
+                        <p><a class="text-link" href="./versioning-and-updates.html#notification-preferences">See update
+                            preference guidance</a></p>
+                    </article>
+                </div>
+            </section>
+        </div>
+    </section>
+</main>
+
+<footer class="footer">
+    <div class="footer__inner">
+        <h2>Need the next layer of detail?</h2>
+        <p>Use the workflow pages when you want step-by-step guidance, or jump straight to the configuration reference
+            when you are tuning a real project.</p>
+        <div class="hero__actions">
+            <a class="button button--primary" href="./project-json-reference.html">Open project.json Reference</a>
+            <a class="button button--secondary" href="./packaging-and-delivery.html">Compare packaging, upload, publish,
+                and release</a>
+        </div>
+        <p class="footer__legal">Also available: <a class="legal-link" href="./working-with-modules.html">Working with
+            Modules</a>, <a class="legal-link" href="./release-notes.html">Release Notes</a>, and the <a
+                class="legal-link" href="./license.html">MIT License</a>.</p>
+    </div>
+</footer>
+</body>
+</html>
+

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -39,16 +39,27 @@
             <img alt="" class="site-brand__icon" src="./assets/icon.png">
             <span class="site-brand__text">NovaModuleTools</span>
         </a>
-        <nav aria-label="Primary" class="site-nav">
-            <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
-            <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
-            <a class="site-nav__link" href="./project-json-reference.html">project.json</a>
-            <a class="site-nav__link site-nav__link--active" href="./commands.html">Commands</a>
-            <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
-            <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
-            <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
-            <a class="site-nav__link" href="./advanced.html">Concepts</a>
-        </nav>
+        <details class="site-menu">
+            <summary class="site-menu__button">
+                <span class="site-menu__button-label">Menu</span>
+                <span class="site-menu__current">Command Reference</span>
+            </summary>
+            <nav aria-label="Primary" class="site-menu__panel">
+                <a class="site-nav__link" href="./index.html">Home</a>
+                <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
+                <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
+                <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+                <a class="site-nav__link" href="./project-json-reference.html">project.json Reference</a>
+                <a aria-current="page" class="site-nav__link site-nav__link--active" href="./commands.html">Command
+                    Reference</a>
+                <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+                <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
+                <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
+                <a class="site-nav__link" href="./advanced.html">Concepts</a>
+                <a class="site-nav__link" href="./release-notes.html">Release Notes</a>
+                <a class="site-nav__link" href="./license.html">License</a>
+            </nav>
+        </details>
     </div>
 </header>
 
@@ -383,4 +394,3 @@ nova notification -enable</code></pre>
 </footer>
 </body>
 </html>
-

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -57,7 +57,6 @@
                 <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
                 <a class="site-nav__link" href="./advanced.html">Concepts</a>
                 <a class="site-nav__link" href="./release-notes.html">Release Notes</a>
-                <a class="site-nav__link" href="./license.html">License</a>
             </nav>
         </details>
     </div>

--- a/docs/core-workflows.html
+++ b/docs/core-workflows.html
@@ -57,7 +57,6 @@
                 <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
                 <a class="site-nav__link" href="./advanced.html">Concepts</a>
                 <a class="site-nav__link" href="./release-notes.html">Release Notes</a>
-                <a class="site-nav__link" href="./license.html">License</a>
             </nav>
         </details>
     </div>

--- a/docs/core-workflows.html
+++ b/docs/core-workflows.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
-    <title>NovaModuleTools — PowerShell module build, test, package, upload, bump, and release workflows</title>
-    <meta content="Follow the normal NovaModuleTools workflow for scaffolding, building, testing, packaging, uploading, versioning, and releasing a PowerShell module."
+    <title>NovaModuleTools — Core workflows for scaffold, build, test, import, and reload</title>
+    <meta content="Follow the normal NovaModuleTools workflow for scaffolding, building, testing, importing, and reloading PowerShell modules during day-to-day development."
           name="description">
     <meta content="index,follow,max-image-preview:large" name="robots">
     <meta content="#0b1020" name="theme-color">
@@ -12,24 +12,22 @@
     <link href="./assets/icon.png" rel="icon" type="image/png">
     <link href="./assets/icon.png" rel="apple-touch-icon">
     <meta content="article" property="og:type">
-    <meta content="NovaModuleTools — PowerShell module build, test, package, upload, bump, and release workflows"
-          property="og:title">
-    <meta content="Learn the standard NovaModuleTools workflow for scaffolding, building, testing, packaging, uploading, versioning, and releasing a PowerShell module."
+    <meta content="NovaModuleTools — Core workflows for scaffold, build, test, import, and reload" property="og:title">
+    <meta content="Use this guide for the normal NovaModuleTools lifecycle: scaffold a project, build the module, run tests, import the built output, and reload safely after changes."
           property="og:description">
     <meta content="https://www.novamoduletools.com/core-workflows.html" property="og:url">
     <meta content="https://www.novamoduletools.com/assets/icon.png" property="og:image">
     <meta content="summary" name="twitter:card">
-    <meta content="NovaModuleTools — PowerShell module build, test, package, upload, bump, and release workflows"
-          name="twitter:title">
-    <meta content="Learn the standard NovaModuleTools workflow for scaffolding, building, testing, packaging, uploading, versioning, and releasing a PowerShell module."
+    <meta content="NovaModuleTools — Core workflows for scaffold, build, test, import, and reload" name="twitter:title">
+    <meta content="Use this guide for the normal NovaModuleTools lifecycle: scaffold a project, build the module, run tests, import the built output, and reload safely after changes."
           name="twitter:description">
     <link href="./assets/site.css" rel="stylesheet">
     <script type="application/ld+json">
         {
             "@context": "https://schema.org",
             "@type": "TechArticle",
-            "headline": "NovaModuleTools Core Workflows",
-            "description": "Build, test, package, upload, bump, and release PowerShell modules with NovaModuleTools.",
+            "headline": "NovaModuleTools core workflows",
+            "description": "The daily scaffold, build, test, import, and reload workflow for NovaModuleTools.",
             "url": "https://www.novamoduletools.com/core-workflows.html"
         }
     </script>
@@ -44,114 +42,153 @@
         <nav aria-label="Primary" class="site-nav">
             <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
             <a class="site-nav__link site-nav__link--active" href="./core-workflows.html">Core Workflows</a>
-            <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+            <a class="site-nav__link" href="./project-json-reference.html">project.json</a>
+            <a class="site-nav__link" href="./commands.html">Commands</a>
+            <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+            <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
             <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
-            <a class="site-nav__link" href="./advanced.html">Advanced</a>
+            <a class="site-nav__link" href="./advanced.html">Concepts</a>
         </nav>
     </div>
 </header>
 
 <main class="page-shell">
     <section class="guide-hero">
-        <p class="eyebrow">Core workflows</p>
-        <h1>Use NovaModuleTools as a repeatable scaffold → build → test → pack → upload → bump → release flow</h1>
-        <p class="lead">This guide explains the normal command sequence for day-to-day PowerShell module work.</p>
+        <p class="eyebrow">How-to Guides</p>
+        <h1>Use the normal Nova loop: scaffold → build → test → import → reload</h1>
+        <p class="lead">Most of your time with NovaModuleTools should stay in this loop. Once you are comfortable here,
+            packaging, upload, publish, and release become much easier to reason about.</p>
     </section>
 
     <section class="content-grid">
         <aside class="toc-card">
             <h2>On this page</h2>
             <ul class="toc-list">
-                <li><a href="#scaffold">Scaffold</a></li>
-                <li><a href="#build">Build</a></li>
-                <li><a href="#test">Test</a></li>
-                <li><a href="#pack">Pack</a></li>
-                <li><a href="#upload">Upload</a></li>
-                <li><a href="#bump">Version bump</a></li>
-                <li><a href="#release">Release</a></li>
+                <li><a href="#scaffold">Create the project</a></li>
+                <li><a href="#build">Build the module</a></li>
+                <li><a href="#test">Run the tests</a></li>
+                <li><a href="#import">Import the built output</a></li>
+                <li><a href="#reload">Reload safely after changes</a></li>
+                <li><a href="#handoff">Move into packaging and release</a></li>
             </ul>
         </aside>
 
         <div class="guide-content">
             <section class="content-section" id="scaffold">
-                <h2>Create a project scaffold</h2>
-                <pre><code>nova init
-nova init -Path ~/Work
-nova init -Example</code></pre>
-                <p>Use the default scaffold when you want a clean starting point. Use <code>-Example</code> when you
-                    want a complete working reference project.</p>
+                <h2>Create the project</h2>
+                <p>Nova supports two scaffold styles:</p>
+                <ul class="plain-list">
+                    <li><strong>minimal scaffold</strong> for a clean new module</li>
+                    <li><strong>example scaffold</strong> for a working sample you can inspect and adapt</li>
+                </ul>
+                <pre><code>nova init -Path ~/Work
+nova init -Example -Path ~/Work</code></pre>
+                <p>Use the example scaffold when you want the shortest path to understanding a real project layout, test
+                    suite, and package configuration. Use the minimal scaffold when you already know the structure you
+                    want.</p>
             </section>
 
             <section class="content-section" id="build">
                 <h2>Build the module</h2>
-                <pre><code>nova build</code></pre>
-                <p>The build combines your source files into a real PowerShell module under <code>dist/&lt;ProjectName&gt;</code>.
-                </p>
-                <p>Use the built output when validating import, test, and publish behavior.</p>
+                <pre><code>nova build
+Invoke-NovaBuild</code></pre>
+                <p>The build step turns your project into a real PowerShell module under
+                    <code>dist/&lt;ProjectName&gt;</code>.</p>
+                <h3>What build includes</h3>
+                <ul class="plain-list">
+                    <li>generated <code>.psm1</code> output</li>
+                    <li>generated manifest</li>
+                    <li>external help generation from the command-help markdown</li>
+                    <li>resource copying</li>
+                    <li>duplicate function validation when enabled</li>
+                </ul>
+                <p>If <code>SetSourcePath</code> is enabled, the generated module includes <code># Source:</code>
+                    markers before each source block. If <code>Preamble</code> is configured, those lines are written at
+                    the top of the generated module before the rest of the content.</p>
             </section>
 
             <section class="content-section" id="test">
-                <h2>Test the built result</h2>
-                <pre><code>nova test</code></pre>
-                <p>NovaModuleTools runs Pester against the project test suite and writes test results for the workflow
-                    under <code>artifacts/TestResults.xml</code>.</p>
-                <p>If your project uses nested test folders, discovery follows the <code>BuildRecursiveFolders</code>
-                    setting in <code>project.json</code>.</p>
+                <h2>Run the tests</h2>
+                <pre><code>nova test
+Test-NovaBuild
+Test-NovaBuild -TagFilter unit,fast
+Test-NovaBuild -ExcludeTagFilter slow
+Test-NovaBuild -OutputVerbosity Detailed -OutputRenderMode Ansi</code></pre>
+                <p><code>Test-NovaBuild</code> reads the Pester configuration from <code>project.json</code>, resolves
+                    the test path, and writes results to <code>artifacts/TestResults.xml</code>.</p>
+                <p><strong>Important behavior:</strong> when <code>BuildRecursiveFolders</code> is <code>true</code>,
+                    nested test files are discovered. When it is <code>false</code>, Nova stays closer to top-level
+                    Pester-style discovery.</p>
+                <p>Use <code>-WhatIf</code> if you want to preview the test run and output path without creating the
+                    results directory or invoking Pester.</p>
             </section>
 
-            <section class="content-section" id="pack">
-                <h2>Create a package artifact</h2>
-                <pre><code>nova pack</code></pre>
-                <p><code>nova pack</code> runs the normal build and test flow, then writes package artifacts to
-                    <code>artifacts/packages/</code> by default. When <code>Package.Types</code> is omitted, it creates
-                    a
-                    <code>.nupkg</code>.</p>
-                <p>Use the optional <code>Package</code> section in <code>project.json</code> when you want to override
-                    the package ID, package types, output directory, or other generic package metadata. Use
-                    <code>Package.Types</code> for <code>NuGet</code>, <code>Zip</code>, or both, and use
-                    <code>Package.OutputDirectory.Path</code> for the target folder and
-                    <code>Package.OutputDirectory.Clean</code> when you want to keep or clear existing package files
-                    before a new package is created.</p>
+            <section class="content-section" id="import">
+                <h2>Import the built output</h2>
+                <p>This is the recommended way to work with Nova-built modules during development:</p>
+                <pre><code>$project = Get-NovaProjectInfo
+Import-Module $project.OutputModuleDir -Force</code></pre>
+                <p>Importing from <code>dist/</code> keeps your runtime behavior aligned with what Nova will package and
+                    publish later.</p>
             </section>
 
-            <section class="content-section" id="upload">
-                <h2>Upload generated package artifacts</h2>
-                <pre><code>nova upload -repository LocalNexus
-nova upload -url https://packages.example/raw/ -token $env:NOVA_PACKAGE_TOKEN</code></pre>
-                <p><code>nova upload</code> pushes existing package artifacts from the configured package output
-                    directory to
-                    a raw HTTP endpoint. It does not rebuild, retest, or recreate the package first.</p>
-                <p>Use <code>-repository</code> when the destination is defined under <code>Package.Repositories</code>
-                    in
-                    <code>project.json</code>, or use <code>-url</code> for direct CI/CD uploads. When multiple matching
-                    package files exist for the selected type, Nova uploads all of them, including versioned and
-                    <code>latest</code> artifacts.</p>
+            <section class="content-section" id="reload">
+                <h2>Reload safely after changes</h2>
+                <p>When you edit source files, rebuild and reload the module instead of trusting the module already
+                    loaded in memory:</p>
+                <pre><code>$project = Get-NovaProjectInfo
+Remove-Module $project.ProjectName -ErrorAction SilentlyContinue
+nova build
+Import-Module $project.OutputModuleDir -Force</code></pre>
+                <p>This avoids stale function definitions and stale resource loading.</p>
+                <div class="notice">
+                    <strong>When local publish changes the story.</strong>
+                    <p><code>Publish-NovaModule -Local</code> and <code>nova publish -local</code> reload the published
+                        module from the local install path after a successful publish. That is different from the normal
+                        build/import loop, which works from <code>dist/</code>.</p>
+                </div>
             </section>
 
-            <section class="content-section" id="bump">
-                <h2>Update the project version</h2>
-                <pre><code>nova bump
-nova bump -WhatIf</code></pre>
-                <p>NovaModuleTools chooses the bump label from your Git commit history:</p>
-                <ul class="plain-list">
-                    <li>breaking change → <strong>Major</strong></li>
-                    <li><code>feat:</code> → <strong>Minor</strong></li>
-                    <li><code>fix:</code> and other commit types → <strong>Patch</strong></li>
-                </ul>
-                <p>If the current folder is not a Git repository, NovaModuleTools falls back to a patch bump. If the
-                    repository exists but has no commits yet, create the first commit before running <code>nova
-                        bump</code>.</p>
-            </section>
-
-            <section class="content-section" id="release">
-                <h2>Run the release workflow</h2>
-                <pre><code>nova release -local
-nova release -repository PSGallery -apikey $env:PSGALLERY_API</code></pre>
-                <p>The release flow coordinates build, test, version bump, rebuild, and publish. Use local mode when you
-                    want to validate the release path without pushing to a repository.</p>
-                <p>For local import and reload habits after release validation, continue to <a class="text-link"
-                                                                                               href="./working-with-modules.html">Working
-                    with Modules</a>.</p>
+            <section class="content-section" id="handoff">
+                <h2>Move into packaging and release when you are ready</h2>
+                <p>Once the build/test/import loop feels natural, the next question is usually one of these:</p>
+                <div class="table-scroll">
+                    <table>
+                        <thead>
+                        <tr>
+                            <th>If you want to…</th>
+                            <th>Go here next</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <td>create package artifacts</td>
+                            <td><a class="text-link" href="./packaging-and-delivery.html#pack">Packaging &amp; Delivery
+                                → Create package artifacts</a></td>
+                        </tr>
+                        <tr>
+                            <td>upload package files to a raw endpoint</td>
+                            <td><a class="text-link" href="./packaging-and-delivery.html#upload">Packaging &amp;
+                                Delivery → Upload package artifacts</a></td>
+                        </tr>
+                        <tr>
+                            <td>publish the module locally or to PowerShell Gallery</td>
+                            <td><a class="text-link" href="./packaging-and-delivery.html#publish">Packaging &amp;
+                                Delivery → Publish to a PowerShell repository</a></td>
+                        </tr>
+                        <tr>
+                            <td>run a full release workflow with version bumping</td>
+                            <td><a class="text-link" href="./packaging-and-delivery.html#release">Packaging &amp;
+                                Delivery → Run the release workflow</a></td>
+                        </tr>
+                        <tr>
+                            <td>tune the project configuration</td>
+                            <td><a class="text-link" href="./project-json-reference.html">project.json Reference</a>
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
             </section>
         </div>
     </section>
@@ -159,9 +196,16 @@ nova release -repository PSGallery -apikey $env:PSGALLERY_API</code></pre>
 
 <footer class="footer">
     <div class="footer__inner">
-        <p class="footer__legal">NovaModuleTools is distributed under the <a class="legal-link" href="./license.html">MIT
-            License</a> and publishes <a class="legal-link" href="./release-notes.html">Release Notes</a> on this
-            site.</p>
+        <h2>Master the daily loop first</h2>
+        <p>When build, test, import, and reload feel predictable, the rest of Nova starts to feel simple instead of
+            magical.</p>
+        <div class="hero__actions">
+            <a class="button button--primary" href="./working-with-modules.html">Open Working with Modules</a>
+            <a class="button button--secondary" href="./packaging-and-delivery.html">Open Packaging &amp; Delivery</a>
+        </div>
+        <p class="footer__legal">Also available: <a class="legal-link" href="./project-json-reference.html">project.json
+            Reference</a>, <a class="legal-link" href="./release-notes.html">Release Notes</a>, and the <a
+                class="legal-link" href="./license.html">MIT License</a>.</p>
     </div>
 </footer>
 </body>

--- a/docs/core-workflows.html
+++ b/docs/core-workflows.html
@@ -39,16 +39,27 @@
             <img alt="" class="site-brand__icon" src="./assets/icon.png">
             <span class="site-brand__text">NovaModuleTools</span>
         </a>
-        <nav aria-label="Primary" class="site-nav">
-            <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
-            <a class="site-nav__link site-nav__link--active" href="./core-workflows.html">Core Workflows</a>
-            <a class="site-nav__link" href="./project-json-reference.html">project.json</a>
-            <a class="site-nav__link" href="./commands.html">Commands</a>
-            <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
-            <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
-            <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
-            <a class="site-nav__link" href="./advanced.html">Concepts</a>
-        </nav>
+        <details class="site-menu">
+            <summary class="site-menu__button">
+                <span class="site-menu__button-label">Menu</span>
+                <span class="site-menu__current">Core Workflows</span>
+            </summary>
+            <nav aria-label="Primary" class="site-menu__panel">
+                <a class="site-nav__link" href="./index.html">Home</a>
+                <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
+                <a aria-current="page" class="site-nav__link site-nav__link--active" href="./core-workflows.html">Core
+                    Workflows</a>
+                <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+                <a class="site-nav__link" href="./project-json-reference.html">project.json Reference</a>
+                <a class="site-nav__link" href="./commands.html">Command Reference</a>
+                <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+                <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
+                <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
+                <a class="site-nav__link" href="./advanced.html">Concepts</a>
+                <a class="site-nav__link" href="./release-notes.html">Release Notes</a>
+                <a class="site-nav__link" href="./license.html">License</a>
+            </nav>
+        </details>
     </div>
 </header>
 

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -59,7 +59,6 @@
                 <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
                 <a class="site-nav__link" href="./advanced.html">Concepts</a>
                 <a class="site-nav__link" href="./release-notes.html">Release Notes</a>
-                <a class="site-nav__link" href="./license.html">License</a>
             </nav>
         </details>
     </div>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -41,16 +41,27 @@
             <img alt="" class="site-brand__icon" src="./assets/icon.png">
             <span class="site-brand__text">NovaModuleTools</span>
         </a>
-        <nav aria-label="Primary" class="site-nav">
-            <a class="site-nav__link site-nav__link--active" href="./getting-started.html">Getting Started</a>
-            <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
-            <a class="site-nav__link" href="./project-json-reference.html">project.json</a>
-            <a class="site-nav__link" href="./commands.html">Commands</a>
-            <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
-            <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
-            <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
-            <a class="site-nav__link" href="./advanced.html">Concepts</a>
-        </nav>
+        <details class="site-menu">
+            <summary class="site-menu__button">
+                <span class="site-menu__button-label">Menu</span>
+                <span class="site-menu__current">Getting Started</span>
+            </summary>
+            <nav aria-label="Primary" class="site-menu__panel">
+                <a class="site-nav__link" href="./index.html">Home</a>
+                <a aria-current="page" class="site-nav__link site-nav__link--active" href="./getting-started.html">Getting
+                    Started</a>
+                <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
+                <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+                <a class="site-nav__link" href="./project-json-reference.html">project.json Reference</a>
+                <a class="site-nav__link" href="./commands.html">Command Reference</a>
+                <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+                <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
+                <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
+                <a class="site-nav__link" href="./advanced.html">Concepts</a>
+                <a class="site-nav__link" href="./release-notes.html">Release Notes</a>
+                <a class="site-nav__link" href="./license.html">License</a>
+            </nav>
+        </details>
     </div>
 </header>
 

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
-    <title>NovaModuleTools — Getting Started with PowerShell module setup</title>
-    <meta content="Install NovaModuleTools, add the optional nova launcher, and create your first PowerShell module project with a guided setup path."
+    <title>NovaModuleTools — Quickstart for installing and using your first PowerShell module project</title>
+    <meta content="Install NovaModuleTools, understand the PowerShell and CLI entrypoints, scaffold the packaged example, and get your first successful build, test, and import within minutes."
           name="description">
     <meta content="index,follow,max-image-preview:large" name="robots">
     <meta content="#0b1020" name="theme-color">
@@ -12,22 +12,24 @@
     <link href="./assets/icon.png" rel="icon" type="image/png">
     <link href="./assets/icon.png" rel="apple-touch-icon">
     <meta content="article" property="og:type">
-    <meta content="NovaModuleTools — Getting Started with PowerShell module setup" property="og:title">
-    <meta content="Install NovaModuleTools and create your first PowerShell module project with the guided Nova workflow."
+    <meta content="NovaModuleTools — Quickstart for installing and using your first PowerShell module project"
+          property="og:title">
+    <meta content="Follow this quickstart to install NovaModuleTools, scaffold the example project, and reach your first successful build and test quickly."
           property="og:description">
     <meta content="https://www.novamoduletools.com/getting-started.html" property="og:url">
     <meta content="https://www.novamoduletools.com/assets/icon.png" property="og:image">
     <meta content="summary" name="twitter:card">
-    <meta content="NovaModuleTools — Getting Started with PowerShell module setup" name="twitter:title">
-    <meta content="Install NovaModuleTools and create your first PowerShell module project with the guided Nova workflow."
+    <meta content="NovaModuleTools — Quickstart for installing and using your first PowerShell module project"
+          name="twitter:title">
+    <meta content="Follow this quickstart to install NovaModuleTools, scaffold the example project, and reach your first successful build and test quickly."
           name="twitter:description">
     <link href="./assets/site.css" rel="stylesheet">
     <script type="application/ld+json">
         {
             "@context": "https://schema.org",
             "@type": "TechArticle",
-            "headline": "NovaModuleTools Getting Started",
-            "description": "Install NovaModuleTools and create your first PowerShell module project.",
+            "headline": "NovaModuleTools quickstart",
+            "description": "Install NovaModuleTools and complete your first successful PowerShell module workflow.",
             "url": "https://www.novamoduletools.com/getting-started.html"
         }
     </script>
@@ -42,94 +44,181 @@
         <nav aria-label="Primary" class="site-nav">
             <a class="site-nav__link site-nav__link--active" href="./getting-started.html">Getting Started</a>
             <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
-            <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+            <a class="site-nav__link" href="./project-json-reference.html">project.json</a>
+            <a class="site-nav__link" href="./commands.html">Commands</a>
+            <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+            <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
             <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
-            <a class="site-nav__link" href="./advanced.html">Advanced</a>
+            <a class="site-nav__link" href="./advanced.html">Concepts</a>
         </nav>
     </div>
 </header>
 
 <main class="page-shell">
     <section class="guide-hero">
-        <p class="eyebrow">Getting started</p>
-        <h1>Install NovaModuleTools and create your first project</h1>
-        <p class="lead">This guide takes you from installation to a working PowerShell module scaffold.</p>
+        <p class="eyebrow">Tutorial</p>
+        <h1>Install NovaModuleTools and prove the workflow works</h1>
+        <p class="lead">This quickstart is optimized for first success. You will install the module, choose the right
+            entrypoint, scaffold the packaged example, build it, test it, import the built module, and run a working
+            command.</p>
     </section>
 
     <section class="content-grid">
         <aside class="toc-card">
             <h2>On this page</h2>
             <ul class="toc-list">
-                <li><a href="#install">1. Install the module</a></li>
-                <li><a href="#launcher">2. Optional CLI launcher</a></li>
-                <li><a href="#first-project">3. Create your first project</a></li>
-                <li><a href="#example-project">4. Start from the example</a></li>
-                <li><a href="#next-step">5. What to do next</a></li>
+                <li><a href="#prerequisites">1. Prerequisites</a></li>
+                <li><a href="#install-module">2. Install the module</a></li>
+                <li><a href="#entrypoints">3. Choose PowerShell or CLI entrypoints</a></li>
+                <li><a href="#scaffold-example">4. Scaffold the packaged example</a></li>
+                <li><a href="#build-and-test">5. Build and test the example</a></li>
+                <li><a href="#import-and-run">6. Import the built module and run a command</a></li>
+                <li><a href="#minimal-scaffold">7. Start from the minimal scaffold instead</a></li>
+                <li><a href="#next-steps">8. Next steps</a></li>
             </ul>
         </aside>
 
         <div class="guide-content">
-            <section class="content-section" id="install">
-                <h2>1. Install the module</h2>
-                <p>Install NovaModuleTools from the PowerShell Gallery and load it into your session:</p>
+            <section class="content-section" id="prerequisites">
+                <h2>1. Prerequisites</h2>
+                <p>You need:</p>
+                <ul class="plain-list">
+                    <li>PowerShell 7.4 or newer</li>
+                    <li>permission to install modules from PowerShell Gallery</li>
+                    <li>Git if you plan to use Git-driven version bumping later</li>
+                </ul>
+                <p>You do <strong>not</strong> need to understand the entire tool before starting. The example-based
+                    path below is designed to show you a complete working project quickly.</p>
+            </section>
+
+            <section class="content-section" id="install-module">
+                <h2>2. Install the module</h2>
+                <p>Install NovaModuleTools from PowerShell Gallery and import it into the current session:</p>
                 <pre><code>Install-Module -Name NovaModuleTools
 Import-Module NovaModuleTools</code></pre>
                 <p>After import, you can use the PowerShell cmdlets directly, and the <code>nova</code> alias is also
                     available inside PowerShell.</p>
+                <p><strong>Expected result:</strong> commands such as <code>Get-NovaProjectInfo</code>, <code>Invoke-NovaBuild</code>,
+                    and <code>nova</code> resolve in your PowerShell session.</p>
             </section>
 
-            <section class="content-section" id="launcher">
-                <h2>2. Optional CLI launcher for macOS and Linux</h2>
-                <p>If you want to run <code>nova</code> directly from your shell instead of from inside PowerShell,
-                    install the launcher:</p>
+            <section class="content-section" id="entrypoints">
+                <h2>3. Choose PowerShell or CLI entrypoints</h2>
+                <p>Nova supports two normal ways of working:</p>
+                <div class="table-scroll">
+                    <table>
+                        <thead>
+                        <tr>
+                            <th>Mode</th>
+                            <th>Use it when…</th>
+                            <th>How it works</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <td>PowerShell cmdlets or <code>nova</code> alias in PowerShell</td>
+                            <td>You are already inside <code>pwsh</code>.</td>
+                            <td>Import the module once, then use cmdlets or the alias directly.</td>
+                        </tr>
+                        <tr>
+                            <td>Standalone <code>nova</code> launcher</td>
+                            <td>You want to run Nova from zsh or bash on macOS/Linux.</td>
+                            <td>Install the launcher once with <code>Install-NovaCli</code>.</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <h3>Install the standalone launcher on macOS/Linux</h3>
                 <pre><code>Install-NovaCli</code></pre>
-                <p>The launcher is copied to <code>~/.local/bin/nova</code> by default. If that folder is not on your
-                    shell path yet, add it:</p>
+                <p>By default, the launcher is installed to <code>~/.local/bin/nova</code>. If that directory is not
+                    already on <code>PATH</code>, add it to your shell profile:</p>
                 <pre><code>echo 'export PATH="$HOME/.local/bin:$PATH"' &gt;&gt; ~/.zshrc
 source ~/.zshrc</code></pre>
-                <p>On Windows, keep using the <code>nova</code> alias inside PowerShell after importing the module.</p>
+                <p>On Windows, keep using the <code>nova</code> alias inside PowerShell after you import the module.
+                    <code>Install-NovaCli</code> is intentionally for macOS/Linux only.</p>
             </section>
 
-            <section class="content-section" id="first-project">
-                <h2>3. Create your first project</h2>
-                <p>The normal entry point is the scaffold flow:</p>
-                <pre><code>nova init</code></pre>
-                <p>If you want to create the project under a specific parent folder, make the destination explicit:</p>
-                <pre><code>nova init -Path ~/Work</code></pre>
-                <p>NovaModuleTools will ask for:</p>
-                <ul class="plain-list">
-                    <li>module name</li>
-                    <li>description</li>
-                    <li>starting semantic version</li>
-                    <li>author name</li>
-                    <li>minimum PowerShell version</li>
-                    <li>whether Git should be initialized</li>
-                </ul>
-                <p>When the prompts finish, you get a project folder with <code>src/</code>, <code>tests/</code> (if
-                    enabled), and <code>project.json</code>.</p>
-            </section>
-
-            <section class="content-section" id="example-project">
-                <h2>4. Start from the packaged example when you want a working reference</h2>
-                <p>If you would rather inspect a complete example than start from a minimal scaffold, use:</p>
-                <pre><code>nova init -Example
-nova init -Example -Path ~/Work</code></pre>
-                <p>This creates a project from the packaged example template, including source files, a resource file,
-                    and tests. The interactive prompt still applies your own project name, description, version, author,
-                    and PowerShell version.</p>
-            </section>
-
-            <section class="content-section" id="next-step">
-                <h2>5. What to do next</h2>
-                <p>After your project exists, continue with the workflow guides:</p>
-                <div class="guide-links">
-                    <a class="button button--primary" href="./core-workflows.html">Go to Core Workflows</a>
-                    <a class="button button--secondary" href="./working-with-modules.html">Learn how to import and
-                        reload modules</a>
+            <section class="content-section" id="scaffold-example">
+                <h2>4. Scaffold the packaged example</h2>
+                <p>The fastest way to understand Nova is to start from the packaged example, because it already contains
+                    a real public command, a private helper, a resource file, tests, and a complete
+                    <code>project.json</code>.</p>
+                <pre><code>nova init -Example -Path ~/Work</code></pre>
+                <p>Nova asks for the project name, description, version, author, minimum PowerShell version, and whether
+                    Git should be initialized. It then creates a project folder under the path you selected.</p>
+                <div class="notice">
+                    <strong>CLI caveat:</strong>
+                    <p>Use <code>nova init -Path ~/Work</code>, not positional path syntax such as <code>nova init
+                        ~/Work</code>. Positional paths are intentionally rejected with migration guidance.</p>
                 </div>
-                <p>Need help choosing settings later? Continue to <a class="text-link" href="./advanced.html">Advanced
-                    Usage</a> for
-                    deeper <code>project.json</code> options and CI guidance.</p>
+                <div class="notice notice--warning">
+                    <strong>Another important caveat:</strong>
+                    <p><code>nova init -WhatIf</code> is intentionally rejected. If you want preview support, use the
+                        PowerShell cmdlet form <code>New-NovaModule -WhatIf</code>.</p>
+                </div>
+                <p><strong>Expected result:</strong> a new project folder that contains <code>src/</code>,
+                    <code>tests/</code>, <code>docs/</code>, and <code>project.json</code>.</p>
+            </section>
+
+            <section class="content-section" id="build-and-test">
+                <h2>5. Build and test the example</h2>
+                <p>Change into the newly created project and run the normal build and test flow:</p>
+                <pre><code>Set-Location ~/Work/&lt;YourProjectName&gt;
+nova build
+nova test</code></pre>
+                <p><strong>Expected result:</strong></p>
+                <ul class="plain-list">
+                    <li>the built module is written to <code>dist/&lt;ProjectName&gt;/</code></li>
+                    <li>the test run writes results to <code>artifacts/TestResults.xml</code></li>
+                </ul>
+                <p>If you prefer the cmdlet form, the same workflow is:</p>
+                <pre><code>Invoke-NovaBuild
+Test-NovaBuild</code></pre>
+            </section>
+
+            <section class="content-section" id="import-and-run">
+                <h2>6. Import the built module and run a command</h2>
+                <p>Now import the module you just built and call the example command:</p>
+                <pre><code>$project = Get-NovaProjectInfo
+Import-Module $project.OutputModuleDir -Force
+Get-ExampleGreeting
+Get-ExampleGreeting -Name 'Nova user' -AsObject</code></pre>
+                <p><strong>Expected result:</strong> the first call returns the example greeting text and the second
+                    call returns a structured object form.</p>
+                <p>This is the key Nova habit: you work with the built output in <code>dist/</code>, not loose source
+                    files, because that matches what will eventually be packaged or published.</p>
+            </section>
+
+            <section class="content-section" id="minimal-scaffold">
+                <h2>7. Start from the minimal scaffold instead</h2>
+                <p>Use the minimal scaffold when you already understand the Nova project shape and want a clean starting
+                    point rather than the full working example.</p>
+                <pre><code>nova init -Path ~/Work</code></pre>
+                <p>The minimal scaffold still asks for the same core project metadata, but it gives you a smaller
+                    starter layout than the example project.</p>
+                <p>Use the example scaffold when you want the fastest learning path. Use the minimal scaffold when you
+                    want the leanest new project.</p>
+            </section>
+
+            <section class="content-section" id="next-steps">
+                <h2>8. Next steps</h2>
+                <div class="guide-links">
+                    <a class="button button--primary" href="./core-workflows.html">Continue to Core Workflows</a>
+                    <a class="button button--secondary" href="./project-json-reference.html">Explore project.json
+                        settings</a>
+                </div>
+                <p>After the quickstart, most developers need one of these pages next:</p>
+                <ul class="plain-list">
+                    <li><a class="text-link" href="./core-workflows.html">Core Workflows</a> for the normal daily
+                        build/test/import loop
+                    </li>
+                    <li><a class="text-link" href="./working-with-modules.html">Working with Modules</a> for reload
+                        habits, local publish, and example-project usage
+                    </li>
+                    <li><a class="text-link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a> when you
+                        are ready to create artifacts, upload them, or publish a module
+                    </li>
+                </ul>
             </section>
         </div>
     </section>
@@ -137,9 +226,17 @@ nova init -Example -Path ~/Work</code></pre>
 
 <footer class="footer">
     <div class="footer__inner">
-        <p class="footer__legal">NovaModuleTools is distributed under the <a class="legal-link" href="./license.html">MIT
-            License</a> and publishes <a class="legal-link" href="./release-notes.html">Release Notes</a> on this
-            site.</p>
+        <h2>Once the first run works, the rest of the docs become much easier</h2>
+        <p>After you have seen a project build, test, and import successfully, use the workflow guides and reference
+            pages to tune the parts you care about instead of trying to learn everything at once.</p>
+        <div class="hero__actions">
+            <a class="button button--primary" href="./core-workflows.html">Open Core Workflows</a>
+            <a class="button button--secondary" href="./working-with-modules.html">Open Working with Modules</a>
+        </div>
+        <p class="footer__legal">Also available: <a class="legal-link" href="./commands.html">Command Reference</a>, <a
+                class="legal-link" href="./release-notes.html">Release Notes</a>, and the <a class="legal-link"
+                                                                                             href="./license.html">MIT
+            License</a>.</p>
     </div>
 </footer>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
-    <title>NovaModuleTools — PowerShell module tools for scaffold, build, test, and release</title>
-    <meta content="NovaModuleTools is a PowerShell module toolchain that helps developers scaffold, build, test, version, and release structured PowerShell modules through a guided workflow."
+    <title>NovaModuleTools — Developer documentation for building PowerShell modules</title>
+    <meta content="Developer documentation for NovaModuleTools. Learn how to scaffold, build, test, package, upload, publish, release, version, and configure PowerShell modules with a clear, task-focused workflow."
           name="description">
     <meta content="index,follow,max-image-preview:large" name="robots">
     <meta content="#0b1020" name="theme-color">
@@ -13,17 +13,15 @@
     <link href="./assets/icon.png" rel="apple-touch-icon">
     <meta content="NovaModuleTools" property="og:site_name">
     <meta content="website" property="og:type">
-    <meta content="NovaModuleTools — PowerShell module tools for scaffold, build, test, and release"
-          property="og:title">
-    <meta content="NovaModuleTools helps developers build PowerShell modules with guided scaffolding, testing, versioning, and release workflows."
+    <meta content="NovaModuleTools — Developer documentation for building PowerShell modules" property="og:title">
+    <meta content="Use NovaModuleTools to scaffold, build, test, package, upload, publish, release, and maintain PowerShell modules with a workflow that developers can learn quickly and trust."
           property="og:description">
     <meta content="https://www.novamoduletools.com/" property="og:url">
     <meta content="https://www.novamoduletools.com/assets/icon.png" property="og:image">
     <meta content="NovaModuleTools icon" property="og:image:alt">
     <meta content="summary_large_image" name="twitter:card">
-    <meta content="NovaModuleTools — PowerShell module tools for scaffold, build, test, and release"
-          name="twitter:title">
-    <meta content="NovaModuleTools helps developers build PowerShell modules with guided scaffolding, testing, versioning, and release workflows."
+    <meta content="NovaModuleTools — Developer documentation for building PowerShell modules" name="twitter:title">
+    <meta content="Use NovaModuleTools to scaffold, build, test, package, upload, publish, release, and maintain PowerShell modules with a workflow that developers can learn quickly and trust."
           name="twitter:description">
     <meta content="https://www.novamoduletools.com/assets/icon.png" name="twitter:image">
     <link href="./assets/site.css" rel="stylesheet">
@@ -34,7 +32,7 @@
             "name": "NovaModuleTools",
             "applicationCategory": "DeveloperApplication",
             "operatingSystem": "Windows, macOS, Linux",
-            "description": "NovaModuleTools helps developers scaffold, build, test, version, and release PowerShell modules.",
+            "description": "NovaModuleTools helps developers scaffold, build, test, package, upload, publish, and release PowerShell modules.",
             "url": "https://www.novamoduletools.com/",
             "image": "https://www.novamoduletools.com/assets/icon.png"
         }
@@ -50,46 +48,51 @@
         <nav aria-label="Primary" class="site-nav">
             <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
             <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
-            <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+            <a class="site-nav__link" href="./project-json-reference.html">project.json</a>
+            <a class="site-nav__link" href="./commands.html">Commands</a>
+            <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+            <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
             <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
-            <a class="site-nav__link" href="./advanced.html">Advanced</a>
+            <a class="site-nav__link" href="./advanced.html">Concepts</a>
         </nav>
     </div>
 </header>
 
 <header class="hero">
     <div class="hero__content">
-        <p class="eyebrow">NovaModuleTools for end users</p>
-        <h1>Build PowerShell modules with guided scaffold, build, test, and release tools</h1>
-        <p class="lead">
-            NovaModuleTools gives you a repeatable PowerShell module workflow from a new project scaffold to a built
-            module in <code>dist/</code>, with testing, versioning, and release commands that work together as one flow.
-        </p>
+        <p class="eyebrow">NovaModuleTools for developers</p>
+        <h1>Build PowerShell modules with a workflow you can actually understand</h1>
+        <p class="lead">This site is the end-user manual for NovaModuleTools. Use it to install the module, scaffold a
+            project, understand <code>project.json</code>, and move through build, test, package, upload, publish,
+            release, versioning, and self-update workflows without guessing.</p>
         <div class="hero__actions">
-            <a class="button button--primary" href="./getting-started.html">Start with installation and setup</a>
-            <a class="button button--secondary" href="./core-workflows.html">See the full workflow</a>
+            <a class="button button--primary" href="./getting-started.html">Start with the quickstart</a>
+            <a class="button button--secondary" href="./project-json-reference.html">Open the project.json reference</a>
         </div>
         <ul class="hero__signals">
-            <li>Clear project structure</li>
-            <li>Practical CLI and PowerShell workflow</li>
-            <li>Guided path from first scaffold to release</li>
+            <li>Task-oriented guides</li>
+            <li>Complete configuration reference</li>
+            <li>CLI and PowerShell coverage</li>
         </ul>
     </div>
-    <div aria-label="Nova workflow summary" class="hero__panel">
+    <div aria-label="NovaModuleTools documentation map" class="hero__panel">
         <div class="panel-card">
             <span class="panel-step">1</span>
-            <strong>Install</strong>
-            <p>Install from the PowerShell Gallery and optionally add the shell launcher.</p>
+            <strong>Get working fast</strong>
+            <p>Use the quickstart to install Nova, scaffold the packaged example, build it, test it, and import a
+                working module.</p>
         </div>
         <div class="panel-card">
             <span class="panel-step">2</span>
-            <strong>Scaffold</strong>
-            <p>Create a new project with <code>nova init</code> or use the full example workflow.</p>
+            <strong>Learn the daily loop</strong>
+            <p>Understand the normal scaffold → build → test → import/reload flow before you move on to packaging and
+                release.</p>
         </div>
         <div class="panel-card">
             <span class="panel-step">3</span>
-            <strong>Build and test</strong>
-            <p>Generate the module in <code>dist/</code> and validate the built result with Pester.</p>
+            <strong>Configure with confidence</strong>
+            <p>Use the <code>project.json</code> reference and delivery guides when you are ready to package, upload,
+                publish, or automate.</p>
         </div>
     </div>
 </header>
@@ -97,133 +100,137 @@
 <main>
     <section class="section section--muted">
         <div class="section__inner narrow">
-            <h2>Use this site as your user guide</h2>
-            <p>
-                This documentation is intentionally task-oriented. Each page helps you complete a real NovaModuleTools
-                workflow.
-            </p>
+            <h2>This site is organized around how developers actually adopt the tool</h2>
+            <p>You should not need to read built-in help cover to cover to become productive. Start with the quickstart,
+                jump to the exact task you need next, and use the reference pages when you are tuning configuration or
+                delivery behavior.</p>
         </div>
     </section>
 
     <section class="section">
         <div class="section__inner">
             <div class="section-heading">
-                <h2>Choose your next PowerShell module step</h2>
-                <p>Start where you are right now and move forward one workflow at a time.</p>
+                <h2>Choose your next task</h2>
+                <p>Each page is written for developers who want a clear answer quickly, with commands, examples, and
+                    expected outcomes.</p>
             </div>
             <div class="guide-grid">
                 <article class="info-card">
                     <h3>Getting Started</h3>
-                    <p>Install the module, add the optional CLI launcher, and create your first structured PowerShell
-                        module project.</p>
-                    <a class="text-link" href="./getting-started.html">Open the PowerShell module getting started
-                        guide</a>
+                    <p>Install NovaModuleTools, understand the PowerShell and CLI entrypoints, and get your first
+                        working project built and tested.</p>
+                    <a class="text-link" href="./getting-started.html">Open the quickstart tutorial</a>
                 </article>
                 <article class="info-card">
                     <h3>Core Workflows</h3>
-                    <p>Follow the normal <code>init → build → test → bump → release</code> flow for a PowerShell module
-                        lifecycle.</p>
-                    <a class="text-link" href="./core-workflows.html">Open the PowerShell module workflow guide</a>
+                    <p>Follow the day-to-day scaffold, build, test, import, and reload workflow you will use most
+                        often.</p>
+                    <a class="text-link" href="./core-workflows.html">Open the core workflow guide</a>
+                </article>
+                <article class="info-card">
+                    <h3>project.json Reference</h3>
+                    <p>See every supported configuration area, defaults, and practical recipes for build, packaging,
+                        upload, and test settings.</p>
+                    <a class="text-link" href="./project-json-reference.html">Open the configuration reference</a>
+                </article>
+                <article class="info-card">
+                    <h3>Command Reference</h3>
+                    <p>Find the right cmdlet or <code>nova</code> command and understand when to use it.</p>
+                    <a class="text-link" href="./commands.html">Open the command reference</a>
+                </article>
+                <article class="info-card">
+                    <h3>Packaging &amp; Delivery</h3>
+                    <p>Compare pack, upload, publish, and release so you choose the right delivery workflow the first
+                        time.</p>
+                    <a class="text-link" href="./packaging-and-delivery.html">Open packaging and delivery guides</a>
+                </article>
+                <article class="info-card">
+                    <h3>Versioning &amp; Updates</h3>
+                    <p>Understand Git-driven version bumps, version display commands, self-update behavior, and
+                        prerelease preferences.</p>
+                    <a class="text-link" href="./versioning-and-updates.html">Open versioning and update guidance</a>
                 </article>
                 <article class="info-card">
                     <h3>Working with Modules</h3>
-                    <p>Import the built output, reload it after changes, and use the packaged example effectively during
-                        local PowerShell module development.</p>
-                    <a class="text-link" href="./working-with-modules.html">Open the module development guide</a>
+                    <p>Learn why Nova is designed around the built output in <code>dist/</code>, how to reload safely,
+                        and how to use the packaged example.</p>
+                    <a class="text-link" href="./working-with-modules.html">Open the working-with-modules guide</a>
                 </article>
                 <article class="info-card">
                     <h3>Troubleshooting</h3>
-                    <p>Fix common issues around paths, tests, module reloads, and version bumps.</p>
-                    <a class="text-link" href="./troubleshooting.html">Open the troubleshooting guide</a>
+                    <p>Fix the most common problems around paths, reload behavior, version bumps, package uploads, and
+                        command selection.</p>
+                    <a class="text-link" href="./troubleshooting.html">Open troubleshooting</a>
                 </article>
                 <article class="info-card">
-                    <h3>Advanced Usage</h3>
-                    <p>Go deeper with CI/CD expectations, project.json settings, and publish/release habits for larger
-                        PowerShell module workflows.</p>
-                    <a class="text-link" href="./advanced.html">Open the advanced PowerShell module guide</a>
+                    <h3>Concepts</h3>
+                    <p>Build a mental model for how Nova structures a project, why it builds into <code>dist/</code>,
+                        and how settings shape the workflow.</p>
+                    <a class="text-link" href="./advanced.html">Open the concepts guide</a>
                 </article>
             </div>
-        </div>
-    </section>
-
-    <section class="section section--muted">
-        <div class="section__inner split">
-            <div>
-                <h2>What people often search for</h2>
-                <p>NovaModuleTools is especially relevant if you are looking for help with:</p>
-                <ul class="check-list">
-                    <li>how to scaffold a PowerShell module project</li>
-                    <li>how to build and test a PowerShell module consistently</li>
-                    <li>how to version and release a PowerShell module from one workflow</li>
-                </ul>
-            </div>
-            <aside class="callout">
-                <h3>Best next links</h3>
-                <p>Start with <a class="text-link" href="./getting-started.html">Getting Started</a>, then move to <a
-                        class="text-link" href="./core-workflows.html">Core Workflows</a> when your first project
-                    exists.</p>
-            </aside>
         </div>
     </section>
 
     <section class="section section--accent">
         <div class="section__inner split">
             <div>
-                <h2>What NovaModuleTools gives you</h2>
-                <ul class="check-list">
-                    <li>A scaffolded PowerShell module structure you can start using immediately</li>
-                    <li>A build flow that turns your source files into a proper module under <code>dist/</code></li>
-                    <li>A test flow that validates the built module result</li>
-                    <li>Built-in support for resources, classes, version bumps, and release workflows</li>
-                </ul>
+                <h2>Recommended first 15-minute path</h2>
+                <ol class="plain-list plain-list--ordered">
+                    <li>Install the module and import it into PowerShell.</li>
+                    <li>Scaffold the packaged example with <code>nova init -Example</code>.</li>
+                    <li>Build with <code>nova build</code>.</li>
+                    <li>Test with <code>nova test</code>.</li>
+                    <li>Import the built example module and run <code>Get-ExampleGreeting</code>.</li>
+                </ol>
+                <p>This path proves the tool works, shows the real folder structure, and gives you a runnable module
+                    before you start customizing anything.</p>
             </div>
             <aside class="callout">
-                <h3>Good fit if you want to…</h3>
-                <p>move from loose scripts to a structured PowerShell module workflow without inventing the build and
-                    test process yourself.</p>
+                <h3>Why the example path is so useful</h3>
+                <p>The packaged example is a maintained working reference. It shows the current
+                    <code>project.json</code> surface, a real public function, a private helper, a resource file, and
+                    tests against the built output.</p>
+                <a class="text-link" href="./working-with-modules.html#example-project">See the example walkthrough</a>
             </aside>
         </div>
     </section>
 
-    <section class="section">
-        <div class="section__inner">
-            <div class="section-heading">
-                <h2>Recommended first path</h2>
-                <p>If you are completely new to NovaModuleTools, follow this order:</p>
+    <section class="section section--muted">
+        <div class="section__inner split">
+            <div>
+                <h2>What NovaModuleTools helps you do</h2>
+                <ul class="check-list">
+                    <li>scaffold a structured PowerShell module project</li>
+                    <li>build a real module into <code>dist/</code> instead of running loose source files</li>
+                    <li>test the current project with Pester by using the project-defined workflow</li>
+                    <li>create package artifacts for raw distribution</li>
+                    <li>upload package artifacts to raw HTTP endpoints</li>
+                    <li>publish modules locally or to PowerShell repositories</li>
+                    <li>orchestrate build, test, version bump, and publish as a release flow</li>
+                </ul>
             </div>
-            <div class="steps">
-                <article class="step-card">
-                    <span class="step-number">01</span>
-                    <h3>Install and import</h3>
-                    <p>Start with the Gallery install and optional CLI launcher setup.</p>
-                </article>
-                <article class="step-card">
-                    <span class="step-number">02</span>
-                    <h3>Create a project</h3>
-                    <p>Use the default scaffold or choose the packaged example for a complete working reference.</p>
-                </article>
-                <article class="step-card">
-                    <span class="step-number">03</span>
-                    <h3>Build, test, and iterate</h3>
-                    <p>Generate the module in <code>dist/</code>, test it, and reload it as you change source files.</p>
-                </article>
-            </div>
+            <aside class="callout">
+                <h3>Also on this site</h3>
+                <p>Use <a class="text-link" href="./release-notes.html">Release Notes</a> when you want to understand
+                    recent changes, and <a class="text-link" href="./license.html">License</a> for the MIT terms.</p>
+            </aside>
         </div>
     </section>
 </main>
 
 <footer class="footer">
     <div class="footer__inner">
-        <h2>Ready to use NovaModuleTools?</h2>
-        <p>Start with installation, then follow the guided workflows all the way through build, test, bump, and
-            release.</p>
+        <h2>Start where you are, then move one workflow at a time</h2>
+        <p>NovaModuleTools becomes easy once the command boundaries are clear. Use the quickstart for first success, the
+            reference pages for exact behavior, and troubleshooting when the workflow does not match your expectation
+            yet.</p>
         <div class="hero__actions">
             <a class="button button--primary" href="./getting-started.html">Open Getting Started</a>
-            <a class="button button--secondary" href="./troubleshooting.html">Need help troubleshooting?</a>
+            <a class="button button--secondary" href="./commands.html">Open Command Reference</a>
         </div>
-        <p class="footer__legal">NovaModuleTools is distributed under the <a class="legal-link" href="./license.html">MIT
-            License</a> and publishes <a class="legal-link" href="./release-notes.html">Release Notes</a> on this
-            site.</p>
+        <p class="footer__legal">Also available: <a class="legal-link" href="./release-notes.html">Release Notes</a> and
+            the <a class="legal-link" href="./license.html">MIT License</a>.</p>
     </div>
 </footer>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -45,16 +45,26 @@
             <img alt="" class="site-brand__icon" src="./assets/icon.png">
             <span class="site-brand__text">NovaModuleTools</span>
         </a>
-        <nav aria-label="Primary" class="site-nav">
-            <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
-            <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
-            <a class="site-nav__link" href="./project-json-reference.html">project.json</a>
-            <a class="site-nav__link" href="./commands.html">Commands</a>
-            <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
-            <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
-            <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
-            <a class="site-nav__link" href="./advanced.html">Concepts</a>
-        </nav>
+        <details class="site-menu">
+            <summary class="site-menu__button">
+                <span class="site-menu__button-label">Menu</span>
+                <span class="site-menu__current">Home</span>
+            </summary>
+            <nav aria-label="Primary" class="site-menu__panel">
+                <a aria-current="page" class="site-nav__link site-nav__link--active" href="./index.html">Home</a>
+                <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
+                <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
+                <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+                <a class="site-nav__link" href="./project-json-reference.html">project.json Reference</a>
+                <a class="site-nav__link" href="./commands.html">Command Reference</a>
+                <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+                <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
+                <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
+                <a class="site-nav__link" href="./advanced.html">Concepts</a>
+                <a class="site-nav__link" href="./release-notes.html">Release Notes</a>
+                <a class="site-nav__link" href="./license.html">License</a>
+            </nav>
+        </details>
     </div>
 </header>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -62,7 +62,6 @@
                 <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
                 <a class="site-nav__link" href="./advanced.html">Concepts</a>
                 <a class="site-nav__link" href="./release-notes.html">Release Notes</a>
-                <a class="site-nav__link" href="./license.html">License</a>
             </nav>
         </details>
     </div>
@@ -220,17 +219,13 @@
                     <li>orchestrate build, test, version bump, and publish as a release flow</li>
                 </ul>
             </div>
-            <aside class="callout">
-                <h3>Also on this site</h3>
-                <p>Use <a class="text-link" href="./release-notes.html">Release Notes</a> when you want to understand
-                    recent changes, and <a class="text-link" href="./license.html">License</a> for the MIT terms.</p>
-            </aside>
         </div>
     </section>
 </main>
 
 <footer class="footer">
     <div class="footer__inner">
+        <br>
         <h2>Start where you are, then move one workflow at a time</h2>
         <p>NovaModuleTools becomes easy once the command boundaries are clear. Use the quickstart for first success, the
             reference pages for exact behavior, and troubleshooting when the workflow does not match your expectation

--- a/docs/license.html
+++ b/docs/license.html
@@ -46,7 +46,6 @@
                 <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
                 <a class="site-nav__link" href="./advanced.html">Concepts</a>
                 <a class="site-nav__link" href="./release-notes.html">Release Notes</a>
-                <a aria-current="page" class="site-nav__link site-nav__link--active" href="./license.html">License</a>
             </nav>
         </details>
     </div>

--- a/docs/license.html
+++ b/docs/license.html
@@ -29,16 +29,26 @@
             <img alt="" class="site-brand__icon" src="./assets/icon.png">
             <span class="site-brand__text">NovaModuleTools</span>
         </a>
-        <nav aria-label="Primary" class="site-nav">
-            <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
-            <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
-            <a class="site-nav__link" href="./project-json-reference.html">project.json</a>
-            <a class="site-nav__link" href="./commands.html">Commands</a>
-            <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
-            <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
-            <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
-            <a class="site-nav__link" href="./advanced.html">Concepts</a>
-        </nav>
+        <details class="site-menu">
+            <summary class="site-menu__button">
+                <span class="site-menu__button-label">Menu</span>
+                <span class="site-menu__current">License</span>
+            </summary>
+            <nav aria-label="Primary" class="site-menu__panel">
+                <a class="site-nav__link" href="./index.html">Home</a>
+                <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
+                <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
+                <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+                <a class="site-nav__link" href="./project-json-reference.html">project.json Reference</a>
+                <a class="site-nav__link" href="./commands.html">Command Reference</a>
+                <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+                <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
+                <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
+                <a class="site-nav__link" href="./advanced.html">Concepts</a>
+                <a class="site-nav__link" href="./release-notes.html">Release Notes</a>
+                <a aria-current="page" class="site-nav__link site-nav__link--active" href="./license.html">License</a>
+            </nav>
+        </details>
     </div>
 </header>
 

--- a/docs/license.html
+++ b/docs/license.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
-    <title>NovaModuleTools — License</title>
+    <title>NovaModuleTools — MIT License</title>
     <meta content="Read the NovaModuleTools MIT License directly on the public documentation site." name="description">
     <meta content="index,follow,max-image-preview:large" name="robots">
     <meta content="#0b1020" name="theme-color">
@@ -11,13 +11,13 @@
     <link href="./assets/icon.png" rel="icon" type="image/png">
     <link href="./assets/icon.png" rel="apple-touch-icon">
     <meta content="article" property="og:type">
-    <meta content="NovaModuleTools — License" property="og:title">
+    <meta content="NovaModuleTools — MIT License" property="og:title">
     <meta content="Read the NovaModuleTools MIT License directly on the public documentation site."
           property="og:description">
     <meta content="https://www.novamoduletools.com/license.html" property="og:url">
     <meta content="https://www.novamoduletools.com/assets/icon.png" property="og:image">
     <meta content="summary" name="twitter:card">
-    <meta content="NovaModuleTools — License" name="twitter:title">
+    <meta content="NovaModuleTools — MIT License" name="twitter:title">
     <meta content="Read the NovaModuleTools MIT License directly on the public documentation site."
           name="twitter:description">
     <link href="./assets/site.css" rel="stylesheet">
@@ -32,9 +32,12 @@
         <nav aria-label="Primary" class="site-nav">
             <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
             <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
-            <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+            <a class="site-nav__link" href="./project-json-reference.html">project.json</a>
+            <a class="site-nav__link" href="./commands.html">Commands</a>
+            <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+            <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
             <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
-            <a class="site-nav__link" href="./advanced.html">Advanced</a>
+            <a class="site-nav__link" href="./advanced.html">Concepts</a>
         </nav>
     </div>
 </header>
@@ -43,6 +46,8 @@
     <section class="guide-hero">
         <p class="eyebrow">License</p>
         <h1>NovaModuleTools is distributed under the MIT License</h1>
+        <p class="lead">This page mirrors the repository license so you can review the distribution terms without
+            leaving the end-user documentation site.</p>
     </section>
 
     <section class="guide-content guide-content--single">
@@ -57,7 +62,7 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THESOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 </code></pre>
             </div>
         </section>
@@ -66,9 +71,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 <footer class="footer">
     <div class="footer__inner">
-        <p class="footer__legal">NovaModuleTools is distributed under the <a class="legal-link" href="./license.html">MIT
-            License</a> and publishes <a class="legal-link" href="./release-notes.html">Release Notes</a> on this
-            site.</p>
+        <p class="footer__legal">Return to <a class="legal-link" href="./index.html">Home</a>, <a class="legal-link"
+                                                                                                  href="./release-notes.html">Release
+            Notes</a>, or <a class="legal-link" href="./getting-started.html">Getting Started</a>.</p>
     </div>
 </footer>
 </body>

--- a/docs/packaging-and-delivery.html
+++ b/docs/packaging-and-delivery.html
@@ -57,7 +57,6 @@
                 <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
                 <a class="site-nav__link" href="./advanced.html">Concepts</a>
                 <a class="site-nav__link" href="./release-notes.html">Release Notes</a>
-                <a class="site-nav__link" href="./license.html">License</a>
             </nav>
         </details>
     </div>

--- a/docs/packaging-and-delivery.html
+++ b/docs/packaging-and-delivery.html
@@ -1,0 +1,324 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1" name="viewport">
+    <title>NovaModuleTools — Package, upload, publish, and release PowerShell modules</title>
+    <meta content="Learn when to use Pack-NovaModule, Upload-NovaPackage, Publish-NovaModule, and Invoke-NovaRelease, with examples for package creation, raw upload, PowerShell repository publish, and release orchestration."
+          name="description">
+    <meta content="index,follow,max-image-preview:large" name="robots">
+    <meta content="#0b1020" name="theme-color">
+    <link href="https://www.novamoduletools.com/packaging-and-delivery.html" rel="canonical">
+    <link href="./assets/icon.png" rel="icon" type="image/png">
+    <link href="./assets/icon.png" rel="apple-touch-icon">
+    <meta content="article" property="og:type">
+    <meta content="NovaModuleTools — Package, upload, publish, and release PowerShell modules" property="og:title">
+    <meta content="Compare NovaModuleTools packaging and delivery workflows so you can choose the right command for artifact creation, raw upload, repository publishing, or release orchestration."
+          property="og:description">
+    <meta content="https://www.novamoduletools.com/packaging-and-delivery.html" property="og:url">
+    <meta content="https://www.novamoduletools.com/assets/icon.png" property="og:image">
+    <meta content="summary" name="twitter:card">
+    <meta content="NovaModuleTools — Package, upload, publish, and release PowerShell modules" name="twitter:title">
+    <meta content="Compare NovaModuleTools packaging and delivery workflows so you can choose the right command for artifact creation, raw upload, repository publishing, or release orchestration."
+          name="twitter:description">
+    <link href="./assets/site.css" rel="stylesheet">
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "TechArticle",
+            "headline": "NovaModuleTools packaging and delivery guide",
+            "description": "How to package, upload, publish, and release modules with NovaModuleTools.",
+            "url": "https://www.novamoduletools.com/packaging-and-delivery.html"
+        }
+    </script>
+</head>
+<body>
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-brand" href="./index.html">
+            <img alt="" class="site-brand__icon" src="./assets/icon.png">
+            <span class="site-brand__text">NovaModuleTools</span>
+        </a>
+        <nav aria-label="Primary" class="site-nav">
+            <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
+            <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
+            <a class="site-nav__link" href="./project-json-reference.html">project.json</a>
+            <a class="site-nav__link" href="./commands.html">Commands</a>
+            <a class="site-nav__link site-nav__link--active" href="./packaging-and-delivery.html">Packaging &amp;
+                Delivery</a>
+            <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
+            <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
+            <a class="site-nav__link" href="./advanced.html">Concepts</a>
+        </nav>
+    </div>
+</header>
+
+<main class="page-shell">
+    <section class="guide-hero">
+        <p class="eyebrow">How-to Guides</p>
+        <h1>Know whether you need pack, upload, publish, or release</h1>
+        <p class="lead">NovaModuleTools gives you four different delivery commands because they solve four different
+            problems. This page shows you what each command does, what it does not do, and how to configure the related
+            workflow safely.</p>
+    </section>
+
+    <section class="content-grid">
+        <aside class="toc-card">
+            <h2>On this page</h2>
+            <ul class="toc-list">
+                <li><a href="#choose-command">Choose the right command</a></li>
+                <li><a href="#pack">Create package artifacts</a></li>
+                <li><a href="#upload">Upload package artifacts to a raw endpoint</a></li>
+                <li><a href="#publish">Publish to a PowerShell repository</a></li>
+                <li><a href="#release">Run the release workflow</a></li>
+            </ul>
+        </aside>
+
+        <div class="guide-content">
+            <section class="content-section" id="choose-command">
+                <h2>Choose the right command</h2>
+                <div class="table-scroll">
+                    <table>
+                        <thead>
+                        <tr>
+                            <th>Command</th>
+                            <th>What it does</th>
+                            <th>What it does not do</th>
+                            <th>Use it when…</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <td><code>Pack-NovaModule</code> / <code>nova pack</code></td>
+                            <td>Builds, tests, and creates package artifacts such as <code>.nupkg</code> and
+                                <code>.zip</code>.
+                            </td>
+                            <td>Does not upload or publish the package anywhere.</td>
+                            <td>You need artifacts in <code>artifacts/packages/</code>.</td>
+                        </tr>
+                        <tr>
+                            <td><code>Upload-NovaPackage</code> / <code>nova upload</code></td>
+                            <td>Uploads existing artifacts to a raw HTTP endpoint.</td>
+                            <td>Does not build, test, or create the package first.</td>
+                            <td>You already have artifacts and need to push them to Nexus, Artifactory, or another raw
+                                endpoint.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><code>Publish-NovaModule</code> / <code>nova publish</code></td>
+                            <td>Builds, tests, and publishes the module locally or to a PowerShell repository.</td>
+                            <td>Does not create generic raw HTTP uploads.</td>
+                            <td>You want the PowerShell module itself published, not just an arbitrary artifact.</td>
+                        </tr>
+                        <tr>
+                            <td><code>Invoke-NovaRelease</code> / <code>nova release</code></td>
+                            <td>Builds, tests, bumps the version, rebuilds, and then publishes.</td>
+                            <td>Does not replace <code>Pack-NovaModule</code> or raw upload as a generic artifact
+                                workflow.
+                            </td>
+                            <td>You want one orchestrated release command instead of separate steps.</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div class="notice notice--warning">
+                    <strong>Most confusion comes from this difference:</strong>
+                    <p><code>Pack-NovaModule</code> creates files. <code>Upload-NovaPackage</code> sends those files to
+                        a raw endpoint. <code>Publish-NovaModule</code> publishes the module itself to a PowerShell
+                        repository. <code>Invoke-NovaRelease</code> coordinates versioning plus publishing.</p>
+                </div>
+            </section>
+
+            <section class="content-section" id="pack">
+                <h2>Create package artifacts</h2>
+                <p>Use <code>Pack-NovaModule</code> or <code>nova pack</code> when you want a package artifact generated
+                    from the built module output.</p>
+                <h3>What happens</h3>
+                <ol class="plain-list plain-list--ordered">
+                    <li>Nova builds the project.</li>
+                    <li>Nova runs the test workflow.</li>
+                    <li>Nova creates one or more package artifacts under <code>Package.OutputDirectory.Path</code>,
+                        which defaults to <code>artifacts/packages/</code>.
+                    </li>
+                </ol>
+                <h3>Common examples</h3>
+                <pre><code>Pack-NovaModule
+nova pack</code></pre>
+                <p>This creates a <code>.nupkg</code> by default when <code>Package.Types</code> is omitted.</p>
+                <pre><code>{
+  "Package": {
+    "Types": ["Zip"]
+  }
+}</code></pre>
+                <p>This creates only a <code>.zip</code>.</p>
+                <pre><code>{
+  "Package": {
+    "Types": ["NuGet", "Zip"],
+    "Latest": true,
+    "OutputDirectory": {
+      "Path": "artifacts/packages",
+      "Clean": true
+    }
+  }
+}</code></pre>
+                <p>This creates both formats and also adds <code>latest</code> aliases, such as:</p>
+                <pre><code>MyModule.2.0.0.nupkg
+MyModule.latest.nupkg
+MyModule.2.0.0.zip
+MyModule.latest.zip</code></pre>
+                <h3>What metadata is reused</h3>
+                <ul class="plain-list">
+                    <li>top-level <code>ProjectName</code>, <code>Description</code>, and <code>Version</code></li>
+                    <li><code>Manifest.Author</code></li>
+                    <li><code>Manifest.Tags</code></li>
+                    <li><code>Manifest.ProjectUri</code></li>
+                    <li><code>Manifest.ReleaseNotes</code></li>
+                    <li><code>Manifest.LicenseUri</code></li>
+                </ul>
+                <p><a class="text-link" href="./project-json-reference.html#package">See package settings in the
+                    configuration reference</a></p>
+            </section>
+
+            <section class="content-section" id="upload">
+                <h2>Upload package artifacts to a raw endpoint</h2>
+                <p>Use <code>Upload-NovaPackage</code> or <code>nova upload</code> when you already have package files
+                    and you need to push them to a raw HTTP endpoint.</p>
+                <div class="notice">
+                    <strong>Upload works on existing files only.</strong>
+                    <p>If you have not run <code>Pack-NovaModule</code> yet, upload has nothing to send unless you
+                        explicitly point it at existing package files with <code>-PackagePath</code>.</p>
+                </div>
+                <h3>Common ways to target artifacts</h3>
+                <pre><code>Upload-NovaPackage -Repository LocalNexus
+nova upload -repository LocalNexus</code></pre>
+                <p>Use a named repository from <code>Package.Repositories</code>.</p>
+                <pre><code>Upload-NovaPackage -Url 'https://packages.example/raw/' -Token $env:NOVA_PACKAGE_TOKEN
+nova upload -url https://packages.example/raw/ -token $env:NOVA_PACKAGE_TOKEN</code></pre>
+                <p>Use a direct URL when CI or a one-off script already knows the endpoint.</p>
+                <pre><code>Upload-NovaPackage -PackageType Zip -Repository LocalNexus</code></pre>
+                <p>Filter to only one package type.</p>
+                <pre><code>Upload-NovaPackage -PackagePath @(
+  'artifacts/packages/MyModule.2.0.0.zip',
+  'artifacts/packages/MyModule.latest.zip'
+) -Url 'https://packages.example/raw/releases/'</code></pre>
+                <p>Use explicit file paths when you do not want Nova to discover package files from the configured
+                    output directory.</p>
+                <h3>How upload target resolution works</h3>
+                <ol class="plain-list plain-list--ordered">
+                    <li>If you pass <code>-Url</code>, Nova uses it.</li>
+                    <li>Otherwise, if you pass <code>-Repository</code>, Nova resolves the matching entry from <code>Package.Repositories</code>.
+                    </li>
+                    <li>Otherwise, Nova falls back to package-level defaults such as <code>Package.RepositoryUrl</code>.
+                    </li>
+                </ol>
+                <p>If no target can be resolved, upload fails fast with a clear error telling you to provide
+                    <code>-Url</code> or configure package-level upload settings.</p>
+                <h3>Headers and auth</h3>
+                <p>Upload uses a generic auth model so you can target many raw repository types without turning the
+                    command into a vendor-specific integration.</p>
+                <div class="table-scroll">
+                    <table>
+                        <thead>
+                        <tr>
+                            <th>Scenario</th>
+                            <th>Recommended configuration</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <td>Bearer token</td>
+                            <td><code>HeaderName = "Authorization"</code>, <code>Scheme = "Bearer"</code>, <code>TokenEnvironmentVariable
+                                = "NOVA_PACKAGE_TOKEN"</code></td>
+                        </tr>
+                        <tr>
+                            <td>Custom API key header</td>
+                            <td><code>HeaderName = "X-Api-Key"</code>, <code>TokenEnvironmentVariable =
+                                "NOVA_PACKAGE_API_KEY"</code></td>
+                        </tr>
+                        <tr>
+                            <td>HTTP Basic auth</td>
+                            <td><code>HeaderName = "Authorization"</code>, <code>Scheme = "Basic"</code>, and an
+                                environment variable whose value is the Base64-encoded <code>username:password</code>
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <p>When multiple matching files exist, Nova uploads all matching artifacts for the selected type or
+                    configured types. That includes versioned and <code>latest</code> artifacts.</p>
+                <p><a class="text-link" href="./troubleshooting.html#upload-auth">See upload auth troubleshooting</a>
+                </p>
+            </section>
+
+            <section class="content-section" id="publish">
+                <h2>Publish to a PowerShell repository</h2>
+                <p>Use <code>Publish-NovaModule</code> or <code>nova publish</code> when you want to publish the built
+                    module itself either locally or to a PowerShell repository.</p>
+                <h3>Local publish</h3>
+                <pre><code>Publish-NovaModule -Local
+nova publish -local</code></pre>
+                <p>Local publish is useful when you want to validate a realistic install/import cycle without pushing to
+                    a shared repository. After a successful local publish, Nova reloads the published module from the
+                    local install path into the current PowerShell session.</p>
+                <h3>Repository publish</h3>
+                <pre><code>Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API
+nova publish -repository PSGallery -apikey $env:PSGALLERY_API</code></pre>
+                <p>Repository mode is for registered PowerShell repositories such as PowerShell Gallery.</p>
+                <h3>Custom local path</h3>
+                <pre><code>Publish-NovaModule -Local -ModuleDirectoryPath ~/Modules</code></pre>
+                <p>Use this when you want local publishing to target a custom module directory.</p>
+                <h3>What <code>-WhatIf</code> means here</h3>
+                <p>When you preview local publish, Nova does not build, test, copy, or import the module. The preview is
+                    safe and side-effect free.</p>
+            </section>
+
+            <section class="content-section" id="release">
+                <h2>Run the release workflow</h2>
+                <p>Use <code>Invoke-NovaRelease</code> or <code>nova release</code> when you want one command to
+                    coordinate build, test, version bump, rebuild, and publish.</p>
+                <h3>What happens</h3>
+                <ol class="plain-list plain-list--ordered">
+                    <li>Build the module.</li>
+                    <li>Run the tests.</li>
+                    <li>Calculate and write the next semantic version.</li>
+                    <li>Build again so the output reflects the new version.</li>
+                    <li>Publish locally or to a repository.</li>
+                </ol>
+                <h3>Examples</h3>
+                <pre><code>Invoke-NovaRelease -PublishOption @{ Local = $true }
+Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $env:PSGALLERY_API }
+nova release -repository PSGallery -apikey $env:PSGALLERY_API</code></pre>
+                <h3>Important difference from local publish</h3>
+                <p>Local release does <strong>not</strong> import the published module into your current session
+                    afterward. That behavior is specific to <code>Publish-NovaModule -Local</code>.</p>
+                <h3>When to prefer release over separate steps</h3>
+                <ul class="plain-list">
+                    <li>Use release when your version bump and publish should happen together.</li>
+                    <li>Use separate commands when you want to inspect artifacts, review versioning, or pause between
+                        steps.
+                    </li>
+                </ul>
+                <p><a class="text-link" href="./versioning-and-updates.html#bump">See how version bump selection
+                    works</a></p>
+            </section>
+        </div>
+    </section>
+</main>
+
+<footer class="footer">
+    <div class="footer__inner">
+        <h2>Still deciding which workflow you need?</h2>
+        <p>Use the command reference when you want a quick lookup, or jump back to the configuration reference if the
+            next step is changing package behavior in <code>project.json</code>.</p>
+        <div class="hero__actions">
+            <a class="button button--primary" href="./commands.html">Open Command Reference</a>
+            <a class="button button--secondary" href="./project-json-reference.html">Open project.json Reference</a>
+        </div>
+        <p class="footer__legal">Also available: <a class="legal-link" href="./versioning-and-updates.html">Versioning
+            &amp; Updates</a>, <a class="legal-link" href="./release-notes.html">Release Notes</a>, and the <a
+                class="legal-link" href="./license.html">MIT License</a>.</p>
+    </div>
+</footer>
+</body>
+</html>
+

--- a/docs/packaging-and-delivery.html
+++ b/docs/packaging-and-delivery.html
@@ -39,17 +39,27 @@
             <img alt="" class="site-brand__icon" src="./assets/icon.png">
             <span class="site-brand__text">NovaModuleTools</span>
         </a>
-        <nav aria-label="Primary" class="site-nav">
-            <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
-            <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
-            <a class="site-nav__link" href="./project-json-reference.html">project.json</a>
-            <a class="site-nav__link" href="./commands.html">Commands</a>
-            <a class="site-nav__link site-nav__link--active" href="./packaging-and-delivery.html">Packaging &amp;
-                Delivery</a>
-            <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
-            <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
-            <a class="site-nav__link" href="./advanced.html">Concepts</a>
-        </nav>
+        <details class="site-menu">
+            <summary class="site-menu__button">
+                <span class="site-menu__button-label">Menu</span>
+                <span class="site-menu__current">Packaging &amp; Delivery</span>
+            </summary>
+            <nav aria-label="Primary" class="site-menu__panel">
+                <a class="site-nav__link" href="./index.html">Home</a>
+                <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
+                <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
+                <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+                <a class="site-nav__link" href="./project-json-reference.html">project.json Reference</a>
+                <a class="site-nav__link" href="./commands.html">Command Reference</a>
+                <a aria-current="page" class="site-nav__link site-nav__link--active"
+                   href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+                <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
+                <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
+                <a class="site-nav__link" href="./advanced.html">Concepts</a>
+                <a class="site-nav__link" href="./release-notes.html">Release Notes</a>
+                <a class="site-nav__link" href="./license.html">License</a>
+            </nav>
+        </details>
     </div>
 </header>
 
@@ -321,4 +331,3 @@ nova release -repository PSGallery -apikey $env:PSGALLERY_API</code></pre>
 </footer>
 </body>
 </html>
-

--- a/docs/project-json-reference.html
+++ b/docs/project-json-reference.html
@@ -57,7 +57,6 @@
                 <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
                 <a class="site-nav__link" href="./advanced.html">Concepts</a>
                 <a class="site-nav__link" href="./release-notes.html">Release Notes</a>
-                <a class="site-nav__link" href="./license.html">License</a>
             </nav>
         </details>
     </div>

--- a/docs/project-json-reference.html
+++ b/docs/project-json-reference.html
@@ -1,0 +1,669 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1" name="viewport">
+    <title>NovaModuleTools — project.json reference and configuration guide</title>
+    <meta content="Complete reference for NovaModuleTools project.json settings, including top-level build settings, manifest metadata, package settings, raw upload configuration, and Pester options."
+          name="description">
+    <meta content="index,follow,max-image-preview:large" name="robots">
+    <meta content="#0b1020" name="theme-color">
+    <link href="https://www.novamoduletools.com/project-json-reference.html" rel="canonical">
+    <link href="./assets/icon.png" rel="icon" type="image/png">
+    <link href="./assets/icon.png" rel="apple-touch-icon">
+    <meta content="article" property="og:type">
+    <meta content="NovaModuleTools — project.json reference and configuration guide" property="og:title">
+    <meta content="Use this page as the source of truth for NovaModuleTools project.json settings, defaults, examples, and workflow effects."
+          property="og:description">
+    <meta content="https://www.novamoduletools.com/project-json-reference.html" property="og:url">
+    <meta content="https://www.novamoduletools.com/assets/icon.png" property="og:image">
+    <meta content="summary" name="twitter:card">
+    <meta content="NovaModuleTools — project.json reference and configuration guide" name="twitter:title">
+    <meta content="Use this page as the source of truth for NovaModuleTools project.json settings, defaults, examples, and workflow effects."
+          name="twitter:description">
+    <link href="./assets/site.css" rel="stylesheet">
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "TechArticle",
+            "headline": "NovaModuleTools project.json reference",
+            "description": "Reference for NovaModuleTools project.json configuration.",
+            "url": "https://www.novamoduletools.com/project-json-reference.html"
+        }
+    </script>
+</head>
+<body>
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-brand" href="./index.html">
+            <img alt="" class="site-brand__icon" src="./assets/icon.png">
+            <span class="site-brand__text">NovaModuleTools</span>
+        </a>
+        <nav aria-label="Primary" class="site-nav">
+            <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
+            <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
+            <a class="site-nav__link site-nav__link--active" href="./project-json-reference.html">project.json</a>
+            <a class="site-nav__link" href="./commands.html">Commands</a>
+            <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+            <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
+            <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
+            <a class="site-nav__link" href="./advanced.html">Concepts</a>
+        </nav>
+    </div>
+</header>
+
+<main class="page-shell">
+    <section class="guide-hero">
+        <p class="eyebrow">Reference</p>
+        <h1>Understand every setting in <code>project.json</code></h1>
+        <p class="lead">NovaModuleTools reads <code>project.json</code> to decide how your project is scaffolded, built,
+            tested, packaged, uploaded, published, and released. Use this page to understand what each setting does,
+            what the defaults are, and when you should override them.</p>
+    </section>
+
+    <section class="content-grid">
+        <aside class="toc-card">
+            <h2>On this page</h2>
+            <ul class="toc-list">
+                <li><a href="#reading-order">How to read this file</a></li>
+                <li><a href="#example">Complete example</a></li>
+                <li><a href="#top-level">Top-level project settings</a></li>
+                <li><a href="#manifest">Manifest settings</a></li>
+                <li><a href="#package">Package settings</a></li>
+                <li><a href="#pester">Pester settings</a></li>
+                <li><a href="#recipes">Common recipes</a></li>
+            </ul>
+        </aside>
+
+        <div class="guide-content">
+            <section class="content-section" id="reading-order">
+                <h2>How to read this file</h2>
+                <p>Think of <code>project.json</code> in layers:</p>
+                <ol class="plain-list plain-list--ordered">
+                    <li><strong>Top-level project settings</strong> control the build shape, source markers, resource
+                        copying, and duplicate-function validation.
+                    </li>
+                    <li><strong><code>Manifest</code></strong> controls metadata for the generated PowerShell module
+                        manifest and package metadata reuse.
+                    </li>
+                    <li><strong><code>Package</code></strong> controls package creation and optional raw HTTP upload
+                        defaults.
+                    </li>
+                    <li><strong><code>Pester</code></strong> controls the test run configuration used by <code>Test-NovaBuild</code>.
+                    </li>
+                </ol>
+                <div class="notice">
+                    <strong>Default behavior matters.</strong>
+                    <p>You only need to add settings when you want to override the default workflow. For example, if you
+                        never add a <code>Package</code> section, <code>Pack-NovaModule</code> still works and defaults
+                        to a single <code>.nupkg</code> written to <code>artifacts/packages/</code>.</p>
+                </div>
+                <div class="notice notice--warning">
+                    <strong>Important compatibility note.</strong>
+                    <p>The runtime and shipped examples currently use some manifest and Pester fields more broadly than
+                        the JSON schema files explicitly enumerate. In practice, the current product and examples use
+                        <code>Manifest.ReleaseNotes</code>, <code>Manifest.LicenseUri</code>,
+                        <code>Manifest.IconUri</code>, and <code>Pester.TestResult.OutputFormat</code>. The reference
+                        below documents the live behavior that the product uses today and calls out those schema gaps
+                        where they matter.</p>
+                </div>
+            </section>
+
+            <section class="content-section" id="example">
+                <h2>Complete example</h2>
+                <p>The packaged example project is the best real-world reference because it shows the current full
+                    configuration surface in one place.</p>
+                <pre><code>{
+  "ProjectName": "NovaExampleModule",
+  "Description": "A working example project that demonstrates how to build, test, package, and upload a small module with NovaModuleTools.",
+  "Version": "0.1.0",
+  "CopyResourcesToModuleRoot": false,
+  "BuildRecursiveFolders": true,
+  "SetSourcePath": true,
+  "FailOnDuplicateFunctionNames": true,
+  "Preamble": [
+    "Set-StrictMode -Version Latest",
+    "$ErrorActionPreference = 'Stop'"
+  ],
+  "Manifest": {
+    "Author": "NovaModuleTools",
+    "PowerShellHostVersion": "7.4",
+    "GUID": "b3b4ca64-a274-4768-872d-2b3c8bc12a39",
+    "Tags": ["Example", "NovaModuleTools", "PowerShell"],
+    "ProjectUri": "https://www.novamoduletools.com/",
+    "ReleaseNotes": "https://www.novamoduletools.com/release-notes.html",
+    "LicenseUri": "https://www.novamoduletools.com/license.html"
+  },
+  "Package": {
+    "Id": "NovaExampleModule",
+    "Types": ["NuGet", "Zip"],
+    "Latest": true,
+    "OutputDirectory": {
+      "Path": "artifacts/packages",
+      "Clean": true
+    },
+    "PackageFileName": "NovaExampleModule.0.1.0",
+    "FileNamePattern": "NovaExampleModule*",
+    "Authors": ["NovaModuleTools", "Example Maintainer"],
+    "Description": "Example package metadata and raw upload configuration for NovaExampleModule.",
+    "RepositoryUrl": "https://packages.example.test/raw/novamodule/",
+    "UploadPath": "stable/latest",
+    "Headers": {
+      "X-Client-Id": "nova-example"
+    },
+    "Auth": {
+      "HeaderName": "Authorization",
+      "Scheme": "Bearer",
+      "TokenEnvironmentVariable": "NOVA_EXAMPLE_PACKAGE_TOKEN"
+    },
+    "Repositories": [
+      {
+        "Name": "ExampleRaw",
+        "Url": "https://packages.example.test/raw/novamodule/"
+      }
+    ]
+  },
+  "Pester": {
+    "TestResult": {
+      "Enabled": true,
+      "OutputFormat": "NUnitXml"
+    },
+    "Output": {
+      "Verbosity": "Detailed"
+    }
+  }
+}</code></pre>
+                <p><a class="text-link" href="./working-with-modules.html#example-project">See how to use the packaged
+                    example as a learning project</a></p>
+            </section>
+
+            <section class="content-section" id="top-level">
+                <h2>Top-level project settings</h2>
+                <div class="table-scroll">
+                    <table>
+                        <thead>
+                        <tr>
+                            <th>Setting</th>
+                            <th>Purpose</th>
+                            <th>Default</th>
+                            <th>Workflow effect</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <td><code>ProjectName</code></td>
+                            <td>Name of the module and the output folder under <code>dist/</code>.</td>
+                            <td>Required</td>
+                            <td>Determines manifest name, module name, and many generated paths.</td>
+                        </tr>
+                        <tr>
+                            <td><code>Description</code></td>
+                            <td>Human-readable project description.</td>
+                            <td>Required</td>
+                            <td>Feeds manifest and package metadata when you do not override them later.</td>
+                        </tr>
+                        <tr>
+                            <td><code>Version</code></td>
+                            <td>Current semantic version stored for the project.</td>
+                            <td>Required</td>
+                            <td>Used in package names, manifest metadata, <code>nova version</code>, and release flows.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><code>CopyResourcesToModuleRoot</code></td>
+                            <td>Controls where resources are copied in the built module.</td>
+                            <td><code>false</code></td>
+                            <td>When <code>false</code>, resources stay in a <code>resources/</code> folder. When <code>true</code>,
+                                they are copied into the module root.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><code>BuildRecursiveFolders</code></td>
+                            <td>Controls recursive discovery for classes, private helpers, and tests.</td>
+                            <td><code>true</code></td>
+                            <td>Affects how nested source files and nested tests are discovered.</td>
+                        </tr>
+                        <tr>
+                            <td><code>SetSourcePath</code></td>
+                            <td>Controls <code># Source:</code> markers in the generated <code>.psm1</code>.</td>
+                            <td><code>true</code></td>
+                            <td>Makes parser and runtime errors easier to map back to source files.</td>
+                        </tr>
+                        <tr>
+                            <td><code>FailOnDuplicateFunctionNames</code></td>
+                            <td>Fails the build when duplicate top-level function names are emitted.</td>
+                            <td><code>true</code></td>
+                            <td>Protects the generated module from ambiguous exports and hidden overwrites.</td>
+                        </tr>
+                        <tr>
+                            <td><code>Preamble</code></td>
+                            <td>Optional lines written at the top of the generated <code>.psm1</code>.</td>
+                            <td>Empty array</td>
+                            <td>Useful for <code>Set-StrictMode</code>, <code>$ErrorActionPreference</code>, or other
+                                module-wide setup lines.
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <h3>Examples</h3>
+                <pre><code>{
+  "CopyResourcesToModuleRoot": true,
+  "BuildRecursiveFolders": false,
+  "SetSourcePath": true,
+  "FailOnDuplicateFunctionNames": true,
+  "Preamble": [
+    "Set-StrictMode -Version Latest",
+    "$ErrorActionPreference = 'Stop'"
+  ]
+}</code></pre>
+                <p>Use this pattern when you want strict runtime defaults, top-level-only test discovery, and resources
+                    copied directly to the module root.</p>
+            </section>
+
+            <section class="content-section" id="manifest">
+                <h2><code>Manifest</code> settings</h2>
+                <p>These settings feed the generated PowerShell module manifest and, in several cases, package
+                    metadata.</p>
+                <div class="table-scroll">
+                    <table>
+                        <thead>
+                        <tr>
+                            <th>Setting</th>
+                            <th>Required</th>
+                            <th>What it does</th>
+                            <th>Notes</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <td><code>Author</code></td>
+                            <td>Yes</td>
+                            <td>Sets the manifest author and the default package author when
+                                <code>Package.Authors</code> is omitted.
+                            </td>
+                            <td>Use a single author string; package logic can later expand into arrays.</td>
+                        </tr>
+                        <tr>
+                            <td><code>PowerShellHostVersion</code></td>
+                            <td>Yes</td>
+                            <td>Defines the minimum PowerShell version expected by the generated module.</td>
+                            <td>Users see this in the manifest and module compatibility expectations.</td>
+                        </tr>
+                        <tr>
+                            <td><code>GUID</code></td>
+                            <td>Yes</td>
+                            <td>Sets the manifest GUID.</td>
+                            <td>Generate a new GUID for each distinct module.</td>
+                        </tr>
+                        <tr>
+                            <td><code>Tags</code></td>
+                            <td>No</td>
+                            <td>Adds manifest tags and is reused by package metadata when present.</td>
+                            <td>Optional in practice and safe to omit.</td>
+                        </tr>
+                        <tr>
+                            <td><code>ProjectUri</code></td>
+                            <td>No</td>
+                            <td>Publishes a project URL in the manifest and package metadata.</td>
+                            <td>Explicitly described in the current build schema.</td>
+                        </tr>
+                        <tr>
+                            <td><code>ReleaseNotes</code></td>
+                            <td>No</td>
+                            <td>Publishes a release notes link for packaging and user-facing metadata.</td>
+                            <td>Used by the current product and examples even though the build schema does not enumerate
+                                it separately yet.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><code>LicenseUri</code></td>
+                            <td>No</td>
+                            <td>Publishes a license URL for packaging and manifest metadata.</td>
+                            <td>Used in practice and shown in the packaged example.</td>
+                        </tr>
+                        <tr>
+                            <td><code>IconUri</code></td>
+                            <td>No</td>
+                            <td>Publishes an icon URL in the manifest.</td>
+                            <td>Used by the repository project itself and worth keeping stable when you publish
+                                publicly.
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <p class="tiny-note">If <code>Tags</code>, <code>ProjectUri</code>, <code>ReleaseNotes</code>, or <code>LicenseUri</code>
+                    are omitted, packaging still succeeds. The corresponding package metadata fields are simply left
+                    out.</p>
+            </section>
+
+            <section class="content-section" id="package">
+                <h2><code>Package</code> settings</h2>
+                <p>The <code>Package</code> section controls two related but different concerns:</p>
+                <ul class="plain-list">
+                    <li><strong>package creation</strong> via <code>Pack-NovaModule</code> / <code>nova pack</code></li>
+                    <li><strong>raw HTTP artifact upload</strong> via <code>Upload-NovaPackage</code> / <code>nova
+                        upload</code></li>
+                </ul>
+                <div class="notice">
+                    <strong>Keep these concepts separate.</strong>
+                    <p><code>Package.Types</code>, <code>Package.Latest</code>, and <code>OutputDirectory</code> decide
+                        what gets created. <code>RepositoryUrl</code>, <code>Headers</code>, <code>Auth</code>, and
+                        <code>Repositories</code> decide how existing artifacts are uploaded later.</p>
+                </div>
+
+                <h3>Package creation settings</h3>
+                <div class="table-scroll">
+                    <table>
+                        <thead>
+                        <tr>
+                            <th>Setting</th>
+                            <th>Default</th>
+                            <th>What it controls</th>
+                            <th>Gotchas</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <td><code>Id</code></td>
+                            <td><code>ProjectName</code></td>
+                            <td>The package identifier and default naming base.</td>
+                            <td>Override this only when the package identity should differ from the module name.</td>
+                        </tr>
+                        <tr>
+                            <td><code>Types</code></td>
+                            <td><code>["NuGet"]</code></td>
+                            <td>Which package formats to create.</td>
+                            <td>Supported values are <code>NuGet</code>, <code>Zip</code>, <code>.nupkg</code>, and
+                                <code>.zip</code>, and matching is case-insensitive.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><code>Latest</code></td>
+                            <td><code>false</code></td>
+                            <td>Whether to create companion <code>latest</code> artifacts for each selected type.</td>
+                            <td>When <code>true</code>, Nova keeps the normal versioned artifact and adds a second file
+                                such as <code>MyModule.latest.nupkg</code>.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><code>OutputDirectory.Path</code></td>
+                            <td><code>artifacts/packages</code></td>
+                            <td>Where packages are written.</td>
+                            <td>This is also the default discovery location for <code>Upload-NovaPackage</code>.</td>
+                        </tr>
+                        <tr>
+                            <td><code>OutputDirectory.Clean</code></td>
+                            <td><code>true</code></td>
+                            <td>Whether to clear the output directory before packaging.</td>
+                            <td>Set it to <code>false</code> only when you intentionally want to retain older files.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><code>PackageFileName</code></td>
+                            <td><code>&lt;Id&gt;.&lt;Version&gt;.nupkg</code></td>
+                            <td>Base file name used for package generation.</td>
+                            <td>Nova normalizes the extension per package type and swaps the version suffix for <code>latest</code>
+                                when needed.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><code>FileNamePattern</code></td>
+                            <td><code>&lt;Id&gt;*</code> in practice</td>
+                            <td>Pattern used to discover matching package files for upload.</td>
+                            <td>Keep it wide enough to include both versioned and <code>latest</code> artifacts when you
+                                use <code>Package.Latest</code>.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><code>Authors</code></td>
+                            <td>Derived from <code>Manifest.Author</code></td>
+                            <td>Package author metadata.</td>
+                            <td>Can be a single string or an array of strings.</td>
+                        </tr>
+                        <tr>
+                            <td><code>Description</code></td>
+                            <td>Derived from top-level <code>Description</code></td>
+                            <td>Package description metadata.</td>
+                            <td>Use this when the package description should differ from the module description.</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <h3>Raw upload settings</h3>
+                <div class="table-scroll">
+                    <table>
+                        <thead>
+                        <tr>
+                            <th>Setting</th>
+                            <th>What it does</th>
+                            <th>Notes</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <td><code>RepositoryUrl</code></td>
+                            <td>Canonical package-level raw upload base URL.</td>
+                            <td>Use this when you only need one default upload target.</td>
+                        </tr>
+                        <tr>
+                            <td><code>RawRepositoryUrl</code></td>
+                            <td>Legacy compatibility alias.</td>
+                            <td>If present, it still maps into <code>RepositoryUrl</code> when the canonical setting is
+                                missing.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><code>UploadPath</code></td>
+                            <td>Optional extra path segment appended before the file name during upload.</td>
+                            <td>Useful for folder-style raw repositories such as <code>stable/latest</code> or <code>preview</code>.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><code>Headers</code></td>
+                            <td>Generic additional HTTP headers.</td>
+                            <td>Merged with repository-specific headers and dynamic parameter headers when you invoke
+                                upload.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><code>Auth.HeaderName</code></td>
+                            <td>Name of the authentication header to emit.</td>
+                            <td>Examples: <code>Authorization</code>, <code>X-Api-Key</code>.</td>
+                        </tr>
+                        <tr>
+                            <td><code>Auth.Scheme</code></td>
+                            <td>Optional scheme prefix for the auth header value.</td>
+                            <td>Examples: <code>Bearer</code>, <code>Basic</code>.</td>
+                        </tr>
+                        <tr>
+                            <td><code>Auth.Token</code></td>
+                            <td>Literal token value.</td>
+                            <td>Good for local testing only. Prefer environment variables for real secrets.</td>
+                        </tr>
+                        <tr>
+                            <td><code>Auth.TokenEnvironmentVariable</code></td>
+                            <td>Name of the environment variable that stores the token value.</td>
+                            <td>This should be the variable name, not the secret itself.</td>
+                        </tr>
+                        <tr>
+                            <td><code>Repositories</code></td>
+                            <td>Named upload targets with optional overrides.</td>
+                            <td>Each repository needs <code>Name</code> and <code>Url</code>, then can add <code>UploadPath</code>,
+                                <code>Headers</code>, and <code>Auth</code>.
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <h3>Authentication examples</h3>
+                <pre><code>{
+  "Package": {
+    "RepositoryUrl": "https://packages.example/raw/",
+    "Auth": {
+      "HeaderName": "Authorization",
+      "Scheme": "Bearer",
+      "TokenEnvironmentVariable": "NOVA_PACKAGE_TOKEN"
+    }
+  }
+}</code></pre>
+                <p>Use this for bearer-token-style endpoints.</p>
+                <pre><code>{
+  "Package": {
+    "Repositories": [
+      {
+        "Name": "RawRepo",
+        "Url": "https://packages.example/raw/",
+        "Auth": {
+          "HeaderName": "X-Api-Key",
+          "TokenEnvironmentVariable": "NOVA_PACKAGE_API_KEY"
+        }
+      }
+    ]
+  }
+}</code></pre>
+                <p>Use this for custom API-key headers.</p>
+                <pre><code>{
+  "Package": {
+    "Repositories": [
+      {
+        "Name": "LocalNexus",
+        "Url": "http://localhost:8081/repository/raw/modules/",
+        "Auth": {
+          "HeaderName": "Authorization",
+          "Scheme": "Basic",
+          "TokenEnvironmentVariable": "NOVA_NEXUS_BASIC_AUTH"
+        }
+      }
+    ]
+  }
+}</code></pre>
+                <p>Use this generic model for Basic auth when the endpoint expects a pre-encoded token value. In that
+                    case, the environment variable should hold the Base64 value for <code>username:password</code>, not
+                    the raw username or password.</p>
+            </section>
+
+            <section class="content-section" id="pester">
+                <h2><code>Pester</code> settings</h2>
+                <p>NovaModuleTools passes your <code>Pester</code> settings into the test run configuration used by
+                    <code>Test-NovaBuild</code>.</p>
+                <div class="table-scroll">
+                    <table>
+                        <thead>
+                        <tr>
+                            <th>Setting</th>
+                            <th>Current usage</th>
+                            <th>Default/Example</th>
+                            <th>Where you see it</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <td><code>Pester.TestResult.Enabled</code></td>
+                            <td>Controls whether test results are configured for output.</td>
+                            <td><code>true</code> in the project template and packaged example</td>
+                            <td>Influences the generated test result artifact behavior.</td>
+                        </tr>
+                        <tr>
+                            <td><code>Pester.TestResult.OutputFormat</code></td>
+                            <td>Passed through by the current project template and examples.</td>
+                            <td><code>NUnitXml</code></td>
+                            <td>Determines the result format written to <code>artifacts/TestResults.xml</code>.</td>
+                        </tr>
+                        <tr>
+                            <td><code>Pester.Output.Verbosity</code></td>
+                            <td>Controls Pester console verbosity.</td>
+                            <td><code>Detailed</code> in the current project template</td>
+                            <td>Affects what you see during <code>Test-NovaBuild</code> and <code>nova test</code>.</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <p class="tiny-note">At runtime, <code>Test-NovaBuild</code> also lets you override verbosity and render
+                    mode temporarily with <code>-OutputVerbosity</code> and <code>-OutputRenderMode</code>.</p>
+            </section>
+
+            <section class="content-section" id="recipes">
+                <h2>Common recipes</h2>
+                <h3>Minimal module project</h3>
+                <pre><code>{
+  "ProjectName": "MyModule",
+  "Description": "My module",
+  "Version": "0.1.0",
+  "Manifest": {
+    "Author": "You",
+    "PowerShellHostVersion": "7.4",
+    "GUID": "00000000-0000-0000-0000-000000000000"
+  }
+}</code></pre>
+                <p>Use this when you want the smallest workable Nova project with default build, test, and packaging
+                    behavior.</p>
+
+                <h3>Create both NuGet and Zip artifacts, plus latest aliases</h3>
+                <pre><code>{
+  "Package": {
+    "Types": ["NuGet", "Zip"],
+    "Latest": true,
+    "OutputDirectory": {
+      "Path": "artifacts/packages",
+      "Clean": true
+    }
+  }
+}</code></pre>
+                <p>This creates four files when both package types are selected: versioned and <code>latest</code>
+                    variants for each format.</p>
+
+                <h3>Use named raw repositories with shared defaults</h3>
+                <pre><code>{
+  "Package": {
+    "RepositoryUrl": "https://packages.example/raw/default/",
+    "Headers": {
+      "X-Client": "my-module"
+    },
+    "Auth": {
+      "HeaderName": "Authorization",
+      "Scheme": "Bearer",
+      "TokenEnvironmentVariable": "NOVA_PACKAGE_TOKEN"
+    },
+    "Repositories": [
+      {
+        "Name": "Stable",
+        "Url": "https://packages.example/raw/stable/"
+      },
+      {
+        "Name": "Preview",
+        "Url": "https://packages.example/raw/preview/",
+        "UploadPath": "nightly"
+      }
+    ]
+  }
+}</code></pre>
+                <p>Use package-level values for the shared default behavior, then override only the repository-specific
+                    parts that need to change.</p>
+            </section>
+        </div>
+    </section>
+</main>
+
+<footer class="footer">
+    <div class="footer__inner">
+        <h2>Ready to apply these settings?</h2>
+        <p>Use the packaged example when you want a live project that demonstrates the current configuration surface, or
+            move to the delivery guides when you are ready to package and publish.</p>
+        <div class="hero__actions">
+            <a class="button button--primary" href="./working-with-modules.html">Open the example project guide</a>
+            <a class="button button--secondary" href="./packaging-and-delivery.html">Open packaging and delivery
+                workflows</a>
+        </div>
+        <p class="footer__legal">Also available: <a class="legal-link" href="./commands.html">Command Reference</a>, <a
+                class="legal-link" href="./release-notes.html">Release Notes</a>, and the <a class="legal-link"
+                                                                                             href="./license.html">MIT
+            License</a>.</p>
+    </div>
+</footer>
+</body>
+</html>
+

--- a/docs/project-json-reference.html
+++ b/docs/project-json-reference.html
@@ -39,16 +39,27 @@
             <img alt="" class="site-brand__icon" src="./assets/icon.png">
             <span class="site-brand__text">NovaModuleTools</span>
         </a>
-        <nav aria-label="Primary" class="site-nav">
-            <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
-            <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
-            <a class="site-nav__link site-nav__link--active" href="./project-json-reference.html">project.json</a>
-            <a class="site-nav__link" href="./commands.html">Commands</a>
-            <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
-            <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
-            <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
-            <a class="site-nav__link" href="./advanced.html">Concepts</a>
-        </nav>
+        <details class="site-menu">
+            <summary class="site-menu__button">
+                <span class="site-menu__button-label">Menu</span>
+                <span class="site-menu__current">project.json Reference</span>
+            </summary>
+            <nav aria-label="Primary" class="site-menu__panel">
+                <a class="site-nav__link" href="./index.html">Home</a>
+                <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
+                <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
+                <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+                <a aria-current="page" class="site-nav__link site-nav__link--active"
+                   href="./project-json-reference.html">project.json Reference</a>
+                <a class="site-nav__link" href="./commands.html">Command Reference</a>
+                <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+                <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
+                <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
+                <a class="site-nav__link" href="./advanced.html">Concepts</a>
+                <a class="site-nav__link" href="./release-notes.html">Release Notes</a>
+                <a class="site-nav__link" href="./license.html">License</a>
+            </nav>
+        </details>
     </div>
 </header>
 
@@ -115,7 +126,7 @@
                     configuration surface in one place.</p>
                 <pre><code>{
   "ProjectName": "NovaExampleModule",
-  "Description": "A working example project that demonstrates how to build, test, package, and upload a small module with NovaModuleTools.",
+  "Description": "A working example project that demonstrates NovaModuleTools.",
   "Version": "0.1.0",
   "CopyResourcesToModuleRoot": false,
   "BuildRecursiveFolders": true,
@@ -666,4 +677,3 @@
 </footer>
 </body>
 </html>
-

--- a/docs/release-notes.html
+++ b/docs/release-notes.html
@@ -39,16 +39,27 @@
             <img alt="" class="site-brand__icon" src="./assets/icon.png">
             <span class="site-brand__text">NovaModuleTools</span>
         </a>
-        <nav aria-label="Primary" class="site-nav">
-            <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
-            <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
-            <a class="site-nav__link" href="./project-json-reference.html">project.json</a>
-            <a class="site-nav__link" href="./commands.html">Commands</a>
-            <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
-            <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
-            <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
-            <a class="site-nav__link" href="./advanced.html">Concepts</a>
-        </nav>
+        <details class="site-menu">
+            <summary class="site-menu__button">
+                <span class="site-menu__button-label">Menu</span>
+                <span class="site-menu__current">Release Notes</span>
+            </summary>
+            <nav aria-label="Primary" class="site-menu__panel">
+                <a class="site-nav__link" href="./index.html">Home</a>
+                <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
+                <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
+                <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+                <a class="site-nav__link" href="./project-json-reference.html">project.json Reference</a>
+                <a class="site-nav__link" href="./commands.html">Command Reference</a>
+                <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+                <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
+                <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
+                <a class="site-nav__link" href="./advanced.html">Concepts</a>
+                <a aria-current="page" class="site-nav__link site-nav__link--active" href="./release-notes.html">Release
+                    Notes</a>
+                <a class="site-nav__link" href="./license.html">License</a>
+            </nav>
+        </details>
     </div>
 </header>
 

--- a/docs/release-notes.html
+++ b/docs/release-notes.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
-    <title>NovaModuleTools — Release notes for PowerShell module workflow updates</title>
-    <meta content="Read the latest NovaModuleTools release notes, feature updates, fixes, and documentation changes for the PowerShell module workflow."
+    <title>NovaModuleTools — Release notes for end-user workflow changes</title>
+    <meta content="Read NovaModuleTools release notes for developer-facing workflow changes, new commands, configuration updates, fixes, and documentation improvements."
           name="description">
     <meta content="index,follow,max-image-preview:large" name="robots">
     <meta content="#0b1020" name="theme-color">
@@ -12,14 +12,14 @@
     <link href="./assets/icon.png" rel="icon" type="image/png">
     <link href="./assets/icon.png" rel="apple-touch-icon">
     <meta content="article" property="og:type">
-    <meta content="NovaModuleTools — Release notes for PowerShell module workflow updates" property="og:title">
-    <meta content="Read the latest NovaModuleTools release notes, feature updates, fixes, and documentation changes."
+    <meta content="NovaModuleTools — Release notes for end-user workflow changes" property="og:title">
+    <meta content="Read NovaModuleTools release notes for developer-facing workflow changes, new commands, configuration updates, fixes, and documentation improvements."
           property="og:description">
     <meta content="https://www.novamoduletools.com/release-notes.html" property="og:url">
     <meta content="https://www.novamoduletools.com/assets/icon.png" property="og:image">
     <meta content="summary" name="twitter:card">
-    <meta content="NovaModuleTools — Release notes for PowerShell module workflow updates" name="twitter:title">
-    <meta content="Read the latest NovaModuleTools release notes, feature updates, fixes, and documentation changes."
+    <meta content="NovaModuleTools — Release notes for end-user workflow changes" name="twitter:title">
+    <meta content="Read NovaModuleTools release notes for developer-facing workflow changes, new commands, configuration updates, fixes, and documentation improvements."
           name="twitter:description">
     <link href="./assets/site.css" rel="stylesheet">
     <script type="application/ld+json">
@@ -42,9 +42,12 @@
         <nav aria-label="Primary" class="site-nav">
             <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
             <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
-            <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+            <a class="site-nav__link" href="./project-json-reference.html">project.json</a>
+            <a class="site-nav__link" href="./commands.html">Commands</a>
+            <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+            <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
             <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
-            <a class="site-nav__link" href="./advanced.html">Advanced</a>
+            <a class="site-nav__link" href="./advanced.html">Concepts</a>
         </nav>
     </div>
 </header>
@@ -52,22 +55,30 @@
 <main class="page-shell">
     <section class="guide-hero">
         <p class="eyebrow">Release notes</p>
-        <h1>Read NovaModuleTools release notes directly on the site</h1>
+        <h1>Track what changed in NovaModuleTools</h1>
+        <p class="lead">Use this page to see workflow changes that matter to developers using NovaModuleTools: new
+            commands, changed configuration behavior, packaging and upload improvements, fixes, and documentation
+            updates.</p>
     </section>
 
     <section class="release-notes-shell">
         <div class="guide-content guide-content--single">
             <section class="content-section">
-                <h2>What you will find here</h2>
-                <p>This page summarizes NovaModuleTools updates for developers who use the tool to scaffold, build,
-                    test, version, and release PowerShell modules.</p>
-                <p>If you are new to the tool, start with <a class="text-link" href="./getting-started.html">Getting
-                    Started</a> and then continue to <a class="text-link" href="./core-workflows.html">Core
-                    Workflows</a>.</p>
+                <h2>When to use release notes vs the rest of the docs</h2>
+                <ul class="plain-list">
+                    <li>Use the main docs pages when you need to learn or run a workflow.</li>
+                    <li>Use release notes when you want to know what changed between versions.</li>
+                    <li>Use both when you are upgrading and want to understand whether your current workflow or
+                        configuration needs attention.
+                    </li>
+                </ul>
+                <p>If you are new to Nova, start with <a class="text-link" href="./getting-started.html">Getting
+                    Started</a>. If you are already using Nova and want upgrade context, stay here and then jump into
+                    the relevant workflow page.</p>
             </section>
         </div>
         <p aria-live="polite" class="release-notes-status" id="release-notes-status">Loading release notes from the
-            branch…</p>
+            current branch…</p>
         <section class="release-notes-card">
             <div class="release-notes-content" id="release-notes-content">
                 <p>Release notes will appear here when the page finishes loading.</p>
@@ -82,9 +93,14 @@
 
 <footer class="footer">
     <div class="footer__inner">
-        <p class="footer__legal">NovaModuleTools is distributed under the <a class="legal-link" href="./license.html">MIT
-            License</a> and publishes <a class="legal-link" href="./release-notes.html">Release Notes</a> on this
-            site.</p>
+        <h2>Need more than a changelog entry?</h2>
+        <p>After you identify the version change you care about, use the workflow and reference pages on this site to
+            see the full current behavior and examples.</p>
+        <div class="hero__actions">
+            <a class="button button--primary" href="./commands.html">Open Command Reference</a>
+            <a class="button button--secondary" href="./project-json-reference.html">Open project.json Reference</a>
+        </div>
+        <p class="footer__legal">Also available: <a class="legal-link" href="./license.html">MIT License</a>.</p>
     </div>
 </footer>
 <script src="./assets/marked.umd.min.js"></script>

--- a/docs/release-notes.html
+++ b/docs/release-notes.html
@@ -57,7 +57,6 @@
                 <a class="site-nav__link" href="./advanced.html">Concepts</a>
                 <a aria-current="page" class="site-nav__link site-nav__link--active" href="./release-notes.html">Release
                     Notes</a>
-                <a class="site-nav__link" href="./license.html">License</a>
             </nav>
         </details>
     </div>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -13,15 +13,27 @@
         <loc>https://www.novamoduletools.com/working-with-modules.html</loc>
     </url>
     <url>
-        <loc>https://www.novamoduletools.com/troubleshooting.html</loc>
-    </url>
-    <url>
         <loc>https://www.novamoduletools.com/advanced.html</loc>
     </url>
     <url>
-        <loc>https://www.novamoduletools.com/license.html</loc>
+        <loc>https://www.novamoduletools.com/project-json-reference.html</loc>
+    </url>
+    <url>
+        <loc>https://www.novamoduletools.com/commands.html</loc>
+    </url>
+    <url>
+        <loc>https://www.novamoduletools.com/packaging-and-delivery.html</loc>
+    </url>
+    <url>
+        <loc>https://www.novamoduletools.com/versioning-and-updates.html</loc>
+    </url>
+    <url>
+        <loc>https://www.novamoduletools.com/troubleshooting.html</loc>
     </url>
     <url>
         <loc>https://www.novamoduletools.com/release-notes.html</loc>
+    </url>
+    <url>
+        <loc>https://www.novamoduletools.com/license.html</loc>
     </url>
 </urlset>

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -40,16 +40,26 @@
             <img alt="" class="site-brand__icon" src="./assets/icon.png">
             <span class="site-brand__text">NovaModuleTools</span>
         </a>
-        <nav aria-label="Primary" class="site-nav">
-            <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
-            <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
-            <a class="site-nav__link" href="./project-json-reference.html">project.json</a>
-            <a class="site-nav__link" href="./commands.html">Commands</a>
-            <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
-            <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
-            <a class="site-nav__link site-nav__link--active" href="./troubleshooting.html">Troubleshooting</a>
-            <a class="site-nav__link" href="./advanced.html">Concepts</a>
-        </nav>
+        <details class="site-menu">
+            <summary class="site-menu__button">
+                <span class="site-menu__button-label">Menu</span>
+                <span class="site-menu__current">Troubleshooting</span>
+            </summary>
+            <nav aria-label="Primary" class="site-menu__panel">
+                <a class="site-nav__link" href="./index.html">Home</a>
+                <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
+                <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
+                <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+                <a class="site-nav__link" href="./project-json-reference.html">project.json Reference</a>
+                <a class="site-nav__link" href="./commands.html">Command Reference</a>
+                <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+                <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
+                <a aria-current="page" class="site-nav__link site-nav__link--active" href="./troubleshooting.html">Troubleshooting</a>
+                <a class="site-nav__link" href="./advanced.html">Concepts</a>
+                <a class="site-nav__link" href="./release-notes.html">Release Notes</a>
+                <a class="site-nav__link" href="./license.html">License</a>
+            </nav>
+        </details>
     </div>
 </header>
 

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
-    <title>NovaModuleTools — Troubleshooting PowerShell module workflow issues</title>
-    <meta content="Fix common NovaModuleTools issues around PowerShell module scaffolding, building, testing, module reloads, and version bumps."
+    <title>NovaModuleTools — Troubleshooting common workflow, package, and update problems</title>
+    <meta content="Fix common NovaModuleTools problems such as project.json lookup failures, init path mistakes, reload issues, missing test results, upload target errors, raw auth confusion, and choosing the wrong delivery command."
           name="description">
     <meta content="index,follow,max-image-preview:large" name="robots">
     <meta content="#0b1020" name="theme-color">
@@ -12,14 +12,15 @@
     <link href="./assets/icon.png" rel="icon" type="image/png">
     <link href="./assets/icon.png" rel="apple-touch-icon">
     <meta content="article" property="og:type">
-    <meta content="NovaModuleTools — Troubleshooting PowerShell module workflow issues" property="og:title">
-    <meta content="Resolve common NovaModuleTools problems around PowerShell module scaffolding, build, test, reload, and version bump workflows."
+    <meta content="NovaModuleTools — Troubleshooting common workflow, package, and update problems" property="og:title">
+    <meta content="Resolve common NovaModuleTools issues around paths, build/test flow, reload behavior, raw package upload, and version/update workflows."
           property="og:description">
     <meta content="https://www.novamoduletools.com/troubleshooting.html" property="og:url">
     <meta content="https://www.novamoduletools.com/assets/icon.png" property="og:image">
     <meta content="summary" name="twitter:card">
-    <meta content="NovaModuleTools — Troubleshooting PowerShell module workflow issues" name="twitter:title">
-    <meta content="Resolve common NovaModuleTools problems around PowerShell module scaffolding, build, test, reload, and version bump workflows."
+    <meta content="NovaModuleTools — Troubleshooting common workflow, package, and update problems"
+          name="twitter:title">
+    <meta content="Resolve common NovaModuleTools issues around paths, build/test flow, reload behavior, raw package upload, and version/update workflows."
           name="twitter:description">
     <link href="./assets/site.css" rel="stylesheet">
     <script type="application/ld+json">
@@ -27,7 +28,7 @@
             "@context": "https://schema.org",
             "@type": "TechArticle",
             "headline": "NovaModuleTools troubleshooting",
-            "description": "Resolve common PowerShell module workflow problems in NovaModuleTools.",
+            "description": "Troubleshoot common NovaModuleTools workflow issues.",
             "url": "https://www.novamoduletools.com/troubleshooting.html"
         }
     </script>
@@ -42,9 +43,12 @@
         <nav aria-label="Primary" class="site-nav">
             <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
             <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
-            <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+            <a class="site-nav__link" href="./project-json-reference.html">project.json</a>
+            <a class="site-nav__link" href="./commands.html">Commands</a>
+            <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+            <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
             <a class="site-nav__link site-nav__link--active" href="./troubleshooting.html">Troubleshooting</a>
-            <a class="site-nav__link" href="./advanced.html">Advanced</a>
+            <a class="site-nav__link" href="./advanced.html">Concepts</a>
         </nav>
     </div>
 </header>
@@ -52,68 +56,206 @@
 <main class="page-shell">
     <section class="guide-hero">
         <p class="eyebrow">Troubleshooting</p>
-        <h1>Common NovaModuleTools problems and how to get unstuck</h1>
-        <p class="lead">These are the issues users most often hit while scaffolding, building, testing, and versioning a
-            PowerShell module project.</p>
+        <h1>Fix the problem you can see, not the one you guess</h1>
+        <p class="lead">Use this page when the workflow outcome is confusing. Each section starts from a symptom,
+            explains the likely cause, shows the fix, and tells you what success should look like.</p>
     </section>
 
-    <section class="guide-content guide-content--single">
-        <section class="content-section">
-            <h2><code>nova init some/path</code> does not work</h2>
-            <p>Path input is explicit. Use:</p>
-            <pre><code>nova init -Path ~/Work</code></pre>
-            <p>or, for the full working example:</p>
-            <pre><code>nova init -Example -Path ~/Work</code></pre>
-        </section>
+    <section class="content-grid">
+        <aside class="toc-card">
+            <h2>On this page</h2>
+            <ul class="toc-list">
+                <li><a href="#project-json-not-found">project.json not found</a></li>
+                <li><a href="#nova-init-path">nova init some/path does not work</a></li>
+                <li><a href="#bump-no-commits">nova bump says the repository has no commits yet</a></li>
+                <li><a href="#reload-stale">the module does not reload after build</a></li>
+                <li><a href="#test-results">tests ran but I cannot find the results</a></li>
+                <li><a href="#psm1-errors">build errors point into the generated .psm1</a></li>
+                <li><a href="#install-cli-windows">Install-NovaCli says it is for macOS/Linux only</a></li>
+                <li><a href="#upload-target">upload target URL is missing</a></li>
+                <li><a href="#upload-auth">raw upload auth does not work</a></li>
+                <li><a href="#latest-artifacts">package output contains both versioned and latest artifacts</a></li>
+                <li><a href="#wrong-command">I expected publish, but I only created a package</a></li>
+            </ul>
+        </aside>
 
-        <section class="content-section">
-            <h2><code>nova bump</code> says the repository has no commits yet</h2>
-            <p><code>nova bump</code> chooses the version label from Git history. If the repository exists but has no
-                commits yet, create the first commit and run the command again.</p>
-            <pre><code>git add .
+        <div class="guide-content">
+            <section class="content-section" id="project-json-not-found">
+                <h2><code>project.json</code> not found</h2>
+                <p><strong>Likely cause:</strong> you are not running the command from a Nova project root, or the path
+                    you supplied does not point at a folder that contains <code>project.json</code>.</p>
+                <p><strong>Fix:</strong></p>
+                <pre><code>Set-Location ~/Work/&lt;YourProjectName&gt;
+Get-NovaProjectInfo</code></pre>
+                <p>If you are targeting a different location explicitly, use:</p>
+                <pre><code>Get-NovaProjectInfo -Path ~/Work/&lt;YourProjectName&gt;</code></pre>
+                <p><strong>Success looks like:</strong> <code>Get-NovaProjectInfo</code> returns a project object
+                    instead of throwing <code>Not a project folder. project.json not found</code>.</p>
+                <p><a class="text-link" href="./project-json-reference.html">See the project.json reference</a></p>
+            </section>
+
+            <section class="content-section" id="nova-init-path">
+                <h2><code>nova init some/path</code> does not work</h2>
+                <p><strong>Likely cause:</strong> positional paths are intentionally rejected by the CLI.</p>
+                <p><strong>Fix:</strong></p>
+                <pre><code>nova init -Path some/path
+nova init -Example -Path some/path</code></pre>
+                <p><strong>Success looks like:</strong> Nova accepts the command, prompts for project details, and
+                    creates the new scaffold under the specified parent directory.</p>
+                <p><a class="text-link" href="./getting-started.html#scaffold-example">See the scaffold quickstart</a>
+                </p>
+            </section>
+
+            <section class="content-section" id="bump-no-commits">
+                <h2><code>nova bump</code> says the repository has no commits yet</h2>
+                <p><strong>Likely cause:</strong> the current folder is a Git repository, but it has not recorded its
+                    first commit yet.</p>
+                <p><strong>Fix:</strong></p>
+                <pre><code>git add .
 git commit -m "feat: initial project scaffold"
 nova bump -WhatIf</code></pre>
-        </section>
+                <p><strong>Success looks like:</strong> <code>nova bump -WhatIf</code> shows a planned semantic version
+                    update instead of throwing the “repository has no commits yet” error.</p>
+                <p><a class="text-link" href="./versioning-and-updates.html#bump">See version bump rules</a></p>
+            </section>
 
-        <section class="content-section">
-            <h2>The module does not seem to reload after I rebuild</h2>
-            <p>PowerShell may still have the previous version loaded in memory. Remove the module first, then rebuild
-                and import again:</p>
-            <pre><code>$project = Get-NovaProjectInfo
+            <section class="content-section" id="reload-stale">
+                <h2>The module does not reload after build</h2>
+                <p><strong>Likely cause:</strong> PowerShell still has the older module loaded in memory.</p>
+                <p><strong>Fix:</strong></p>
+                <pre><code>$project = Get-NovaProjectInfo
 Remove-Module $project.ProjectName -ErrorAction SilentlyContinue
 nova build
 Import-Module $project.OutputModuleDir -Force</code></pre>
-        </section>
+                <p><strong>Success looks like:</strong> the imported module reflects your latest source changes.</p>
+                <p><a class="text-link" href="./working-with-modules.html#reload">See the reload guide</a></p>
+            </section>
 
-        <section class="content-section">
-            <h2>Tests fail but I cannot see where the results went</h2>
-            <p>The normal Nova test workflow writes XML results to:</p>
-            <pre><code>artifacts/TestResults.xml</code></pre>
-            <p>If you run Pester directly instead of through <code>nova test</code> / <code>Test-NovaBuild</code>, you
-                may get different output behavior.</p>
-        </section>
+            <section class="content-section" id="test-results">
+                <h2>Tests ran but I cannot find the results</h2>
+                <p><strong>Likely cause:</strong> you expected test output in a different location, or you ran Pester
+                    directly instead of through Nova.</p>
+                <p><strong>Fix:</strong> use the Nova workflow and check:</p>
+                <pre><code>artifacts/TestResults.xml</code></pre>
+                <p><strong>Success looks like:</strong> the file exists after a successful <code>Test-NovaBuild</code>
+                    or <code>nova test</code> run.</p>
+                <p><a class="text-link" href="./core-workflows.html#test">See the test workflow</a></p>
+            </section>
 
-        <section class="content-section">
-            <h2>Build errors point at the generated <code>.psm1</code> file</h2>
-            <p>Enable or keep <code>SetSourcePath</code> in <code>project.json</code>. NovaModuleTools will add <code>#
-                Source:</code> markers to the generated module so you can map errors back to the original files under
-                <code>src/</code>.</p>
-        </section>
+            <section class="content-section" id="psm1-errors">
+                <h2>Build errors point into the generated <code>.psm1</code></h2>
+                <p><strong>Likely cause:</strong> the generated module is showing you the combined output, but you need
+                    to map the error back to source files.</p>
+                <p><strong>Fix:</strong> keep <code>SetSourcePath</code> enabled in <code>project.json</code>.</p>
+                <pre><code>{
+  "SetSourcePath": true
+}</code></pre>
+                <p><strong>Success looks like:</strong> the generated module contains <code># Source:</code> markers
+                    that point back to the originating files under <code>src/</code>.</p>
+                <p><a class="text-link" href="./project-json-reference.html#top-level">See top-level build settings</a>
+                </p>
+            </section>
 
-        <section class="content-section">
-            <h2>I want the normal command flow after fixing an issue</h2>
-            <p>Go back to <a class="text-link" href="./core-workflows.html">Core Workflows</a> for the standard build,
-                test, bump, and release sequence, or use <a class="text-link" href="./working-with-modules.html">Working
-                    with Modules</a> if you need import and reload steps.</p>
-        </section>
+            <section class="content-section" id="install-cli-windows">
+                <h2><code>Install-NovaCli</code> says it is for macOS/Linux only</h2>
+                <p><strong>Likely cause:</strong> that is the current intended behavior. The standalone launcher is for
+                    macOS/Linux shell use.</p>
+                <p><strong>Fix:</strong> on Windows, import the module and use the <code>nova</code> alias inside
+                    PowerShell instead.</p>
+                <pre><code>Import-Module NovaModuleTools
+nova --help</code></pre>
+                <p><strong>Success looks like:</strong> you can run Nova commands from PowerShell on Windows without
+                    installing the standalone launcher.</p>
+                <p><a class="text-link" href="./getting-started.html#entrypoints">See entrypoint guidance</a></p>
+            </section>
+
+            <section class="content-section" id="upload-target">
+                <h2>Upload target URL is missing</h2>
+                <p><strong>Likely cause:</strong> you ran <code>Upload-NovaPackage</code> without <code>-Url</code> and
+                    without package or repository upload settings that resolve to a target URL.</p>
+                <p><strong>Fix:</strong> either pass <code>-Url</code> directly or configure
+                    <code>Package.RepositoryUrl</code> or <code>Package.Repositories[].Url</code>.</p>
+                <pre><code>Upload-NovaPackage -Url 'https://packages.example/raw/'
+
+# or in project.json
+{
+  "Package": {
+    "RepositoryUrl": "https://packages.example/raw/"
+  }
+}</code></pre>
+                <p><strong>Success looks like:</strong> upload resolves a concrete destination URL and starts sending
+                    matching artifacts.</p>
+                <p><a class="text-link" href="./packaging-and-delivery.html#upload">See upload target resolution</a></p>
+            </section>
+
+            <section class="content-section" id="upload-auth">
+                <h2>Raw upload auth does not work</h2>
+                <p><strong>Likely cause:</strong> the header name, scheme, token value, or environment-variable usage
+                    does not match what the raw endpoint expects.</p>
+                <p><strong>Fix checklist:</strong></p>
+                <ul class="plain-list">
+                    <li>Make sure <code>TokenEnvironmentVariable</code> contains the variable name, not the secret value
+                        itself.
+                    </li>
+                    <li>For bearer auth, use <code>HeaderName = "Authorization"</code> and <code>Scheme =
+                        "Bearer"</code>.
+                    </li>
+                    <li>For custom API keys, use the exact header name the server expects.</li>
+                    <li>For Basic auth, put the Base64-encoded <code>username:password</code> value in the environment
+                        variable and use <code>Scheme = "Basic"</code>.
+                    </li>
+                </ul>
+                <p><strong>Success looks like:</strong> the raw endpoint accepts the request and upload returns result
+                    objects with HTTP status codes instead of authentication failures.</p>
+                <p><a class="text-link" href="./project-json-reference.html#package">See package auth settings</a></p>
+            </section>
+
+            <section class="content-section" id="latest-artifacts">
+                <h2>Package output contains both versioned and <code>latest</code> artifacts</h2>
+                <p><strong>Likely cause:</strong> <code>Package.Latest</code> is enabled.</p>
+                <p><strong>Fix:</strong> if you only want versioned files, remove the setting or set it to
+                    <code>false</code>.</p>
+                <pre><code>{
+  "Package": {
+    "Latest": false
+  }
+}</code></pre>
+                <p><strong>Success looks like:</strong> the next package run creates only the normal versioned
+                    artifacts.</p>
+                <p><a class="text-link" href="./packaging-and-delivery.html#pack">See package output behavior</a></p>
+            </section>
+
+            <section class="content-section" id="wrong-command">
+                <h2>I expected publish, but I only created a package</h2>
+                <p><strong>Likely cause:</strong> you used <code>Pack-NovaModule</code> when you actually wanted <code>Upload-NovaPackage</code>,
+                    <code>Publish-NovaModule</code>, or <code>Invoke-NovaRelease</code>.</p>
+                <p><strong>Fix:</strong> choose the command based on the outcome you need:</p>
+                <ul class="plain-list">
+                    <li><strong>package file only:</strong> <code>Pack-NovaModule</code></li>
+                    <li><strong>raw HTTP upload:</strong> <code>Upload-NovaPackage</code></li>
+                    <li><strong>PowerShell repository publish:</strong> <code>Publish-NovaModule</code></li>
+                    <li><strong>version bump + publish orchestration:</strong> <code>Invoke-NovaRelease</code></li>
+                </ul>
+                <p><strong>Success looks like:</strong> the workflow result matches the actual destination you intended.
+                </p>
+                <p><a class="text-link" href="./packaging-and-delivery.html#choose-command">See the delivery command
+                    comparison</a></p>
+            </section>
+        </div>
     </section>
 </main>
 
 <footer class="footer">
     <div class="footer__inner">
-        <p class="footer__legal">NovaModuleTools is distributed under the <a class="legal-link" href="./license.html">MIT
-            License</a> and publishes <a class="legal-link" href="./release-notes.html">Release Notes</a> on this
-            site.</p>
+        <h2>If the symptom is clear, the fix is usually short</h2>
+        <p>Most Nova issues come down to working in the wrong folder, using the wrong command for the job, or forgetting
+            that the built module in <code>dist/</code> is the thing you should validate.</p>
+        <div class="hero__actions">
+            <a class="button button--primary" href="./commands.html">Open Command Reference</a>
+            <a class="button button--secondary" href="./core-workflows.html">Open Core Workflows</a>
+        </div>
+        <p class="footer__legal">Also available: <a class="legal-link" href="./release-notes.html">Release Notes</a> and
+            the <a class="legal-link" href="./license.html">MIT License</a>.</p>
     </div>
 </footer>
 </body>

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -57,7 +57,6 @@
                 <a aria-current="page" class="site-nav__link site-nav__link--active" href="./troubleshooting.html">Troubleshooting</a>
                 <a class="site-nav__link" href="./advanced.html">Concepts</a>
                 <a class="site-nav__link" href="./release-notes.html">Release Notes</a>
-                <a class="site-nav__link" href="./license.html">License</a>
             </nav>
         </details>
     </div>

--- a/docs/versioning-and-updates.html
+++ b/docs/versioning-and-updates.html
@@ -39,17 +39,27 @@
             <img alt="" class="site-brand__icon" src="./assets/icon.png">
             <span class="site-brand__text">NovaModuleTools</span>
         </a>
-        <nav aria-label="Primary" class="site-nav">
-            <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
-            <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
-            <a class="site-nav__link" href="./project-json-reference.html">project.json</a>
-            <a class="site-nav__link" href="./commands.html">Commands</a>
-            <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
-            <a class="site-nav__link site-nav__link--active" href="./versioning-and-updates.html">Versioning &amp;
-                Updates</a>
-            <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
-            <a class="site-nav__link" href="./advanced.html">Concepts</a>
-        </nav>
+        <details class="site-menu">
+            <summary class="site-menu__button">
+                <span class="site-menu__button-label">Menu</span>
+                <span class="site-menu__current">Versioning &amp; Updates</span>
+            </summary>
+            <nav aria-label="Primary" class="site-menu__panel">
+                <a class="site-nav__link" href="./index.html">Home</a>
+                <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
+                <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
+                <a class="site-nav__link" href="./working-with-modules.html">Working with Modules</a>
+                <a class="site-nav__link" href="./project-json-reference.html">project.json Reference</a>
+                <a class="site-nav__link" href="./commands.html">Command Reference</a>
+                <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+                <a aria-current="page" class="site-nav__link site-nav__link--active"
+                   href="./versioning-and-updates.html">Versioning &amp; Updates</a>
+                <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
+                <a class="site-nav__link" href="./advanced.html">Concepts</a>
+                <a class="site-nav__link" href="./release-notes.html">Release Notes</a>
+                <a class="site-nav__link" href="./license.html">License</a>
+            </nav>
+        </details>
     </div>
 </header>
 
@@ -241,4 +251,3 @@ nova notification -enable</code></pre>
 </footer>
 </body>
 </html>
-

--- a/docs/versioning-and-updates.html
+++ b/docs/versioning-and-updates.html
@@ -57,7 +57,6 @@
                 <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
                 <a class="site-nav__link" href="./advanced.html">Concepts</a>
                 <a class="site-nav__link" href="./release-notes.html">Release Notes</a>
-                <a class="site-nav__link" href="./license.html">License</a>
             </nav>
         </details>
     </div>

--- a/docs/versioning-and-updates.html
+++ b/docs/versioning-and-updates.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta content="width=device-width, initial-scale=1" name="viewport">
+    <title>NovaModuleTools — Versioning, self-update, and notification preferences</title>
+    <meta content="Learn how NovaModuleTools handles semantic version bumps, version display commands, self-update workflows, prerelease eligibility, and notification preferences."
+          name="description">
+    <meta content="index,follow,max-image-preview:large" name="robots">
+    <meta content="#0b1020" name="theme-color">
+    <link href="https://www.novamoduletools.com/versioning-and-updates.html" rel="canonical">
+    <link href="./assets/icon.png" rel="icon" type="image/png">
+    <link href="./assets/icon.png" rel="apple-touch-icon">
+    <meta content="article" property="og:type">
+    <meta content="NovaModuleTools — Versioning, self-update, and notification preferences" property="og:title">
+    <meta content="Use this guide to understand nova bump, version display commands, self-update behavior, and stable versus prerelease update eligibility."
+          property="og:description">
+    <meta content="https://www.novamoduletools.com/versioning-and-updates.html" property="og:url">
+    <meta content="https://www.novamoduletools.com/assets/icon.png" property="og:image">
+    <meta content="summary" name="twitter:card">
+    <meta content="NovaModuleTools — Versioning, self-update, and notification preferences" name="twitter:title">
+    <meta content="Use this guide to understand nova bump, version display commands, self-update behavior, and stable versus prerelease update eligibility."
+          name="twitter:description">
+    <link href="./assets/site.css" rel="stylesheet">
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "TechArticle",
+            "headline": "NovaModuleTools versioning and updates guide",
+            "description": "How to bump versions and self-update NovaModuleTools.",
+            "url": "https://www.novamoduletools.com/versioning-and-updates.html"
+        }
+    </script>
+</head>
+<body>
+<header class="site-header">
+    <div class="site-header__inner">
+        <a class="site-brand" href="./index.html">
+            <img alt="" class="site-brand__icon" src="./assets/icon.png">
+            <span class="site-brand__text">NovaModuleTools</span>
+        </a>
+        <nav aria-label="Primary" class="site-nav">
+            <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
+            <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
+            <a class="site-nav__link" href="./project-json-reference.html">project.json</a>
+            <a class="site-nav__link" href="./commands.html">Commands</a>
+            <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+            <a class="site-nav__link site-nav__link--active" href="./versioning-and-updates.html">Versioning &amp;
+                Updates</a>
+            <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
+            <a class="site-nav__link" href="./advanced.html">Concepts</a>
+        </nav>
+    </div>
+</header>
+
+<main class="page-shell">
+    <section class="guide-hero">
+        <p class="eyebrow">How-to Guides</p>
+        <h1>Version your project intentionally and keep Nova up to date</h1>
+        <p class="lead">NovaModuleTools separates project versioning from self-updating the tool itself. This page
+            explains which command answers which question, how version bumps are chosen from Git history, and how stable
+            versus prerelease self-update eligibility works.</p>
+    </section>
+
+    <section class="content-grid">
+        <aside class="toc-card">
+            <h2>On this page</h2>
+            <ul class="toc-list">
+                <li><a href="#version-views">Choose the right version command</a></li>
+                <li><a href="#bump">Bump project versions</a></li>
+                <li><a href="#self-update">Self-update NovaModuleTools</a></li>
+                <li><a href="#notification-preferences">Manage prerelease eligibility</a></li>
+            </ul>
+        </aside>
+
+        <div class="guide-content">
+            <section class="content-section" id="version-views">
+                <h2>Choose the right version command</h2>
+                <div class="table-scroll">
+                    <table>
+                        <thead>
+                        <tr>
+                            <th>Command</th>
+                            <th>What it shows</th>
+                            <th>When to use it</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <td><code>Get-NovaProjectInfo -Version</code> or <code>nova version</code></td>
+                            <td>The current version stored in the active project's <code>project.json</code>.</td>
+                            <td>Use this when you want to know what your project will build and publish as.</td>
+                        </tr>
+                        <tr>
+                            <td><code>nova version -Installed</code></td>
+                            <td>The version installed locally for the current project/module from the module path.</td>
+                            <td>Use this when you want to compare the installed copy against the current working
+                                project.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><code>nova --version</code></td>
+                            <td>The installed NovaModuleTools version.</td>
+                            <td>Use this when you are troubleshooting Nova itself or checking whether the tool needs an
+                                update.
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <pre><code>nova version
+nova version -Installed
+nova --version</code></pre>
+            </section>
+
+            <section class="content-section" id="bump">
+                <h2>Bump project versions</h2>
+                <p>Use <code>Update-NovaModuleVersion</code> or <code>nova bump</code> when you want Nova to choose the
+                    next semantic version based on Git history.</p>
+                <h3>How Nova chooses the bump label</h3>
+                <ul class="plain-list">
+                    <li><strong>Major</strong> for breaking changes</li>
+                    <li><strong>Minor</strong> for <code>feat:</code> commits</li>
+                    <li><strong>Patch</strong> for <code>fix:</code> commits and all other cases</li>
+                </ul>
+                <p>When Git tags exist, Nova uses commits since the latest tag. When the folder is not a Git repository,
+                    Nova falls back to a patch bump. When the repository exists but has no commits yet, Nova stops with
+                    a clear error.</p>
+                <pre><code>Update-NovaModuleVersion -WhatIf
+nova bump -WhatIf
+nova bump -Confirm</code></pre>
+                <div class="notice notice--warning">
+                    <strong>Empty repository rule.</strong>
+                    <p>If your Git repository exists but has no commits yet, Nova throws: <code>Cannot bump version
+                        because the repository has no commits yet. Create an initial commit first.</code></p>
+                </div>
+                <p>The standalone launcher uses a CLI-friendly confirmation flow for <code>nova bump -Confirm</code>. If
+                    you decline, Nova exits cleanly without writing a new version.</p>
+            </section>
+
+            <section class="content-section" id="self-update">
+                <h2>Self-update NovaModuleTools</h2>
+                <p>Use <code>Update-NovaModuleTool</code>, its compatibility alias <code>Update-NovaModuleTools</code>,
+                    or <code>nova update</code> to update the installed NovaModuleTools module itself.</p>
+                <h3>What self-update does</h3>
+                <ol class="plain-list plain-list--ordered">
+                    <li>Read the stored prerelease preference.</li>
+                    <li>Resolve the best eligible update candidate from PowerShell Gallery.</li>
+                    <li>Apply the update if one is available.</li>
+                    <li>Print the release notes link after a successful update.</li>
+                </ol>
+                <pre><code>Update-NovaModuleTool
+nova update</code></pre>
+                <p>If no newer version is available, <code>nova update</code> prints a friendly “You're up to date!”
+                    message together with the installed NovaModuleTools version.</p>
+                <div class="table-scroll">
+                    <table>
+                        <thead>
+                        <tr>
+                            <th>State</th>
+                            <th>What happens</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <td>Stable update available</td>
+                            <td>Nova can apply it normally without prerelease-specific confirmation.</td>
+                        </tr>
+                        <tr>
+                            <td>Only prerelease update available and prerelease eligibility is enabled</td>
+                            <td>Nova may target the prerelease, but it always asks for explicit confirmation before
+                                updating.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Prerelease eligibility disabled</td>
+                            <td>Nova ignores prerelease targets and stays on stable-only updates.</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            <section class="content-section" id="notification-preferences">
+                <h2>Manage prerelease eligibility</h2>
+                <p>The update preference commands do not update the module by themselves. They only control whether
+                    prerelease self-update targets are eligible when you later run the update command.</p>
+                <pre><code>Get-NovaUpdateNotificationPreference
+Set-NovaUpdateNotificationPreference -DisablePrereleaseNotifications
+Set-NovaUpdateNotificationPreference -EnablePrereleaseNotifications
+nova notification
+nova notification -disable
+nova notification -enable</code></pre>
+                <h3>Recommended choices</h3>
+                <div class="table-scroll">
+                    <table>
+                        <thead>
+                        <tr>
+                            <th>If you are…</th>
+                            <th>Recommended setting</th>
+                            <th>Why</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr>
+                            <td>using Nova on a stable-only workstation or CI runner</td>
+                            <td>Disable prerelease notifications</td>
+                            <td>You avoid prerelease self-update targets entirely.</td>
+                        </tr>
+                        <tr>
+                            <td>testing new Nova features early</td>
+                            <td>Enable prerelease notifications</td>
+                            <td>You allow prerelease targets, but still get an explicit confirmation prompt before they
+                                run.
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <p><code>Get-NovaUpdateNotificationPreference</code> and <code>nova notification</code> return the
+                    current state and the settings path so you can confirm exactly what the stored preference is.</p>
+            </section>
+        </div>
+    </section>
+</main>
+
+<footer class="footer">
+    <div class="footer__inner">
+        <h2>Need release guidance next?</h2>
+        <p>Once your versioning rules are clear, move to the packaging and delivery guides so you can decide whether the
+            next step is package creation, repository publish, or a full release run.</p>
+        <div class="hero__actions">
+            <a class="button button--primary" href="./packaging-and-delivery.html">Open Packaging &amp; Delivery</a>
+            <a class="button button--secondary" href="./troubleshooting.html">Open Troubleshooting</a>
+        </div>
+        <p class="footer__legal">Also available: <a class="legal-link" href="./commands.html">Command Reference</a>, <a
+                class="legal-link" href="./release-notes.html">Release Notes</a>, and the <a class="legal-link"
+                                                                                             href="./license.html">MIT
+            License</a>.</p>
+    </div>
+</footer>
+</body>
+</html>
+

--- a/docs/working-with-modules.html
+++ b/docs/working-with-modules.html
@@ -59,7 +59,6 @@
                 <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
                 <a class="site-nav__link" href="./advanced.html">Concepts</a>
                 <a class="site-nav__link" href="./release-notes.html">Release Notes</a>
-                <a class="site-nav__link" href="./license.html">License</a>
             </nav>
         </details>
     </div>

--- a/docs/working-with-modules.html
+++ b/docs/working-with-modules.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
-    <title>NovaModuleTools — Working with PowerShell modules during development</title>
-    <meta content="Import built PowerShell modules, reload them during local development, and use NovaModuleTools effectively while you iterate."
+    <title>NovaModuleTools — Work with the built module, reload safely, and learn from the packaged example</title>
+    <meta content="Learn why NovaModuleTools is designed around the built module in dist, how to reload after changes, how local publish differs, and how to use the packaged example project as a live reference."
           name="description">
     <meta content="index,follow,max-image-preview:large" name="robots">
     <meta content="#0b1020" name="theme-color">
@@ -12,22 +12,24 @@
     <link href="./assets/icon.png" rel="icon" type="image/png">
     <link href="./assets/icon.png" rel="apple-touch-icon">
     <meta content="article" property="og:type">
-    <meta content="NovaModuleTools — Working with PowerShell modules during development" property="og:title">
-    <meta content="Import, reload, and validate the built PowerShell module during local development with NovaModuleTools."
+    <meta content="NovaModuleTools — Work with the built module, reload safely, and learn from the packaged example"
+          property="og:title">
+    <meta content="Import the built output from dist, reload after changes, compare local publish with the normal build loop, and use the packaged example as a working reference."
           property="og:description">
     <meta content="https://www.novamoduletools.com/working-with-modules.html" property="og:url">
     <meta content="https://www.novamoduletools.com/assets/icon.png" property="og:image">
     <meta content="summary" name="twitter:card">
-    <meta content="NovaModuleTools — Working with PowerShell modules during development" name="twitter:title">
-    <meta content="Import, reload, and validate the built PowerShell module during local development with NovaModuleTools."
+    <meta content="NovaModuleTools — Work with the built module, reload safely, and learn from the packaged example"
+          name="twitter:title">
+    <meta content="Import the built output from dist, reload after changes, compare local publish with the normal build loop, and use the packaged example as a working reference."
           name="twitter:description">
     <link href="./assets/site.css" rel="stylesheet">
     <script type="application/ld+json">
         {
             "@context": "https://schema.org",
             "@type": "TechArticle",
-            "headline": "Working with PowerShell modules in NovaModuleTools",
-            "description": "Import, reload, and validate the built PowerShell module during local development.",
+            "headline": "Working with modules in NovaModuleTools",
+            "description": "How to work with the built module and packaged example in NovaModuleTools.",
             "url": "https://www.novamoduletools.com/working-with-modules.html"
         }
     </script>
@@ -42,81 +44,124 @@
         <nav aria-label="Primary" class="site-nav">
             <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
             <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
-            <a class="site-nav__link site-nav__link--active" href="./working-with-modules.html">Working with Modules</a>
+            <a class="site-nav__link" href="./project-json-reference.html">project.json</a>
+            <a class="site-nav__link" href="./commands.html">Commands</a>
+            <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+            <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
             <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
-            <a class="site-nav__link" href="./advanced.html">Advanced</a>
+            <a class="site-nav__link" href="./advanced.html">Concepts</a>
         </nav>
     </div>
 </header>
 
 <main class="page-shell">
     <section class="guide-hero">
-        <p class="eyebrow">Working with modules</p>
-        <h1>Import, reload, and validate the built module during local development</h1>
-        <p class="lead">NovaModuleTools is designed around working with the built PowerShell module in
-            <code>dist/</code>, not just
-            loose script files.</p>
+        <p class="eyebrow">How-to Guides</p>
+        <h1>Work with the built module instead of loose source files</h1>
+        <p class="lead">NovaModuleTools is designed around the module it generates in <code>dist/</code>. This page
+            explains why that matters, how to reload safely during development, how local publish changes the import
+            story, and how to use the packaged example project as a live reference.</p>
     </section>
 
     <section class="content-grid">
         <aside class="toc-card">
             <h2>On this page</h2>
             <ul class="toc-list">
+                <li><a href="#why-dist">Why dist matters</a></li>
                 <li><a href="#import-built">Import the built module</a></li>
                 <li><a href="#reload">Reload after changes</a></li>
-                <li><a href="#local-publish">Use local publish</a></li>
-                <li><a href="#example">Use the packaged example</a></li>
+                <li><a href="#local-publish">Use local publish intentionally</a></li>
+                <li><a href="#example-project">Use the packaged example as a working reference</a></li>
             </ul>
         </aside>
 
         <div class="guide-content">
+            <section class="content-section" id="why-dist">
+                <h2>Why <code>dist/</code> matters</h2>
+                <p>NovaModuleTools does not treat your project as a pile of loose scripts. It treats it as a buildable
+                    PowerShell module project.</p>
+                <p>That means the important runtime artifact is the generated module under <code>dist/&lt;ProjectName&gt;</code>,
+                    because that is the shape Nova later tests, packages, and publishes.</p>
+                <div class="notice">
+                    <strong>Practical rule:</strong>
+                    <p>When you want to validate behavior, import from <code>dist/</code>. If you only load source files
+                        ad hoc, you can miss real packaging or manifest issues that only show up in the built output.
+                    </p>
+                </div>
+            </section>
+
             <section class="content-section" id="import-built">
                 <h2>Import the built module</h2>
-                <p>After building, import the output from <code>dist/&lt;ProjectName&gt;</code>:</p>
                 <pre><code>nova build
 $project = Get-NovaProjectInfo
 Import-Module $project.OutputModuleDir -Force</code></pre>
-                <p>This keeps your runtime behavior aligned with what you intend to publish.</p>
+                <p>Use this after a successful build when you want the session to use the generated module exactly as
+                    Nova produced it.</p>
+                <p><strong>Expected result:</strong> the module imports from <code>dist/&lt;ProjectName&gt;</code>, not
+                    from your source folders.</p>
             </section>
 
             <section class="content-section" id="reload">
                 <h2>Reload after changes</h2>
-                <p>When you edit source files, rebuild and reload the module to avoid using stale code already loaded in
-                    the session:</p>
+                <p>PowerShell can keep an older version of the module loaded in memory. The safe pattern is:</p>
                 <pre><code>$project = Get-NovaProjectInfo
 Remove-Module $project.ProjectName -ErrorAction SilentlyContinue
 nova build
 Import-Module $project.OutputModuleDir -Force</code></pre>
+                <p>Use this every time you edit functions, resources, or manifest-related settings and want to validate
+                    the current state.</p>
+                <p>If you skip the remove/rebuild/import cycle, you can think you are testing current code when you are
+                    really still using an older imported version.</p>
             </section>
 
             <section class="content-section" id="local-publish">
-                <h2>Validate a local publish flow</h2>
-                <p>If you want to test how the module behaves when copied to your local PowerShell module path:</p>
-                <pre><code>nova publish -local</code></pre>
-                <p>This is useful when you want to simulate a more realistic install-and-import cycle without publishing
-                    to a shared repository. After a successful local publish in PowerShell, NovaModuleTools reloads the
-                    published module from the local install path so you can use the freshly published version right
-                    away.</p>
+                <h2>Use local publish intentionally</h2>
+                <pre><code>nova publish -local
+Publish-NovaModule -Local</code></pre>
+                <p>Local publish is different from the normal build/import loop:</p>
+                <ul class="plain-list">
+                    <li>Nova builds the project</li>
+                    <li>Nova runs the tests</li>
+                    <li>Nova copies the module to the resolved local install directory</li>
+                    <li>Nova reloads the published copy into the current PowerShell session after success</li>
+                </ul>
+                <p>Use local publish when you want to simulate a real installed-module experience. Use the normal
+                    build/import loop when you just want fast iteration in <code>dist/</code>.</p>
+                <div class="notice notice--warning">
+                    <strong>Do not confuse local publish with local release.</strong>
+                    <p><code>Invoke-NovaRelease -PublishOption @{ Local = $true }</code> publishes locally too, but it
+                        does <strong>not</strong> import the published module into the current session afterward. That
+                        special import behavior belongs to <code>Publish-NovaModule -Local</code>.</p>
+                </div>
             </section>
 
-            <section class="content-section" id="example">
+            <section class="content-section" id="example-project">
                 <h2>Use the packaged example as a working reference</h2>
-                <p>The packaged example is available through <code>nova init -Example</code>. It is the fastest way to
-                    inspect a complete workflow that includes:</p>
+                <p>The packaged example is more than sample content. It is a maintained project that demonstrates the
+                    Nova workflow in one place.</p>
+                <h3>What the example includes</h3>
                 <ul class="plain-list">
-                    <li>a real <code>project.json</code></li>
-                    <li>a public command</li>
+                    <li>a full <code>project.json</code> with current configuration examples</li>
+                    <li>a public function</li>
                     <li>a private helper</li>
                     <li>a resource file</li>
-                    <li>Pester tests against the built output</li>
+                    <li>Pester tests that validate the built module output</li>
+                    <li>package and raw-upload examples, including <code>Package.Types</code>,
+                        <code>Package.Latest</code>, and named repositories
+                    </li>
                 </ul>
-                <p>If you prefer learning from a working sample first, start there and then adapt the generated project
-                    to your own module.</p>
-                <p>If you have not scaffolded a project yet, go back to <a class="text-link"
-                                                                           href="./getting-started.html">Getting
-                    Started</a>.
-                    For the command sequence after that, use <a class="text-link" href="./core-workflows.html">Core
-                        Workflows</a>.</p>
+                <h3>How to learn from it</h3>
+                <pre><code>nova init -Example -Path ~/Work
+Set-Location ~/Work/&lt;YourProjectName&gt;
+nova build
+nova test
+$project = Get-NovaProjectInfo
+Import-Module $project.OutputModuleDir -Force
+Get-ExampleGreeting</code></pre>
+                <p>Once you understand the example, copy the patterns you want into your own project instead of copying
+                    the whole project blindly.</p>
+                <p><a class="text-link" href="./project-json-reference.html#example">See the example configuration
+                    reference</a></p>
             </section>
         </div>
     </section>
@@ -124,9 +169,17 @@ Import-Module $project.OutputModuleDir -Force</code></pre>
 
 <footer class="footer">
     <div class="footer__inner">
-        <p class="footer__legal">NovaModuleTools is distributed under the <a class="legal-link" href="./license.html">MIT
-            License</a> and publishes <a class="legal-link" href="./release-notes.html">Release Notes</a> on this
-            site.</p>
+        <h2>The built module is the product you are developing</h2>
+        <p>Keep coming back to that idea and Nova becomes much easier to reason about. Build it, test it, import it, and
+            only then decide whether you need packaging, upload, publish, or release.</p>
+        <div class="hero__actions">
+            <a class="button button--primary" href="./packaging-and-delivery.html">Open Packaging &amp; Delivery</a>
+            <a class="button button--secondary" href="./troubleshooting.html">Open Troubleshooting</a>
+        </div>
+        <p class="footer__legal">Also available: <a class="legal-link" href="./commands.html">Command Reference</a>, <a
+                class="legal-link" href="./release-notes.html">Release Notes</a>, and the <a class="legal-link"
+                                                                                             href="./license.html">MIT
+            License</a>.</p>
     </div>
 </footer>
 </body>

--- a/docs/working-with-modules.html
+++ b/docs/working-with-modules.html
@@ -41,16 +41,27 @@
             <img alt="" class="site-brand__icon" src="./assets/icon.png">
             <span class="site-brand__text">NovaModuleTools</span>
         </a>
-        <nav aria-label="Primary" class="site-nav">
-            <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
-            <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
-            <a class="site-nav__link" href="./project-json-reference.html">project.json</a>
-            <a class="site-nav__link" href="./commands.html">Commands</a>
-            <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
-            <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
-            <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
-            <a class="site-nav__link" href="./advanced.html">Concepts</a>
-        </nav>
+        <details class="site-menu">
+            <summary class="site-menu__button">
+                <span class="site-menu__button-label">Menu</span>
+                <span class="site-menu__current">Working with Modules</span>
+            </summary>
+            <nav aria-label="Primary" class="site-menu__panel">
+                <a class="site-nav__link" href="./index.html">Home</a>
+                <a class="site-nav__link" href="./getting-started.html">Getting Started</a>
+                <a class="site-nav__link" href="./core-workflows.html">Core Workflows</a>
+                <a aria-current="page" class="site-nav__link site-nav__link--active" href="./working-with-modules.html">Working
+                    with Modules</a>
+                <a class="site-nav__link" href="./project-json-reference.html">project.json Reference</a>
+                <a class="site-nav__link" href="./commands.html">Command Reference</a>
+                <a class="site-nav__link" href="./packaging-and-delivery.html">Packaging &amp; Delivery</a>
+                <a class="site-nav__link" href="./versioning-and-updates.html">Versioning &amp; Updates</a>
+                <a class="site-nav__link" href="./troubleshooting.html">Troubleshooting</a>
+                <a class="site-nav__link" href="./advanced.html">Concepts</a>
+                <a class="site-nav__link" href="./release-notes.html">Release Notes</a>
+                <a class="site-nav__link" href="./license.html">License</a>
+            </nav>
+        </details>
     </div>
 </header>
 


### PR DESCRIPTION
## Summary

- Wire the CI helper flow to run the repository ScriptAnalyzer helper and emit `scriptanalyzer.txt` into the selected artifacts directory.
- Ensure the CI module installer includes `PSScriptAnalyzer` so the CI helper can run consistently in automation.
- Add a regression test for the CI helper/analyzer wiring and update contributor-facing documentation so the local and CI quality flow is easier to understand.
- This change was needed because `Test-NovaBuild` does not run ScriptAnalyzer by itself, and the documented CI-parity helper flow did not clearly surface ScriptAnalyzer output in the same way as the standalone analyzer helper.
- Follow-up: consider whether import sites should use `-DisableNameChecking` to suppress the non-fatal unapproved verb warning for `Pack-NovaModule` / `Upload-NovaPackage`.

## Affected area

- [ ] `nova` CLI or command routing
- [ ] Public PowerShell cmdlet behavior
- [ ] Scaffolding or `project.json` handling
- [x] Build, test, analyzer, coverage, or CI helper flow
- [ ] Package, raw upload, or package metadata workflow
- [ ] Publish, release, semantic-release, or GitHub Actions automation
- [ ] Self-update or notification preference behavior
- [x] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
- [ ] End-user docs (`docs/*.html`)
- [ ] Command help (`docs/NovaModuleTools/en-US/*.md`)
- [ ] `src/resources/example/`
- [ ] Dependency or manifest changes (`package.json`, workflow dependencies, release tooling)
- [ ] Security-sensitive change
- [ ] Documentation-only change
- [ ] Other

## Review guidance

- Start with `scripts/build/ci/Invoke-NovaModuleToolsCI.ps1` to review the main behavior change: the CI helper now runs the repository ScriptAnalyzer helper and writes the report into the selected output directory.
- Then review `scripts/build/ci/Install-CiPowerShellModules.ps1` to confirm `PSScriptAnalyzer` is installed for CI/local parity.
- Finally review `tests/CiWorkflow.Tests.ps1` and the contributor docs updates in `README.md` / `CHANGELOG.md`.
- Primary files changed:
  - `scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
  - `scripts/build/ci/Install-CiPowerShellModules.ps1`
  - `tests/CiWorkflow.Tests.ps1`
  - `README.md`
  - `CHANGELOG.md`
- Trade-offs / limitations:
  - This keeps the current public command names and does not attempt to resolve the non-fatal import warning about unapproved verbs (`Pack-*`, `Upload-*`).
  - The CI helper uses the repository ScriptAnalyzer helper scope rather than expanding analyzer coverage to the full test suite, which avoids existing test-only warnings from turning the CI helper into a noisy failure path.

## Validation

- [ ] `Invoke-NovaBuild`
- [ ] `Test-NovaBuild`
- [x] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [x] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
- [ ] Targeted Nova workflow validated (`nova build`, `nova test`, `nova pack`, `nova upload`, `nova publish`,
  `nova release`, `nova update`, `nova notification`, or `nova init` as relevant)
- [ ] Docs/example only; executable validation not needed

Validation notes:

```text
Ran the repository ScriptAnalyzer helper directly:

  pwsh -NoLogo -NoProfile -File ./scripts/build/Invoke-ScriptAnalyzerCI.ps1 -OutputDirectory ./artifacts

Observed:
  artifacts/scriptanalyzer.txt
  PSScriptAnalyzer: no findings.

Ran the CI helper end-to-end:

  pwsh -NoLogo -NoProfile -File ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1 -OutputDirectory ./artifacts/ci-check

Observed CI-style artifacts:
  artifacts/ci-check/scriptanalyzer.txt
  artifacts/ci-check/pester-junit.xml
  artifacts/ci-check/pester-coverage.cobertura.xml
  artifacts/ci-check/coverage-low.txt

Verified the ScriptAnalyzer artifact content:
  PSScriptAnalyzer: no findings.

Ran targeted regression tests:
  pwsh -NoLogo -NoProfile -Command '$result = Invoke-Pester -Path ./tests/CiWorkflow.Tests.ps1 -Output Detailed -PassThru; if (-not $result.Passed) { exit 1 }'

Result:
  Tests Passed: 2, Failed: 0, Skipped: 0

`Invoke-NovaBuild` / `Test-NovaBuild` were exercised transitively via the CI helper flow, but not called as standalone validation commands in this check set.
```

## Documentation and release follow-up

- [x] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
- [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
- [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [ ] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
- [ ] `docs/*.html` updated if end-user workflows or examples changed
- [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
  changed
- [ ] No documentation, changelog, or example updates were needed

## Maintainability, compatibility, and risk

- [x] Code Health / maintainability impact considered
- [x] No breaking change
- [ ] Breaking change
- [ ] Security-sensitive change
- [x] CI, workflow, or release-pipeline impact
- [ ] Dependency-review impact

Risk, rollout, or rollback notes:

```text
Compatibility impact is low: this change aligns the CI helper with the documented repository quality flow and adds the missing analyzer dependency for CI installs.

No public command behavior changes are introduced.

If rollback is needed:
- revert the CI helper ScriptAnalyzer invocation
- revert the CI installer addition for PSScriptAnalyzer
- remove the regression test and docs updates

Known follow-up:
- decide whether import sites should suppress the non-fatal PowerShell name-checking warning for Pack-NovaModule / Upload-NovaPackage, or whether those commands should eventually gain approved-verb alternatives.
```

> [!IMPORTANT]
> Do not use a public pull request to disclose a vulnerability before coordinated handling.
> Use the private reporting path in `SECURITY.md` for new security issues.