### PR TITLE
Bug/89 error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix configuration and validation errors so empty `project.json` files and unsupported `Manifest` keys fail fast with
   clear messages.
+- Fix `Update-NovaModuleVersion` / `nova bump` so prerelease versions finalize the correct SemVer target instead of
+  carrying old prerelease labels like `preview7` into the next major, minor, or patch line.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Package output now supports `Package.Types` with case-insensitive `NuGet`, `Zip`, `.nupkg`, and `.zip` values.
     - Omitting `Package.Types` still defaults packaging to a `.nupkg` artifact.
     - Selecting both `NuGet` and `Zip` creates both package formats in the configured output directory.
+  - `Package.AddVersionToFileName` can append the top-level project version to a custom `Package.PackageFileName`
+    before the package extension is applied.
   - Setting `Package.Latest` to `true` also creates a companion `*.latest.*` artifact for each selected package type
     while keeping the normal versioned file.
     - Package output now uses `Package.OutputDirectory.Path` with `Package.OutputDirectory.Clean` defaulting to `true`.

--- a/README.md
+++ b/README.md
@@ -247,6 +247,11 @@ Use this `project.json` shape when you want Nova to resolve upload targets from 
 - `nova deploy` is the CLI entrypoint for the same raw upload workflow.
 - `-Url` overrides repository or package-level upload settings and is the simplest CI/CD path.
 - When `-PackagePath` is omitted, Nova resolves package files from `Package.OutputDirectory.Path`.
+- `Package.FileNamePattern` overrides the default upload discovery pattern. When omitted, Nova falls back to
+  `<Package.Id>*` and then applies the selected package type extension.
+- When `Package.FileNamePattern` already ends with `.zip` or `.nupkg`, Nova treats that extension as authoritative.
+  For example, `MyModule.*.zip` discovers `MyModule.1.2.3.zip` and `MyModule.latest.zip` without picking up
+  `MyModule.1.2.3.nupkg`.
 - When multiple matching files exist for a selected package type, Nova uploads all of them, including versioned and
   `latest` variants.
 - `Package.Headers`, `Package.Auth`, `Package.RepositoryUrl`, and repository-specific overrides remain generic so the

