### PR TITLE
Bug/91 investigate why nova bump rewrites packagerepositories in projectjson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   clear messages.
 - Fix `Update-NovaModuleVersion` / `nova bump` so prerelease versions finalize the correct SemVer target instead of
   carrying old prerelease labels like `preview7` into the next major, minor, or patch line.
+- Fix `Update-NovaModuleVersion` / `nova bump` so bumping `project.json` preserves nested `Package.Repositories` and
+  other nested JSON objects instead of truncating them during serialization.
 
 ### Documentation
 

--- a/project.json
+++ b/project.json
@@ -1,7 +1,7 @@
 {
   "ProjectName": "NovaModuleTools",
   "Description": "NovaModuleTools is an enterprise-focused evolution of ModuleTools, designed for large-scale PowerShell projects with a strong emphasis on structure, maintainability, and automated CI/CD pipelines.",
-  "Version": "2.0.0-preview7",
+  "Version": "2.0.0-preview8",
   "Preamble": [
     "Set-StrictMode -Version Latest",
     "$ErrorActionPreference = 'Stop'"

--- a/src/private/release/SetNovaModuleVersion.ps1
+++ b/src/private/release/SetNovaModuleVersion.ps1
@@ -20,7 +20,7 @@ function Set-NovaModuleVersion {
         Write-Host "Version bumped to : $newVersion"
 
         # Convert the JSON object back to JSON format
-        $newJsonContent = $jsonContent | ConvertTo-Json
+        $newJsonContent = $jsonContent | ConvertTo-Json -Depth 20
 
         # Write the updated JSON back to the file
         $newJsonContent | Set-Content -LiteralPath $versionUpdatePlan.ProjectFile

--- a/tests/CoverageGaps.ReleaseInternals.Tests.ps1
+++ b/tests/CoverageGaps.ReleaseInternals.Tests.ps1
@@ -107,16 +107,47 @@ Describe 'Coverage gaps for release and git internals' {
         }
     }
 
-    It 'Set-NovaModuleVersion writes a new semantic version to project.json' {
+    It 'Set-NovaModuleVersion writes a new semantic version to project.json without flattening nested package repositories' {
         InModuleScope $script:moduleName {
             $projectJsonPath = Join-Path $TestDrive 'project.json'
-            Set-Content -LiteralPath $projectJsonPath -Value '{"Version":"1.2.3"}' -Encoding utf8
+            Set-Content -LiteralPath $projectJsonPath -Encoding utf8 -Value @'
+{
+  "ProjectName": "AzureDevOpsAgentInstaller",
+  "Version": "1.2.3",
+  "Package": {
+    "RepositoryUrl": "https://packages.example/raw/",
+    "Auth": {
+      "HeaderName": "Authorization",
+      "Scheme": "Basic",
+      "Token": "NEXUS_TOKEN"
+    },
+    "Repositories": [
+      {
+        "Name": "staging",
+        "Url": "https://packages.example/raw/staging/",
+        "Auth": {
+          "TokenEnvironmentVariable": "NEXUS_STAGING_TOKEN"
+        }
+      }
+    ]
+  }
+}
+'@
             Mock Get-NovaProjectInfo {[pscustomobject]@{ProjectJSON = $projectJsonPath}}
             Mock Write-Host {}
+            $warningMessages = $null
 
-            Set-NovaModuleVersion -Label Minor -PreviewRelease -Confirm:$false
+            Set-NovaModuleVersion -Label Minor -PreviewRelease -Confirm:$false -WarningVariable warningMessages
 
-            (Get-Content -LiteralPath $projectJsonPath -Raw | ConvertFrom-Json).Version | Should -Be '1.3.0-preview'
+            $updatedProject = Get-Content -LiteralPath $projectJsonPath -Raw | ConvertFrom-Json
+
+            $updatedProject.Version | Should -Be '1.3.0-preview'
+            $updatedProject.Package.Auth.HeaderName | Should -Be 'Authorization'
+            $updatedProject.Package.Repositories.Count | Should -Be 1
+            ($updatedProject.Package.Repositories[0] -is [string]) | Should -BeFalse
+            $updatedProject.Package.Repositories[0].Name | Should -Be 'staging'
+            $updatedProject.Package.Repositories[0].Auth.TokenEnvironmentVariable | Should -Be 'NEXUS_STAGING_TOKEN'
+            $warningMessages | Should -BeNullOrEmpty
         }
     }
 

--- a/tests/NovaCommandModel.BumpAndCli.Tests.ps1
+++ b/tests/NovaCommandModel.BumpAndCli.Tests.ps1
@@ -110,6 +110,56 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
         }
     }
 
+    It 'Update-NovaModuleVersion preserves nested package repository objects when writing the bumped version' {
+        InModuleScope $script:moduleName {
+            $projectRoot = Join-Path $TestDrive 'package-repository-bump-project'
+            New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+            $projectJsonPath = Join-Path $projectRoot 'project.json'
+            Set-Content -LiteralPath $projectJsonPath -Encoding utf8 -Value @'
+{
+  "ProjectName": "AzureDevOpsAgentInstaller",
+  "Description": "Self-contained installer that configures Azure DevOps build agents on Windows.",
+  "Version": "1.5.2-preview",
+  "Manifest": {
+    "Author": "DevOps Teamet"
+  },
+  "Package": {
+    "RepositoryUrl": "https://packages.example/raw/",
+    "Auth": {
+      "HeaderName": "Authorization",
+      "Scheme": "Basic",
+      "Token": "NEXUS_TOKEN"
+    },
+    "Repositories": [
+      {
+        "Name": "staging",
+        "Url": "https://packages.example/raw/staging/",
+        "Auth": {
+          "TokenEnvironmentVariable": "NEXUS_STAGING_TOKEN"
+        }
+      }
+    ]
+  }
+}
+'@
+            Mock Get-GitCommitMessageForVersionBump {@('feat!: breaking api')}
+            Mock Write-Host {}
+            $warningMessages = $null
+
+            $result = Update-NovaModuleVersion -Path $projectRoot -Confirm:$false -WarningVariable warningMessages
+            $updatedProject = Get-Content -LiteralPath $projectJsonPath -Raw | ConvertFrom-Json
+
+            $result.PreviousVersion | Should -Be '1.5.2-preview'
+            $result.NewVersion | Should -Be '2.0.0'
+            $result.Label | Should -Be 'Major'
+            $updatedProject.Version | Should -Be '2.0.0'
+            ($updatedProject.Package.Repositories[0] -is [string]) | Should -BeFalse
+            $updatedProject.Package.Repositories[0].Name | Should -Be 'staging'
+            $updatedProject.Package.Repositories[0].Auth.TokenEnvironmentVariable | Should -Be 'NEXUS_STAGING_TOKEN'
+            $warningMessages | Should -BeNullOrEmpty
+        }
+    }
+
     It 'Update-NovaModuleVersion -WhatIf falls back to a Patch preview when the project is not a git repository' {
         InModuleScope $script:moduleName {
             $projectRoot = Join-Path $TestDrive 'no-git-bump-project'


### PR DESCRIPTION
## Summary

- What changed?
  - Fixed the `project.json` write path used by `Update-NovaModuleVersion` / `nova bump` so nested JSON structures are preserved when the version is updated.
  - Added regression coverage for both the internal write path and the public bump command path to verify nested `Package.Repositories` and nested `Auth` objects survive a real version write.
  - Updated the unreleased changelog entry to document the bugfix.
  - Updated the repository `project.json` version from `2.0.0-preview7` to `2.0.0-preview8` as part of the branch changes.

- Why was this change needed?
  - `nova bump` could rewrite nested `Package.Repositories` entries into PowerShell string output such as `"@{...}"` instead of preserving valid JSON objects.
  - The command also emitted `WARNING: Resulting JSON is truncated as serialization has exceeded the set depth of 2.`, which showed the write path was serializing `project.json` with insufficient JSON depth.
  - This fix ensures version bumps only update the intended version field without corrupting unrelated nested configuration.

- Link the issue, discussion, or follow-up work (for example `Closes #123`).
  - Fixes the `nova bump` / `Update-NovaModuleVersion` nested `Package.Repositories` serialization bug tracked on branch `bug/91-investigate-why-nova-bump-rewrites-packagerepositories-in-projectjson`.

## Affected area

- [x] `nova` CLI or command routing
- [x] Public PowerShell cmdlet behavior
- [x] Scaffolding or `project.json` handling
- [ ] Build, test, analyzer, coverage, or CI helper flow
- [ ] Package, raw upload, or package metadata workflow
- [ ] Publish, release, semantic-release, or GitHub Actions automation
- [ ] Self-update or notification preference behavior
- [ ] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
- [ ] End-user docs (`docs/*.html`)
- [ ] Command help (`docs/NovaModuleTools/en-US/*.md`)
- [ ] `src/resources/example/`
- [ ] Dependency or manifest changes (`package.json`, workflow dependencies, release tooling)
- [ ] Security-sensitive change
- [ ] Documentation-only change
- [x] Other

## Review guidance

- Highlight the main code path or workflow reviewers should start with.
  - Start with `src/private/release/SetNovaModuleVersion.ps1`.
  - Then review the new regression coverage in:
    - `tests/CoverageGaps.ReleaseInternals.Tests.ps1`
    - `tests/NovaCommandModel.BumpAndCli.Tests.ps1`
  - Finish with the changelog update in `CHANGELOG.md`.

- Call out the primary files or folders changed (for example `src/public/`, `src/private/cli/`, `scripts/build/ci/`,
  `.github/workflows/`, `docs/`, or `src/resources/example/`).
  - Primary implementation:
    - `src/private/release/`
  - Primary regression coverage:
    - `tests/`
  - Release notes metadata:
    - `CHANGELOG.md`
    - `project.json`

- Call out any trade-offs, follow-up work, or known limitations.
  - The code fix is intentionally minimal: it corrects the current write-path serialization depth rather than doing the larger follow-up refactor to centralize all `project.json` writing behind one shared helper.
  - This branch fixes the concrete corruption bug now, while still leaving room for a future maintainability refactor.
  - The targeted tests cover the cmdlet and command-path behavior, but broad CI helper flows were not rerun as part of this PR preparation.

## Validation

- [x] `Invoke-NovaBuild`
- [ ] `Test-NovaBuild`
- [ ] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
- [ ] Targeted Nova workflow validated (`nova build`, `nova test`, `nova merge`, `nova deploy`, `nova publish`,
  `nova release`, `nova update`, `nova notification`, or `nova init` as relevant)
- [ ] Docs/example only; executable validation not needed

Validation notes:

```text
Confirmed in this branch work:

- pwsh -NoLogo -NoProfile -Command 'Invoke-NovaBuild'
  - completed successfully

- pwsh -NoLogo -NoProfile -Command 'Invoke-Pester ./tests/CoverageGaps.ReleaseInternals.Tests.ps1 -Output Detailed; Invoke-Pester ./tests/NovaCommandModel.BumpAndCli.Tests.ps1 -Output Detailed'
  - CoverageGaps.ReleaseInternals.Tests.ps1: 27 passed, 0 failed
  - NovaCommandModel.BumpAndCli.Tests.ps1: 7 passed, 0 failed

- git --no-pager diff --check -- src/private/release/SetNovaModuleVersion.ps1 tests/CoverageGaps.ReleaseInternals.Tests.ps1 tests/NovaCommandModel.BumpAndCli.Tests.ps1 CHANGELOG.md
  - no diff-check issues in the edited files

Not re-run for this PR write-up:
- Test-NovaBuild
- ScriptAnalyzer CI wrapper
- Full CI helper script
- Standalone `nova bump` shell-level smoke test
```

## Documentation and release follow-up

- [ ] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
- [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
- [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [ ] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
- [ ] `docs/*.html` updated if end-user workflows or examples changed
- [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
  changed
- [x] No documentation, changelog, or example updates were needed

## Maintainability, compatibility, and risk

- [x] Code Health / maintainability impact considered
- [x] No breaking change
- [ ] Breaking change
- [ ] Security-sensitive change
- [ ] CI, workflow, or release-pipeline impact
- [ ] Dependency-review impact

Risk, rollout, or rollback notes:

```text
Compatibility impact:
- Low risk. The fix only changes how `project.json` is serialized after a version bump so nested objects are preserved correctly.
- No intended CLI or SemVer behavior changes beyond preventing JSON corruption.

Rollback:
- Revert the serialization-depth change in `src/private/release/SetNovaModuleVersion.ps1`.
- Revert the regression tests and changelog entry added in this branch.

Maintainer follow-up:
- A future maintainability improvement could still centralize all `project.json` writing behind one shared helper so scaffold and version-bump flows stop owning separate serialization logic.
```

> [!IMPORTANT]
> Do not use a public pull request to disclose a vulnerability before coordinated handling.
> Use the private reporting path in `SECURITY.md` for new security issues.