--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ Use this `project.json` shape when you want to control the package types and out
 ```json
 {
   "Package": {
+    "PackageFileName": "AgentInstaller",
+    "AddVersionToFileName": true,
     "Types": ["NuGet", "Zip"],
     "Latest": true,
     "OutputDirectory": {
@@ -208,6 +210,12 @@ Use this `project.json` shape when you want to control the package types and out
 - Use `Types = ["Zip"]` when you only want a `.zip`, or `Types = ["NuGet", "Zip"]` when you want both files.
 - `Latest` is optional and defaults to `false`. When set to `true`, Nova also creates a companion `*.latest.*`
   artifact for each selected package type, such as `NovaModuleTools.latest.nupkg` next to the normal versioned file.
+- `PackageFileName` lets you override the base artifact name.
+- `AddVersionToFileName` defaults to `false`. When set to `true`, Nova appends `.<Version>` from `project.json` to the
+  configured `PackageFileName`, so `AgentInstaller` becomes `AgentInstaller.2.3.4` before the package
+  extension is applied.
+- When both `AddVersionToFileName` and `Latest` are enabled, the companion artifact substitutes that appended version
+  suffix with `.latest`, such as `AgentInstaller.latest.nupkg`.
 - `Path` selects where the package artifact(s) are written.
 - `Clean` defaults to `true` and removes that output directory before a new package is created.
 - Set `Clean` to `false` when you want to keep existing files in the package output directory.
@@ -249,6 +257,8 @@ Use this `project.json` shape when you want Nova to resolve upload targets from 
 - When `-PackagePath` is omitted, Nova resolves package files from `Package.OutputDirectory.Path`.
 - `Package.FileNamePattern` overrides the default upload discovery pattern. When omitted, Nova falls back to
   `<Package.Id>*` and then applies the selected package type extension.
+- If `Package.PackageFileName` uses a different base name than `Package.Id`, update `Package.FileNamePattern` too so
+  automatic upload discovery keeps matching the generated files.
 - When `Package.FileNamePattern` already ends with `.zip` or `.nupkg`, Nova treats that extension as authoritative.
   For example, `MyModule.*.zip` discovers `MyModule.1.2.3.zip` and `MyModule.latest.zip` without picking up
   `MyModule.1.2.3.nupkg`.

--- a/docs/NovaModuleTools/en-US/Deploy-NovaPackage.md
+++ b/docs/NovaModuleTools/en-US/Deploy-NovaPackage.md
@@ -31,6 +31,10 @@ When `-PackagePath` is omitted, the command resolves artifacts from the configur
 current package model, which means it can upload `.nupkg`, `.zip`, or both, depending on `Package.Types` and the files
 present in the output directory.
 
+If you customize `Package.PackageFileName`, you can keep upload discovery aligned by updating
+`Package.FileNamePattern` as well. When `Package.AddVersionToFileName` is `true`, Nova appends `.<Version>` from
+`project.json` to the configured package file base name before it discovers or uploads matching artifacts.
+
 When multiple matching artifacts exist for a selected package type, `Deploy-NovaPackage` uploads all of them. That
 includes versioned and `latest` variants such as `NovaModuleTools.2.0.0-preview6.nupkg` and
 `NovaModuleTools.latest.nupkg`.

--- a/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
@@ -54,6 +54,9 @@ want both formats. Supported values are `NuGet`, `Zip`, `.nupkg`, and `.zip`, an
 Set `Package.Latest` to `true` when you also want `nova package` to create companion latest-named package artifacts such
 as `NovaModuleTools.latest.nupkg` next to the normal versioned files.
 
+Set `Package.AddVersionToFileName` to `true` when `Package.PackageFileName` is a stable base name such as
+`AgentInstaller` and you want Nova to append `.<Version>` from `project.json` before creating the package files.
+
 Use `nova deploy` when you want to push existing package artifacts from the configured package output directory to a raw
 HTTP endpoint. It can upload all matching artifacts for the configured package types, including versioned and `latest`
 files, and it resolves the upload target from `-url`, `Package.RepositoryUrl`, or `Package.Repositories`.

--- a/docs/NovaModuleTools/en-US/New-NovaModulePackage.md
+++ b/docs/NovaModuleTools/en-US/New-NovaModulePackage.md
@@ -36,6 +36,8 @@ Use this `project.json` shape when you want to control package types and the pac
 ```json
 {
   "Package": {
+    "PackageFileName": "AgentInstaller",
+    "AddVersionToFileName": true,
     "Types": [
       "NuGet",
       "Zip"
@@ -58,6 +60,14 @@ Supported `Package.Types` values are `NuGet`, `Zip`, `.nupkg`, and `.zip`, and m
 `Package.Latest` is optional and defaults to `false`. When set to `true`, `New-NovaModulePackage` also writes a
 companion
 `*.latest.*` artifact for each selected package type while keeping the normal versioned file.
+
+`Package.PackageFileName` lets you override the base package file name.
+
+`Package.AddVersionToFileName` defaults to `false`. When you set it to `true`, Nova appends `.<Version>` from
+`project.json` to the configured `Package.PackageFileName` before the package extension is applied.
+
+When both `Package.AddVersionToFileName` and `Package.Latest` are enabled, `New-NovaModulePackage` replaces that
+appended version suffix with `.latest` for the companion artifact.
 
 `Package.OutputDirectory.Clean` defaults to `true`, which deletes the configured package output directory before a new
 package is created. Set it to `false` when you want to keep existing files in that directory.
@@ -105,12 +115,21 @@ file such as `NovaModuleTools.latest.nupkg`.
 ### EXAMPLE 5
 
 ```powershell
+PS> New-NovaModulePackage
+```
+
+When `Package.PackageFileName` is `AgentInstaller` and `Package.AddVersionToFileName` is `true`, the command writes
+package files such as `AgentInstaller.2.3.4.nupkg` and `AgentInstaller.latest.nupkg`.
+
+### EXAMPLE 6
+
+```powershell
 PS> New-NovaModulePackage -WhatIf
 ```
 
 Previews the build, test, and package workflow without writing a package artifact.
 
-### EXAMPLE 6
+### EXAMPLE 7
 
 ```powershell
 PS> New-NovaModulePackage -Confirm

--- a/docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md
+++ b/docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md
@@ -44,6 +44,10 @@ has no commits yet. Create an initial commit first.`
 This command supports `-WhatIf` and `-Confirm` through PowerShell `SupportsShouldProcess`. Use `-WhatIf` to preview the
 calculated release label and the exact next version without changing the stored version.
 
+When the current version is already a prerelease for the selected release line, Nova finalizes that same semantic
+version instead of incrementing again. For example, a `Major` bump from `2.0.0-preview7` resolves to `2.0.0`, not
+`3.0.0-preview7`.
+
 From the standalone `nova` launcher on macOS/Linux, `nova bump -Confirm` uses a CLI-friendly confirmation prompt. If you
 choose `No`, `No to All`, or `Suspend`, the command exits without changing `project.json` and without returning a
 version
@@ -69,17 +73,33 @@ Updates the version for the project rooted at `./src/resources/example`.
 
 ### EXAMPLE 3
 
-```powershell
+```text
 PS> Update-NovaModuleVersion -WhatIf
 
 What if: Performing the operation "Update module version using Minor release label" on target "project.json".
 
-PreviousVersion NewVersion Label CommitCount
---------------- ---------- ----- -----------
-1.12.0          1.13.0     Minor          12
+PreviousVersion: 1.12.0
+NewVersion: 1.13.0
+Label: Minor
+CommitCount: 12
 ```
 
 Shows the calculated version update without modifying `project.json`.
+
+### EXAMPLE 4
+
+```text
+PS> Update-NovaModuleVersion -WhatIf
+
+What if: Performing the operation "Update module version using Major release label" on target "project.json".
+
+PreviousVersion: 2.0.0-preview7
+NewVersion: 2.0.0
+Label: Major
+CommitCount: 84
+```
+
+Shows how Nova finalizes an existing prerelease target instead of carrying the old prerelease label into the next major.
 
 ## PARAMETERS
 

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -302,6 +302,11 @@ nova release -repository PSGallery -apikey $env:PSGALLERY_API</code></pre>
                             <li><strong>Notable behavior:</strong> falls back to a patch bump when the folder is not a
                                 Git repository, but throws when the repository exists and has no commits yet
                             </li>
+                            <li><strong>Prerelease rule:</strong> finalizes matching prerelease targets like
+                                <code>2.0.0-preview7 -&gt; 2.0.0</code> instead of carrying the old prerelease label
+                                into
+                                the next release line
+                            </li>
                         </ul>
                         <pre><code>Update-NovaModuleVersion -WhatIf
 nova bump -Confirm</code></pre>

--- a/docs/project-json-reference.html
+++ b/docs/project-json-reference.html
@@ -153,7 +153,8 @@
       "Path": "artifacts/packages",
       "Clean": true
     },
-    "PackageFileName": "NovaExampleModule.0.1.0",
+    "PackageFileName": "NovaExampleModule",
+    "AddVersionToFileName": true,
     "FileNamePattern": "NovaExampleModule*",
     "Authors": ["NovaModuleTools", "Example Maintainer"],
     "Description": "Example package metadata and raw upload configuration for NovaExampleModule.",
@@ -417,8 +418,21 @@
                             <td><code>PackageFileName</code></td>
                             <td><code>&lt;Id&gt;.&lt;Version&gt;.nupkg</code></td>
                             <td>Base file name used for package generation.</td>
-                            <td>Nova normalizes the extension per package type and swaps the version suffix for <code>latest</code>
-                                when needed.
+                            <td>Nova normalizes the extension per package type. When you combine a custom base name with
+                                <code>AddVersionToFileName</code>, Nova appends the project version before the extension
+                                and can still swap that suffix for <code>latest</code> when needed.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><code>AddVersionToFileName</code></td>
+                            <td><code>false</code></td>
+                            <td>Appends <code>.&lt;Version&gt;</code> from the top-level project version to the
+                                configured
+                                <code>PackageFileName</code>.
+                            </td>
+                            <td>Useful when <code>PackageFileName</code> is a stable base name such as
+                                <code>AgentInstaller</code>. With <code>Latest</code> enabled, Nova substitutes the
+                                appended version suffix with <code>.latest</code> for the companion artifact.
                             </td>
                         </tr>
                         <tr>
@@ -428,6 +442,8 @@
                             <td>When you omit it, Nova falls back to <code>&lt;Id&gt;*</code> and adds the active
                                 package
                                 type extension during discovery. When you set it, your pattern overrides that default.
+                                If <code>PackageFileName</code> uses a different base name than <code>Id</code>, update
+                                <code>FileNamePattern</code> too so deploy discovery still matches the generated files.
                                 A pattern that already ends with <code>.zip</code> or <code>.nupkg</code> is treated as
                                 authoritative, so <code>MyModule.*.zip</code> matches <code>MyModule.1.2.3.zip</code>
                                 and <code>MyModule.latest.zip</code> without discovering <code>.nupkg</code> files.

--- a/docs/project-json-reference.html
+++ b/docs/project-json-reference.html
@@ -425,8 +425,12 @@
                             <td><code>FileNamePattern</code></td>
                             <td><code>&lt;Id&gt;*</code> in practice</td>
                             <td>Pattern used to discover matching package files for upload.</td>
-                            <td>Keep it wide enough to include both versioned and <code>latest</code> artifacts when you
-                                use <code>Package.Latest</code>.
+                            <td>When you omit it, Nova falls back to <code>&lt;Id&gt;*</code> and adds the active
+                                package
+                                type extension during discovery. When you set it, your pattern overrides that default.
+                                A pattern that already ends with <code>.zip</code> or <code>.nupkg</code> is treated as
+                                authoritative, so <code>MyModule.*.zip</code> matches <code>MyModule.1.2.3.zip</code>
+                                and <code>MyModule.latest.zip</code> without discovering <code>.nupkg</code> files.
                             </td>
                         </tr>
                         <tr>

--- a/docs/versioning-and-updates.html
+++ b/docs/versioning-and-updates.html
@@ -135,6 +135,16 @@ nova --version</code></pre>
                 <p>When Git tags exist, Nova uses commits since the latest tag. When the folder is not a Git repository,
                     Nova falls back to a patch bump. When the repository exists but has no commits yet, Nova stops with
                     a clear error.</p>
+                <p>Nova treats prerelease versions as previews of a specific semantic version target. That means a bump
+                    does not blindly carry prerelease labels such as <code>preview7</code> into the next major, minor,
+                    or
+                    patch. If the current version is already a prerelease of the selected release line, Nova finalizes
+                    that
+                    version instead.</p>
+                <pre><code>2.0.0-preview7 + Major -> 2.0.0
+1.3.0-preview7 + Minor -> 1.3.0
+1.2.4-preview7 + Patch -> 1.2.4
+1.2.3-preview7 + Minor -> 1.3.0</code></pre>
                 <pre><code>Update-NovaModuleVersion -WhatIf
 nova bump -WhatIf
 nova bump -Confirm</code></pre>

--- a/project.json
+++ b/project.json
@@ -1,7 +1,7 @@
 {
   "ProjectName": "NovaModuleTools",
   "Description": "NovaModuleTools is an enterprise-focused evolution of ModuleTools, designed for large-scale PowerShell projects with a strong emphasis on structure, maintainability, and automated CI/CD pipelines.",
-  "Version": "2.0.0-preview6",
+  "Version": "2.0.0-preview7",
   "Preamble": [
     "Set-StrictMode -Version Latest",
     "$ErrorActionPreference = 'Stop'"

--- a/src/private/package/GetNovaPackageArtifactPatternInfo.ps1
+++ b/src/private/package/GetNovaPackageArtifactPatternInfo.ps1
@@ -1,0 +1,23 @@
+function Get-NovaPackageArtifactPatternInfo {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo
+    )
+
+    $pattern = "$( Get-NovaPackageSettingValue -InputObject $ProjectInfo.Package -Name 'FileNamePattern' )".Trim()
+    if ( [string]::IsNullOrWhiteSpace($pattern)) {
+        $packageId = "$( Get-NovaPackageSettingValue -InputObject $ProjectInfo.Package -Name 'Id' )".Trim()
+        $pattern = "$packageId*"
+    }
+
+    $explicitPackageType = $null
+    if ($pattern -match '(?i)(\.nupkg|\.zip)$') {
+        $explicitPackageType = ConvertTo-NovaPackageType -Type $Matches[1]
+    }
+
+    return [pscustomobject]@{
+        Pattern = $pattern
+        ExplicitPackageType = $explicitPackageType
+    }
+}
+

--- a/src/private/package/GetNovaPackageArtifactSearchPattern.ps1
+++ b/src/private/package/GetNovaPackageArtifactSearchPattern.ps1
@@ -5,13 +5,11 @@ function Get-NovaPackageArtifactSearchPattern {
         [Parameter(Mandatory)][string]$PackageType
     )
 
-    $pattern = "$( Get-NovaPackageSettingValue -InputObject $ProjectInfo.Package -Name 'FileNamePattern' )".Trim()
-    if ( [string]::IsNullOrWhiteSpace($pattern)) {
-        $packageId = "$( Get-NovaPackageSettingValue -InputObject $ProjectInfo.Package -Name 'Id' )".Trim()
-        $pattern = "$packageId*"
+    $patternInfo = Get-NovaPackageArtifactPatternInfo -ProjectInfo $ProjectInfo
+    if ($null -ne $patternInfo.ExplicitPackageType) {
+        return $patternInfo.Pattern
     }
 
-    $pattern = $pattern -replace '(?i)(?:\.nupkg|\.zip)$', ''
-    return "$pattern$( Get-NovaPackageTypeExtension -PackageType $PackageType )"
+    return "$( $patternInfo.Pattern )$( Get-NovaPackageTypeExtension -PackageType $PackageType )"
 }
 

--- a/src/private/package/GetNovaPackageFileName.ps1
+++ b/src/private/package/GetNovaPackageFileName.ps1
@@ -8,29 +8,65 @@ function Get-NovaPackageFileName {
     )
 
     $packageType = ConvertTo-NovaPackageType -Type $PackageType
+    $packageFileName = Get-NovaPackageBaseFileName -ProjectInfo $ProjectInfo -PackageId $PackageId
+    if ($Latest) {
+        $packageFileName = ConvertTo-NovaLatestPackageFileName -PackageFileName $packageFileName -Version $ProjectInfo.Version
+    }
+
+    return "$packageFileName$( Get-NovaPackageTypeExtension -PackageType $packageType )"
+}
+
+function Get-NovaPackageBaseFileName {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
+        [Parameter(Mandatory)][string]$PackageId
+    )
+
     $packageFileName = "$( $ProjectInfo.Package.PackageFileName )".Trim()
     if ( [string]::IsNullOrWhiteSpace($packageFileName)) {
-        $packageFileName = "$PackageId.$( $ProjectInfo.Version )"
+        return "$PackageId.$( $ProjectInfo.Version )"
     }
 
     $packageFileName = $packageFileName -replace '(?i)(?:\.nupkg|\.zip)$', ''
-    if ($Latest) {
-        $versionSuffix = ".$( $ProjectInfo.Version )"
-        if ( $packageFileName.EndsWith($versionSuffix, [System.StringComparison]::OrdinalIgnoreCase)) {
-            $packageFileName = "$($packageFileName.Substring(0, $packageFileName.Length - $versionSuffix.Length) ).latest"
-        }
-        elseif (-not $packageFileName.EndsWith('.latest', [System.StringComparison]::OrdinalIgnoreCase)) {
-            $packageFileName = "$packageFileName.latest"
-        }
+    if (-not (Get-NovaPackageSettingValue -InputObject $ProjectInfo.Package -Name 'AddVersionToFileName')) {
+        return $packageFileName
     }
 
-    $fileExtension = if ($packageType -eq 'Zip') {
-        '.zip'
-    }
-    else {
-        '.nupkg'
+    return Add-NovaPackageVersionSuffix -PackageFileName $packageFileName -Version $ProjectInfo.Version
+}
+
+function Add-NovaPackageVersionSuffix {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$PackageFileName,
+        [Parameter(Mandatory)][string]$Version
+    )
+
+    $versionSuffix = ".${Version}"
+    if ( $PackageFileName.EndsWith($versionSuffix, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $PackageFileName
     }
 
-    return "$packageFileName$fileExtension"
+    return "$PackageFileName$versionSuffix"
+}
+
+function ConvertTo-NovaLatestPackageFileName {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$PackageFileName,
+        [Parameter(Mandatory)][string]$Version
+    )
+
+    $versionSuffix = ".${Version}"
+    if ( $PackageFileName.EndsWith($versionSuffix, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return "$($PackageFileName.Substring(0, $PackageFileName.Length - $versionSuffix.Length) ).latest"
+    }
+
+    if (-not $PackageFileName.EndsWith('.latest', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return "$PackageFileName.latest"
+    }
+
+    return $PackageFileName
 }
 

--- a/src/private/package/ResolveNovaPackageUploadTypeList.ps1
+++ b/src/private/package/ResolveNovaPackageUploadTypeList.ps1
@@ -6,22 +6,46 @@ function Resolve-NovaPackageUploadTypeList {
         [string[]]$PackageType
     )
 
+    $patternInfo = Get-NovaPackageArtifactPatternInfo -ProjectInfo $ProjectInfo
     $requestedTypeList = @($PackageType | Where-Object {-not [string]::IsNullOrWhiteSpace("$_")})
     if ($requestedTypeList.Count -gt 0) {
-        $resolvedTypeList = @()
-        foreach ($requestedType in $requestedTypeList) {
-            $resolvedType = ConvertTo-NovaPackageType -Type $requestedType
-            if ($resolvedType -notin $resolvedTypeList) {
-                $resolvedTypeList += $resolvedType
-            }
-        }
+        return @(Resolve-NovaRequestedPackageUploadTypeList -RequestedTypeList $requestedTypeList -PatternInfo $patternInfo)
+    }
 
-        return $resolvedTypeList
+    if ($null -ne $patternInfo.ExplicitPackageType) {
+        return @($patternInfo.ExplicitPackageType)
     }
 
     return @(
     @(Get-NovaPackageMetadataList -ProjectInfo $ProjectInfo).Type |
             Select-Object -Unique
     )
+}
+
+function Resolve-NovaRequestedPackageUploadTypeList {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string[]]$RequestedTypeList,
+        [Parameter(Mandatory)][pscustomobject]$PatternInfo
+    )
+
+    $resolvedTypeList = @()
+    foreach ($requestedType in $RequestedTypeList) {
+        $resolvedType = ConvertTo-NovaPackageType -Type $requestedType
+        if ($resolvedType -notin $resolvedTypeList) {
+            $resolvedTypeList += $resolvedType
+        }
+    }
+
+    if ($null -eq $PatternInfo.ExplicitPackageType) {
+        return $resolvedTypeList
+    }
+
+    $matchingRequestedTypeList = @($resolvedTypeList | Where-Object {$_ -eq $PatternInfo.ExplicitPackageType})
+    if ($matchingRequestedTypeList.Count -gt 0) {
+        return $matchingRequestedTypeList
+    }
+
+    throw "Package.FileNamePattern '$( $PatternInfo.Pattern )' resolves to type '$( $PatternInfo.ExplicitPackageType )', but requested PackageType values are: $( $resolvedTypeList -join ', ' )."
 }
 

--- a/src/private/release/GetNovaVersionPartForLabel.ps1
+++ b/src/private/release/GetNovaVersionPartForLabel.ps1
@@ -6,6 +6,10 @@ function Get-NovaVersionPartForLabel {
         [string]$Label = 'Patch'
     )
 
+    if (Test-NovaVersionShouldFinalizePrereleaseTarget -CurrentVersion $CurrentVersion -Label $Label) {
+        return Get-NovaVersionPartObject -CurrentVersion $CurrentVersion
+    }
+
     switch ($Label) {
         'Major' {
             return [pscustomobject]@{
@@ -28,5 +32,49 @@ function Get-NovaVersionPartForLabel {
                 Patch = $CurrentVersion.Patch + 1
             }
         }
+    }
+}
+
+function Test-NovaVersionShouldFinalizePrereleaseTarget {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][semver]$CurrentVersion,
+        [Parameter(Mandatory)][string]$Label
+    )
+
+    if ( [string]::IsNullOrWhiteSpace($CurrentVersion.PreReleaseLabel)) {
+        return $false
+    }
+
+    return (Get-NovaVersionTargetLabelForPrerelease -CurrentVersion $CurrentVersion) -eq $Label
+}
+
+function Get-NovaVersionTargetLabelForPrerelease {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][semver]$CurrentVersion
+    )
+
+    if ($CurrentVersion.Patch -gt 0) {
+        return 'Patch'
+    }
+
+    if ($CurrentVersion.Minor -gt 0) {
+        return 'Minor'
+    }
+
+    return 'Major'
+}
+
+function Get-NovaVersionPartObject {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][semver]$CurrentVersion
+    )
+
+    return [pscustomobject]@{
+        Major = $CurrentVersion.Major
+        Minor = $CurrentVersion.Minor
+        Patch = $CurrentVersion.Patch
     }
 }

--- a/src/private/release/GetNovaVersionPreReleaseLabel.ps1
+++ b/src/private/release/GetNovaVersionPreReleaseLabel.ps1
@@ -1,7 +1,6 @@
 function Get-NovaVersionPreReleaseLabel {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][semver]$CurrentVersion,
         [switch]$PreviewRelease,
         [switch]$StableRelease
     )
@@ -14,5 +13,5 @@ function Get-NovaVersionPreReleaseLabel {
         return $null
     }
 
-    return $CurrentVersion.PreReleaseLabel
+    return $null
 }

--- a/src/private/release/GetNovaVersionUpdatePlan.ps1
+++ b/src/private/release/GetNovaVersionUpdatePlan.ps1
@@ -11,7 +11,7 @@ function Get-NovaVersionUpdatePlan {
     $jsonContent = Get-Content -LiteralPath $projectInfo.ProjectJSON -Raw | ConvertFrom-Json
     [semver]$currentVersion = $jsonContent.Version
     $versionPart = Get-NovaVersionPartForLabel -CurrentVersion $currentVersion -Label $Label
-    $releaseType = Get-NovaVersionPreReleaseLabel -CurrentVersion $currentVersion -PreviewRelease:$PreviewRelease -StableRelease:$StableRelease
+    $releaseType = Get-NovaVersionPreReleaseLabel -PreviewRelease:$PreviewRelease -StableRelease:$StableRelease
     $newVersion = [semver]::new($versionPart.Major, $versionPart.Minor, $versionPart.Patch, $releaseType, $null)
 
     return [pscustomobject]@{

--- a/src/private/shared/GetNovaResolvedProjectPackageSettings.ps1
+++ b/src/private/shared/GetNovaResolvedProjectPackageSettings.ps1
@@ -13,6 +13,7 @@ function Get-NovaResolvedProjectPackageSettings {
     Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'Id' -Value $ProjectData['ProjectName'] -TreatWhitespaceAsMissing
 
     Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'PackageFileName' -Value "$( $packageSettings['Id'] ).$( $ProjectData['Version'] ).nupkg" -TreatWhitespaceAsMissing
+    Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'AddVersionToFileName' -Value $false
     Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'FileNamePattern' -Value "$( $packageSettings['Id'] )*" -TreatWhitespaceAsMissing
     Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'Authors' -Value $ManifestSettings['Author']
     Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'Description' -Value $ProjectData['Description'] -TreatWhitespaceAsMissing
@@ -22,6 +23,7 @@ function Get-NovaResolvedProjectPackageSettings {
     Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'Auth' -Value ([ordered]@{})
 
     $packageSettings['Latest'] = [bool]$packageSettings['Latest']
+    $packageSettings['AddVersionToFileName'] = [bool]$packageSettings['AddVersionToFileName']
     $packageSettings['Repositories'] = @($packageSettings['Repositories'])
     $packageSettings['Headers'] = [ordered]@{} + $packageSettings['Headers']
     $packageSettings['Auth'] = [ordered]@{} + $packageSettings['Auth']

--- a/src/resources/Schema-Build.json
+++ b/src/resources/Schema-Build.json
@@ -99,6 +99,9 @@
           "PackageFileName": {
             "type": "string"
           },
+          "AddVersionToFileName": {
+            "type": "boolean"
+          },
           "FileNamePattern": {
             "type": "string"
           },

--- a/src/resources/example/project.json
+++ b/src/resources/example/project.json
@@ -34,7 +34,8 @@
       "Path": "artifacts/packages",
       "Clean": true
     },
-    "PackageFileName": "NovaExampleModule.0.1.0",
+    "PackageFileName": "NovaExampleModule",
+    "AddVersionToFileName": true,
     "FileNamePattern": "NovaExampleModule*",
     "Authors": [
       "NovaModuleTools",

--- a/tests/CoverageGaps.ReleaseInternals.Tests.ps1
+++ b/tests/CoverageGaps.ReleaseInternals.Tests.ps1
@@ -55,12 +55,55 @@ Describe 'Coverage gaps for release and git internals' {
         }
     }
 
-    It 'Get-NovaVersionPreReleaseLabel returns preview, stable, or the existing prerelease label' {
+    It 'Get-NovaVersionPartForLabel finalizes prerelease targets or advances to the next stable core when <Name>' -ForEach @(
+        @{Name = 'major prerelease already targets the current release line'; CurrentVersion = '2.0.0-preview7'; Label = 'Major'; Expected = '2.0.0'}
+        @{Name = 'minor prerelease already targets the current release line'; CurrentVersion = '1.3.0-preview7'; Label = 'Minor'; Expected = '1.3.0'}
+        @{Name = 'patch prerelease already targets the current release line'; CurrentVersion = '1.2.4-preview7'; Label = 'Patch'; Expected = '1.2.4'}
+        @{Name = 'major prerelease on a lower release line advances to the next major'; CurrentVersion = '1.2.3-preview7'; Label = 'Major'; Expected = '2.0.0'}
+        @{Name = 'minor prerelease on a lower release line advances to the next minor'; CurrentVersion = '1.2.3-preview7'; Label = 'Minor'; Expected = '1.3.0'}
+        @{Name = 'patch prerelease on the current patch line finalizes that line'; CurrentVersion = '1.2.3-preview7'; Label = 'Patch'; Expected = '1.2.3'}
+    ) {
+        InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+            param($TestCase)
+
+            $result = Get-NovaVersionPartForLabel -CurrentVersion ([semver]$TestCase.CurrentVersion) -Label $TestCase.Label
+
+            "$( $result.Major ).$( $result.Minor ).$( $result.Patch )" | Should -Be $TestCase.Expected
+        }
+    }
+
+    It 'Get-NovaVersionPreReleaseLabel returns preview or stable output without preserving prerelease labels by default' {
         InModuleScope $script:moduleName {
-            Get-NovaVersionPreReleaseLabel -CurrentVersion ([semver]'1.2.3-preview') -PreviewRelease | Should -Be 'preview'
-            $stable = Get-NovaVersionPreReleaseLabel -CurrentVersion ([semver]'1.2.3-preview') -StableRelease
+            Get-NovaVersionPreReleaseLabel -PreviewRelease | Should -Be 'preview'
+            $stable = Get-NovaVersionPreReleaseLabel -StableRelease
             $stable | Should -BeNullOrEmpty
-            Get-NovaVersionPreReleaseLabel -CurrentVersion ([semver]'1.2.3-preview') | Should -Be 'preview'
+            Get-NovaVersionPreReleaseLabel | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'Get-NovaVersionPreReleaseLabel handles dotted prerelease identifiers when preview parsing is supported' {
+        InModuleScope $script:moduleName {
+            $version = [semver]'1.2.3-preview.7'
+
+            $version.ToString() | Should -Be '1.2.3-preview.7'
+            Get-NovaVersionPreReleaseLabel -PreviewRelease | Should -Be 'preview'
+            Get-NovaVersionPreReleaseLabel | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'Get-NovaVersionUpdatePlan resolves prerelease versions to the expected next stable target when <Name>' -ForEach @(
+        @{Name = 'finalizing a major prerelease line'; CurrentVersion = '2.0.0-preview7'; Label = 'Major'; ExpectedVersion = '2.0.0'}
+        @{Name = 'finalizing a minor prerelease line'; CurrentVersion = '1.3.0-preview7'; Label = 'Minor'; ExpectedVersion = '1.3.0'}
+        @{Name = 'finalizing a patch prerelease line'; CurrentVersion = '1.2.4-preview7'; Label = 'Patch'; ExpectedVersion = '1.2.4'}
+        @{Name = 'advancing from an earlier prerelease line to the next minor'; CurrentVersion = '1.2.3-preview7'; Label = 'Minor'; ExpectedVersion = '1.3.0'}
+    ) {
+        InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+            param($TestCase)
+
+            Mock Get-NovaProjectInfo {[pscustomobject]@{ProjectJSON = '/tmp/project.json'}}
+            Mock Get-Content {([ordered]@{Version = $TestCase.CurrentVersion} | ConvertTo-Json -Compress)} -ParameterFilter {$LiteralPath -eq '/tmp/project.json' -and $Raw}
+
+            (Get-NovaVersionUpdatePlan -Label $TestCase.Label).NewVersion.ToString() | Should -Be $TestCase.ExpectedVersion
         }
     }
 

--- a/tests/NovaCommandModel.BumpAndCli.Tests.ps1
+++ b/tests/NovaCommandModel.BumpAndCli.Tests.ps1
@@ -88,6 +88,28 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
         }
     }
 
+    It 'Update-NovaModuleVersion -WhatIf finalizes a prerelease major target instead of carrying the old prerelease label forward' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    Version = '2.0.0-preview7'
+                    ProjectJSON = '/tmp/project.json'
+                }
+            }
+            Mock Get-Content {'{"Version":"2.0.0-preview7"}'} -ParameterFilter {$LiteralPath -eq '/tmp/project.json' -and $Raw}
+            Mock Get-GitCommitMessageForVersionBump {@('feat!: breaking api')}
+            Mock Get-VersionLabelFromCommitSet {'Major'}
+            Mock Set-NovaModuleVersion {}
+
+            $result = Update-NovaModuleVersion -Path (Get-Location).Path -WhatIf
+
+            $result.PreviousVersion | Should -Be '2.0.0-preview7'
+            $result.NewVersion | Should -Be '2.0.0'
+            $result.Label | Should -Be 'Major'
+            Assert-MockCalled Set-NovaModuleVersion -Times 0
+        }
+    }
+
     It 'Update-NovaModuleVersion -WhatIf falls back to a Patch preview when the project is not a git repository' {
         InModuleScope $script:moduleName {
             $projectRoot = Join-Path $TestDrive 'no-git-bump-project'

--- a/tests/NovaCommandModel.PackageUpload.TestSupport.ps1
+++ b/tests/NovaCommandModel.PackageUpload.TestSupport.ps1
@@ -3,6 +3,7 @@ $global:novaCommandModelPackageUploadTestSupportFunctionNameList = @(
     'Initialize-TestNovaPackageUploadLayout'
     'New-TestNovaPackageUploadProjectInfo'
     'New-TestNovaPackageArtifactFile'
+    'New-TestNovaPackageArtifactSet'
 )
 
 function Get-TestNovaPackageUploadOptionValue {
@@ -86,5 +87,28 @@ function New-TestNovaPackageArtifactFile {
     $path = Join-Path $Directory $Name
     'artifact' | Set-Content -LiteralPath $path -Encoding utf8
     return $path
+}
+
+function New-TestNovaPackageArtifactSet {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Directory,
+        [string[]]$PackageType = @('NuGet', 'Zip'),
+        [switch]$IncludeLatest
+    )
+
+    return @(
+    foreach ($type in $PackageType) {
+        $extension = if ($type -eq 'Zip') {
+            '.zip'
+        } else {
+            '.nupkg'
+        }
+        New-TestNovaPackageArtifactFile -Directory $Directory -Name "PackageProject.2.3.4$extension"
+        if ($IncludeLatest) {
+            New-TestNovaPackageArtifactFile -Directory $Directory -Name "PackageProject.latest$extension"
+        }
+    }
+    )
 }
 

--- a/tests/NovaCommandModel.PackageUpload.Tests.ps1
+++ b/tests/NovaCommandModel.PackageUpload.Tests.ps1
@@ -130,30 +130,61 @@ Describe 'Nova command model - package upload behavior' {
         }
     }
 
-    It 'Deploy-NovaPackage handles the current package model when multiple artifacts may exist' {
-        $layout = Initialize-TestNovaPackageUploadLayout -ProjectRoot (Join-Path $TestDrive 'multi-artifact-upload')
+    It 'Deploy-NovaPackage resolves matching artifacts when <Name>' -ForEach @(
+        @{
+            Name = 'multiple artifacts exist for the configured package types'
+            ProjectRootName = 'multi-artifact-upload'
+            Options = @{PackageTypes = @('Zip', 'NuGet')}
+            ExpectedPackagePathFilter = 'PackageProject.*'
+            ExpectedTypeList = @('NuGet', 'NuGet', 'Zip', 'Zip')
+        }
+        @{
+            Name = 'FileNamePattern targets zip artifacts'
+            ProjectRootName = 'explicit-zip-pattern-upload'
+            Options = @{PackageTypes = @('Zip', 'NuGet'); FileNamePattern = 'PackageProject.*.zip'}
+            ExpectedPackagePathFilter = '*.zip'
+            ExpectedTypeList = @('Zip', 'Zip')
+        }
+    ) {
+        $testCase = $_
+        $layout = Initialize-TestNovaPackageUploadLayout -ProjectRoot (Join-Path $TestDrive $testCase.ProjectRootName)
+        $artifactPathList = @(New-TestNovaPackageArtifactSet -Directory $layout.PackageOutputDir -PackageType @('NuGet', 'Zip') -IncludeLatest)
         $expectedPackagePathList = @(
-            New-TestNovaPackageArtifactFile -Directory $layout.PackageOutputDir -Name 'PackageProject.2.3.4.nupkg'
-            New-TestNovaPackageArtifactFile -Directory $layout.PackageOutputDir -Name 'PackageProject.latest.nupkg'
-            New-TestNovaPackageArtifactFile -Directory $layout.PackageOutputDir -Name 'PackageProject.2.3.4.zip'
-            New-TestNovaPackageArtifactFile -Directory $layout.PackageOutputDir -Name 'PackageProject.latest.zip'
+        $artifactPathList |
+                Where-Object {[System.IO.Path]::GetFileName($_) -like $testCase.ExpectedPackagePathFilter}
         )
 
         InModuleScope $script:moduleName -Parameters @{
-            ProjectInfo = (New-TestNovaPackageUploadProjectInfo -Layout $layout -Options @{PackageTypes = @('Zip', 'NuGet')})
+            ProjectInfo = (New-TestNovaPackageUploadProjectInfo -Layout $layout -Options $testCase.Options)
             ExpectedPackagePathList = $expectedPackagePathList
+            ExpectedTypeList = $testCase.ExpectedTypeList
         } {
-            param($ProjectInfo, $ExpectedPackagePathList)
+            param($ProjectInfo, $ExpectedPackagePathList, $ExpectedTypeList)
 
             Mock Get-NovaProjectInfo {$ProjectInfo}
             Mock Invoke-WebRequest {[pscustomobject]@{StatusCode = 200}}
 
             $result = @(Deploy-NovaPackage -Url 'https://packages.example/raw/')
 
-            $result.Count | Should -Be 4
+            $result.Count | Should -Be $ExpectedPackagePathList.Count
             @($result.PackagePath | Sort-Object) | Should -Be @($ExpectedPackagePathList | Sort-Object)
-            @($result.Type | Sort-Object) | Should -Be @('NuGet', 'NuGet', 'Zip', 'Zip')
-            Assert-MockCalled Invoke-WebRequest -Times 4
+            @($result.Type | Sort-Object) | Should -Be @($ExpectedTypeList | Sort-Object)
+            Assert-MockCalled Invoke-WebRequest -Times $ExpectedPackagePathList.Count
+        }
+    }
+
+    It 'Deploy-NovaPackage fails clearly when PackageType conflicts with FileNamePattern' {
+        $layout = Initialize-TestNovaPackageUploadLayout -ProjectRoot (Join-Path $TestDrive 'conflicting-package-type-and-pattern')
+        New-TestNovaPackageArtifactFile -Directory $layout.PackageOutputDir -Name 'PackageProject.2.3.4.zip' | Out-Null
+
+        InModuleScope $script:moduleName -Parameters @{
+            ProjectInfo = (New-TestNovaPackageUploadProjectInfo -Layout $layout -Options @{PackageTypes = @('Zip', 'NuGet'); FileNamePattern = 'PackageProject.*.zip'})
+        } {
+            param($ProjectInfo)
+
+            Mock Get-NovaProjectInfo {$ProjectInfo}
+
+            {Deploy-NovaPackage -PackageType NuGet -Url 'https://packages.example/raw/'} | Should -Throw "Package.FileNamePattern 'PackageProject.*.zip' resolves to type 'Zip'*"
         }
     }
 

--- a/tests/NovaCommandModel.ReleasePublish.Tests.ps1
+++ b/tests/NovaCommandModel.ReleasePublish.Tests.ps1
@@ -570,6 +570,54 @@ Describe 'Nova command model - release and publish behavior' {
         }
     }
 
+    It 'Get-NovaPackageMetadataList resolves custom PackageFileName versioning when <Name>' -ForEach @(
+        @{
+            Name = 'AddVersionToFileName appends the project version'
+            PackageFileName = 'AgentInstaller'
+        }
+        @{
+            Name = 'PackageFileName already ends with the current version'
+            PackageFileName = 'AgentInstaller.2.3.4.zip'
+        }
+    ) {
+        InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+            param($TestCase)
+
+            $projectInfo = [pscustomobject]@{
+                ProjectName = 'PackageProject'
+                Version = '2.3.4'
+                ProjectRoot = '/tmp/project'
+                Description = 'Top-level description'
+                Manifest = [ordered]@{
+                    Author = 'Author One'
+                    Tags = @('Nova', 'Packaging')
+                }
+                Package = [ordered]@{
+                    Id = 'PackageProject'
+                    Types = @('NuGet', 'Zip')
+                    Latest = $true
+                    OutputDirectory = [ordered]@{
+                        Path = '/tmp/project/artifacts/packages'
+                        Clean = $true
+                    }
+                    PackageFileName = $TestCase.PackageFileName
+                    AddVersionToFileName = $true
+                    Authors = 'Author One'
+                    Description = 'Top-level description'
+                }
+            }
+
+            $result = @(Get-NovaPackageMetadataList -ProjectInfo $projectInfo)
+
+            $result.PackageFileName | Should -Be @(
+                'AgentInstaller.2.3.4.nupkg',
+                'AgentInstaller.latest.nupkg',
+                'AgentInstaller.2.3.4.zip',
+                'AgentInstaller.latest.zip'
+            )
+        }
+    }
+
     It 'Get-NovaPackageMetadata keeps schema-optional manifest fields empty when they are omitted' {
         InModuleScope $script:moduleName {
             $projectInfo = [pscustomobject]@{

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -130,6 +130,7 @@ Describe 'Nova command model - project, help, and build behavior' {
             $projectInfo.Package.OutputDirectory.Clean | Should -BeTrue
             $projectInfo.Package.FileNamePattern | Should -Be 'DefaultPackageProject*'
             $projectInfo.Package.PackageFileName | Should -Be 'DefaultPackageProject.0.0.1.nupkg'
+            $projectInfo.Package.AddVersionToFileName | Should -BeFalse
             $projectInfo.Package.Latest | Should -BeFalse
             $projectInfo.Package.Authors | Should -Be 'Test Author'
             $projectInfo.Package.Description | Should -Be 'Default package option test'
@@ -155,8 +156,10 @@ Describe 'Nova command model - project, help, and build behavior' {
                 Package = [ordered]@{
                     Types = @('Zip')
                     Latest = $true
+                    AddVersionToFileName = $true
                     RepositoryUrl = 'https://packages.example/raw/'
                     UploadPath = 'releases/latest'
+                    PackageFileName = 'AgentInstaller'
                     FileNamePattern = 'PackageUploadProject*'
                     Headers = [ordered]@{
                         'X-Trace-Id' = 'trace-123'
@@ -181,8 +184,10 @@ Describe 'Nova command model - project, help, and build behavior' {
 
             $projectInfo.Package.Types | Should -Be @('Zip')
             $projectInfo.Package.Latest | Should -BeTrue
+            $projectInfo.Package.AddVersionToFileName | Should -BeTrue
             $projectInfo.Package.RepositoryUrl | Should -Be 'https://packages.example/raw/'
             $projectInfo.Package.UploadPath | Should -Be 'releases/latest'
+            $projectInfo.Package.PackageFileName | Should -Be 'AgentInstaller'
             $projectInfo.Package.FileNamePattern | Should -Be 'PackageUploadProject*'
             $projectInfo.Package.Headers['X-Trace-Id'] | Should -Be 'trace-123'
             $projectInfo.Package.Auth.HeaderName | Should -Be 'X-Api-Key'

--- a/tests/RemainingHelperCoverage.TestSupport.ps1
+++ b/tests/RemainingHelperCoverage.TestSupport.ps1
@@ -86,6 +86,8 @@ function Get-TestNovaPackageProjectInfo {
         [Parameter(Mandatory)][bool]$CleanOutputDirectory,
         [string[]]$PackageTypes = @('NuGet'),
         [bool]$Latest = $false,
+        [string]$PackageFileName = 'PackageProject.2.3.4.nupkg',
+        [bool]$AddVersionToFileName = $false,
         [switch]$OmitOptionalManifestMetadata
     )
 
@@ -118,7 +120,8 @@ function Get-TestNovaPackageProjectInfo {
                 Path = $Layout.PackageOutputDir
                 Clean = $CleanOutputDirectory
             }
-            PackageFileName = 'PackageProject.2.3.4.nupkg'
+            PackageFileName = $PackageFileName
+            AddVersionToFileName = $AddVersionToFileName
             Authors = @('Author One', 'Author Two')
             Description = 'Package project description'
         }

--- a/tests/RemainingHelperCoverage.Tests.ps1
+++ b/tests/RemainingHelperCoverage.Tests.ps1
@@ -420,6 +420,27 @@ Locale: en-US
         @($result.PackagePath | ForEach-Object {Test-Path -LiteralPath $_}) | Should -Be @($true, $true, $true, $true)
     }
 
+    It 'New-NovaPackageArtifacts appends the project version to a custom PackageFileName when AddVersionToFileName is true' {
+        $layout = Initialize-TestNovaPackageProjectLayout -ProjectRoot (Join-Path $TestDrive 'versioned-custom-package-name-project')
+
+        $result = InModuleScope $script:moduleName -Parameters @{
+            ProjectInfo = (Get-TestNovaPackageProjectInfo -Layout $layout -CleanOutputDirectory $true -PackageTypes @('NuGet', 'Zip') -Latest $true -PackageFileName 'AgentInstaller' -AddVersionToFileName $true)
+        } {
+            param($ProjectInfo)
+
+            $packageMetadataList = @(Get-NovaPackageMetadataList -ProjectInfo $ProjectInfo)
+            @(New-NovaPackageArtifacts -ProjectInfo $ProjectInfo -PackageMetadataList $packageMetadataList)
+        }
+
+        $result.PackageFileName | Should -Be @(
+            'AgentInstaller.2.3.4.nupkg',
+            'AgentInstaller.latest.nupkg',
+            'AgentInstaller.2.3.4.zip',
+            'AgentInstaller.latest.zip'
+        )
+        @($result.PackagePath | ForEach-Object {Test-Path -LiteralPath $_}) | Should -Be @($true, $true, $true, $true)
+    }
+
     It 'New-NovaPackageArtifact omits schema-optional manifest URI elements when they are not provided' {
         $layout = Initialize-TestNovaPackageProjectLayout -ProjectRoot (Join-Path $TestDrive 'package-project-without-optional-manifest-metadata')
         $packagePath = InModuleScope $script:moduleName -Parameters @{


### PR DESCRIPTION
## Summary

- What changed?
  - Added `Package.AddVersionToFileName` support so a custom `Package.PackageFileName` can optionally receive the top-level project version before the package extension is applied.
  - Kept `Package.Latest` behavior aligned with that naming model so companion `*.latest.*` artifacts are still produced correctly for versioned custom package names.
  - Improved package artifact discovery and upload matching so raw package upload scenarios can resolve the correct artifacts for configured package types and filename patterns.
  - Fixed `Update-NovaModuleVersion` / `nova bump` so prerelease versions finalize the correct SemVer target instead of carrying prerelease labels like `preview7` into the next major, minor, or patch line.

- Why was this change needed?
  - Projects using a custom package base name needed a way to keep filenames stable while still appending the project version automatically.
  - Raw package upload needed more reliable artifact matching when multiple package types or explicit filename patterns are involved.
  - The previous bump behavior was semantically wrong for prerelease versions, for example `2.0.0-preview7` incorrectly previewed as `3.0.0-preview7` for a major bump instead of finalizing to `2.0.0`.

- Link the issue, discussion, or follow-up work (for example `Closes #123`).
  - Closes #89

## Affected area

- [x] `nova` CLI or command routing
- [x] Public PowerShell cmdlet behavior
- [x] Scaffolding or `project.json` handling
- [ ] Build, test, analyzer, coverage, or CI helper flow
- [x] Package, raw upload, or package metadata workflow
- [ ] Publish, release, semantic-release, or GitHub Actions automation
- [ ] Self-update or notification preference behavior
- [x] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
- [x] End-user docs (`docs/*.html`)
- [x] Command help (`docs/NovaModuleTools/en-US/*.md`)
- [x] `src/resources/example/`
- [ ] Dependency or manifest changes (`package.json`, workflow dependencies, release tooling)
- [ ] Security-sensitive change
- [ ] Documentation-only change
- [ ] Other

## Review guidance

- Highlight the main code path or workflow reviewers should start with.
  - Start with the package naming and bump planning paths:
    - `src/private/package/GetNovaPackageFileName.ps1`
    - `src/private/shared/GetNovaResolvedProjectPackageSettings.ps1`
    - `src/private/package/GetNovaPackageArtifactPatternInfo.ps1`
    - `src/private/package/GetNovaPackageArtifactSearchPattern.ps1`
    - `src/private/package/ResolveNovaPackageUploadTypeList.ps1`
    - `src/private/release/GetNovaVersionPartForLabel.ps1`
    - `src/private/release/GetNovaVersionPreReleaseLabel.ps1`
    - `src/private/release/GetNovaVersionUpdatePlan.ps1`

- Call out the primary files or folders changed (for example `src/public/`, `src/private/cli/`, `scripts/build/ci/`,
  `.github/workflows/`, `docs/`, or `src/resources/example/`).
  - Primary implementation:
    - `src/private/package/`
    - `src/private/release/`
    - `src/private/shared/`
    - `src/resources/Schema-Build.json`
  - Regression coverage:
    - `tests/CoverageGaps.ReleaseInternals.Tests.ps1`
    - `tests/NovaCommandModel.BumpAndCli.Tests.ps1`
    - `tests/NovaCommandModel.PackageUpload.Tests.ps1`
    - `tests/NovaCommandModel.ReleasePublish.Tests.ps1`
    - `tests/RemainingHelperCoverage.Tests.ps1`
  - Docs/examples:
    - `README.md`
    - `docs/NovaModuleTools/en-US/*.md`
    - `docs/commands.html`
    - `docs/project-json-reference.html`
    - `docs/versioning-and-updates.html`
    - `src/resources/example/project.json`
    - `CHANGELOG.md`

- Call out any trade-offs, follow-up work, or known limitations.
  - The branch combines closely related package workflow work with the SemVer prerelease bump fix, so reviewers may want to review package/upload changes and version-bump changes as two separate passes.
  - Full broad-suite validation was not re-confirmed in this PR write-up; the notes below focus on targeted validation that was explicitly exercised.
  - `git diff --check develop...HEAD` currently reports one whitespace-style issue (`new blank line at EOF`) in `src/private/package/GetNovaPackageArtifactPatternInfo.ps1`.

## Validation

- [x] `Invoke-NovaBuild`
- [ ] `Test-NovaBuild`
- [ ] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
- [x] Targeted Nova workflow validated (`nova build`, `nova test`, `nova merge`, `nova deploy`, `nova publish`,
  `nova release`, `nova update`, `nova notification`, or `nova init` as relevant)
- [ ] Docs/example only; executable validation not needed

Validation notes:

```text
Confirmed in this pass:

- pwsh -NoLogo -NoProfile -Command 'Invoke-NovaBuild'
  - Completed successfully with no error output

- pwsh -NoLogo -NoProfile -Command 'Invoke-Pester ./tests/CoverageGaps.ReleaseInternals.Tests.ps1 -Output Detailed; Invoke-Pester ./tests/NovaCommandModel.BumpAndCli.Tests.ps1 -Output Detailed; Invoke-Pester ./tests/NovaCommandModel.PackageUpload.Tests.ps1 -Output Detailed; Invoke-Pester ./tests/NovaCommandModel.ReleasePublish.Tests.ps1 -Output Detailed'
  - CoverageGaps.ReleaseInternals.Tests.ps1: 27 passed, 0 failed
  - NovaCommandModel.BumpAndCli.Tests.ps1: 6 passed, 0 failed
  - NovaCommandModel.PackageUpload.Tests.ps1: 12 passed, 0 failed
  - NovaCommandModel.ReleasePublish.Tests.ps1: 22 passed, 0 failed

- ./dist/NovaModuleTools/resources/nova bump -WhatIf
  - Previewed:
    PreviousVersion: 2.0.0-preview7
    NewVersion: 2.0.0
    Label: Major
    CommitCount: 85

Additional note:
- git --no-pager diff --check develop...HEAD
  - Reports: src/private/package/GetNovaPackageArtifactPatternInfo.ps1:23: new blank line at EOF.

Not re-confirmed in this pass:
- Test-NovaBuild
- ScriptAnalyzer CI wrapper
- Full CI helper script
```

## Documentation and release follow-up

- [x] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
- [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
- [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [x] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
- [x] `docs/*.html` updated if end-user workflows or examples changed
- [x] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
  changed
- [ ] No documentation, changelog, or example updates were needed

## Maintainability, compatibility, and risk

- [x] Code Health / maintainability impact considered
- [x] No breaking change
- [ ] Breaking change
- [ ] Security-sensitive change
- [ ] CI, workflow, or release-pipeline impact
- [ ] Dependency-review impact

Risk, rollout, or rollback notes:

```text
Compatibility impact:
- Package naming changes are opt-in through Package.AddVersionToFileName, so existing custom PackageFileName behavior remains unchanged unless projects enable the new setting.
- The bump fix changes user-visible prerelease planning output, but only to correct SemVer-aligned release behavior.

Rollback:
- Revert the package filename helper changes and the prerelease bump planning changes in src/private/package/ and src/private/release/.
- Revert matching documentation/help/example updates so docs stay aligned with runtime behavior.

Maintainer follow-up:
- Consider fixing the reported trailing-blank-line diff warning before merge.
- If desired, run the full CI helper/analyzer wrappers before merge for broader branch-level confirmation.
```

> [!IMPORTANT]
> Do not use a public pull request to disclose a vulnerability before coordinated handling.
> Use the private reporting path in `SECURITY.md` for new security issues.