### PR TITLE
feat(#101): implement opt-in preview bump mode for nova bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `nova version -Installed` so users can compare the locally installed version of the current project/module with
   the current project version from `project.json`, while keeping `nova --version` dedicated to the installed
   NovaModuleTools version.
+- Add an opt-in `-Preview` mode to `Update-NovaModuleVersion` / `nova bump` for explicit preview iteration.
+    - Stable versions still use the normal semantic bump target first, then append `-preview`.
+    - Existing prerelease versions now stay on the same semantic core and preserve the current prerelease stem while
+      appending or incrementing trailing digits, for example `preview -> preview1`, `rc1 -> rc2`, and
+      `SNAPSHOT -> SNAPSHOT1`.
 - Add `New-NovaModulePackage` and `nova package` so projects can build, test, and package the built module output as a
   `.nupkg`
   artifact by using generic metadata from `project.json`, including repositories whose test runs reload or remove

--- a/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
@@ -4,7 +4,7 @@ external help file: NovaModuleTools-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: NovaModuleTools
-ms.date: 04/19/2026
+ms.date: 04/22/2026
 PlatyPS schema version: 2024-05-01
 title: Invoke-NovaCli
 ---
@@ -84,6 +84,11 @@ before running a prerelease update. If no newer version is available, the standa
 For the standalone launcher, `nova bump -Confirm` uses a CLI-friendly confirmation prompt. Declined or suspended choices
 cancel the bump cleanly and return control to the shell without printing a version result.
 
+Use `nova bump -Preview` when you want an explicit prerelease-continuation bump. Stable versions resolve to the normal
+semantic target plus `-preview`, while existing prerelease versions stay on the same semantic core and preserve the
+current prerelease stem while appending or incrementing trailing digits such as `preview -> preview1`, `rc1 -> rc2`,
+or `SNAPSHOT -> SNAPSHOT1`.
+
 `nova init` remains interactive. Use `nova init -Path <path>` when you want an explicit destination and
 `nova init -Example` when you want the packaged example scaffold. The CLI rejects positional `nova init <path>` usage
 and also rejects `nova init -WhatIf` with a clear error.
@@ -129,6 +134,14 @@ PS> nova init --help
 Shows the full help for `Initialize-NovaModule` through the CLI without starting the interactive scaffold flow.
 
 ### EXAMPLE 16
+
+```powershell
+nova bump -Preview -WhatIf
+```
+
+Previews an explicit preview bump by routing `-Preview` through `Update-NovaModuleVersion`.
+
+### EXAMPLE 17
 
 ```powershell
 nova version
@@ -228,7 +241,7 @@ PS> Invoke-NovaCli -Command init -Arguments @('-Example', '-Path', '~/Work')
 
 Runs the interactive init flow, scaffolds from the packaged example project, and creates the project under `~/Work`.
 
-### EXAMPLE 14
+### EXAMPLE 18
 
 ```powershell
 nova update
@@ -245,7 +258,7 @@ Successful updates print the release notes link from the installed module manife
 If no newer version is available, the standalone launcher prints `You're up to date!` and reports the installed
 `NovaModuleTools` version.
 
-### EXAMPLE 15
+### EXAMPLE 19
 
 ```powershell
 nova notification
@@ -253,7 +266,7 @@ nova notification
 
 Shows whether prerelease self-updates are enabled and where the preference is stored.
 
-### EXAMPLE 16
+### EXAMPLE 20
 
 ```powershell
 nova notification -disable
@@ -261,7 +274,7 @@ nova notification -disable
 
 Disables prerelease self-update targets so `nova update` stays on stable releases.
 
-### EXAMPLE 17
+### EXAMPLE 21
 
 ```powershell
 PS> Invoke-NovaCli -Command notification -Arguments @('-enable')

--- a/docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md
+++ b/docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md
@@ -4,7 +4,7 @@ external help file: NovaModuleTools-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: NovaModuleTools
-ms.date: 04/15/2026
+ms.date: 04/22/2026
 PlatyPS schema version: 2024-05-01
 title: Update-NovaModuleVersion
 ---
@@ -20,7 +20,7 @@ Updates the project version in `project.json` based on git commit history.
 ### __AllParameterSets
 
 ```powershell
-PS> Update-NovaModuleVersion [[-Path] <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+PS> Update-NovaModuleVersion [[-Path] <string>] [-Preview] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -28,6 +28,11 @@ PS> Update-NovaModuleVersion [[-Path] <string>] [-WhatIf] [-Confirm] [<CommonPar
 `Update-NovaModuleVersion` reads the current project version from `project.json`, collects Git commit messages from the
 project repository, chooses a semantic version bump label, calculates the next semantic version, and writes the updated
 version back to `project.json`.
+
+Use `-Preview` when you want an explicit prerelease-continuation bump instead of the default prerelease finalization
+behavior. In preview mode, stable versions first calculate the normal semantic bump target and then append
+`-preview`. Existing prerelease versions keep the same semantic core and preserve the current prerelease stem while
+appending or incrementing trailing digits: `preview -> preview1`, `rc1 -> rc2`, and `SNAPSHOT -> SNAPSHOT1`.
 
 The release label is inferred from the commit set:
 
@@ -101,6 +106,53 @@ CommitCount: 84
 
 Shows how Nova finalizes an existing prerelease target instead of carrying the old prerelease label into the next major.
 
+### EXAMPLE 5
+
+```text
+PS> Update-NovaModuleVersion -Preview -WhatIf
+
+What if: Performing the operation "Update module version using Minor release label" on target "project.json".
+
+PreviousVersion: 1.5.3
+NewVersion: 1.6.0-preview
+Label: Minor
+CommitCount: 12
+```
+
+Shows how `-Preview` keeps the normal bump label selection but emits a preview target when the current version is
+stable.
+
+### EXAMPLE 6
+
+```text
+PS> Update-NovaModuleVersion -Preview -WhatIf
+
+What if: Performing the operation "Update module version using Patch release label" on target "project.json".
+
+PreviousVersion: 1.5.3-preview1
+NewVersion: 1.5.3-preview2
+Label: Patch
+CommitCount: 3
+```
+
+Shows how `-Preview` stays on the same semantic core and increments the current prerelease label when the current
+version is already a prerelease.
+
+### EXAMPLE 7
+
+```text
+PS> Update-NovaModuleVersion -Preview -WhatIf
+
+What if: Performing the operation "Update module version using Patch release label" on target "project.json".
+
+PreviousVersion: 1.5.3-rc1
+NewVersion: 1.5.3-rc2
+Label: Patch
+CommitCount: 3
+```
+
+Shows how `-Preview` preserves non-preview prerelease stems such as `rc` and only increments the trailing number.
+
 ## PARAMETERS
 
 ### -Path
@@ -121,6 +173,31 @@ ParameterSets:
   ValueFromRemainingArguments: false
 DontShow: false
 AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Preview
+
+Opt into preview bump mode.
+
+When the current version is stable, Nova calculates the normal semantic target and appends `-preview`. When the current
+version already has any prerelease label, Nova keeps the same semantic core version and increments the current
+prerelease suffix instead of finalizing or advancing to another release line.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: [ ]
+ParameterSets:
+  - Name: (All)
+    Position: Named
+    IsRequired: false
+    ValueFromPipeline: false
+    ValueFromPipelineByPropertyName: false
+    ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: [ ]
 HelpMessage: ''
 ```
 

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -298,7 +298,7 @@ nova release -repository PSGallery -apikey $env:PSGALLERY_API</code></pre>
                         </p>
                         <ul class="plain-list">
                             <li><strong>Best for:</strong> Git-driven semantic version updates</li>
-                            <li><strong>Key parameter:</strong> <code>-Path</code></li>
+                            <li><strong>Key parameters:</strong> <code>-Path</code>, <code>-Preview</code></li>
                             <li><strong>Notable behavior:</strong> falls back to a patch bump when the folder is not a
                                 Git repository, but throws when the repository exists and has no commits yet
                             </li>
@@ -307,9 +307,14 @@ nova release -repository PSGallery -apikey $env:PSGALLERY_API</code></pre>
                                 into
                                 the next release line
                             </li>
+                            <li><strong>Preview mode:</strong> <code>-Preview</code> keeps the default bump rules for
+                                stable versions but appends <code>-preview</code>, and it preserves any existing
+                                prerelease stem while appending or incrementing trailing digits on the same semantic
+                                core
+                            </li>
                         </ul>
-                        <pre><code>Update-NovaModuleVersion -WhatIf
-nova bump -Confirm</code></pre>
+                        <pre><code>Update-NovaModuleVersion -Preview -WhatIf
+nova bump -Preview -Confirm</code></pre>
                         <p><a class="text-link" href="./versioning-and-updates.html#bump">See versioning rules</a></p>
                     </article>
 

--- a/docs/versioning-and-updates.html
+++ b/docs/versioning-and-updates.html
@@ -145,8 +145,19 @@ nova --version</code></pre>
 1.3.0-preview7 + Minor -> 1.3.0
 1.2.4-preview7 + Patch -> 1.2.4
 1.2.3-preview7 + Minor -> 1.3.0</code></pre>
+                <p>Use <code>-Preview</code> when you want that bump to stay explicitly in prerelease mode. Stable
+                    versions first resolve the normal semantic target and then append <code>-preview</code>. Existing
+                    prerelease versions keep the same semantic core and preserve the current prerelease stem while
+                    appending or incrementing trailing digits instead of finalizing.</p>
+                <pre><code>1.5.3 + Minor + -Preview -> 1.6.0-preview
+1.5.3-preview + -Preview -> 1.5.3-preview1
+1.5.3-preview1 + -Preview -> 1.5.3-preview2
+1.5.3-rc1 + -Preview -> 1.5.3-rc2
+1.5.3-SNAPSHOT + -Preview -> 1.5.3-SNAPSHOT1</code></pre>
                 <pre><code>Update-NovaModuleVersion -WhatIf
+Update-NovaModuleVersion -Preview -WhatIf
 nova bump -WhatIf
+nova bump -Preview -WhatIf
 nova bump -Confirm</code></pre>
                 <div class="notice notice--warning">
                     <strong>Empty repository rule.</strong>

--- a/src/private/cli/ConvertFromNovaBumpCliArgument.ps1
+++ b/src/private/cli/ConvertFromNovaBumpCliArgument.ps1
@@ -1,0 +1,23 @@
+function ConvertFrom-NovaBumpCliArgument {
+    [CmdletBinding()]
+    param(
+        [string[]]$Arguments
+    )
+
+    $Arguments = ConvertTo-NovaCliArgumentArray -BoundParameters $PSBoundParameters -Arguments $Arguments
+    $options = @{}
+
+    foreach ($token in $Arguments) {
+        switch -Regex ($token) {
+            '^(--preview|-Preview)$' {
+                $options.Preview = $true
+            }
+            default {
+                throw "Unknown argument: $token"
+            }
+        }
+    }
+
+    return $options
+}
+

--- a/src/private/release/GetNovaVersionPreReleaseLabel.ps1
+++ b/src/private/release/GetNovaVersionPreReleaseLabel.ps1
@@ -1,12 +1,13 @@
 function Get-NovaVersionPreReleaseLabel {
     [CmdletBinding()]
     param(
+        [AllowNull()][semver]$CurrentVersion,
         [switch]$PreviewRelease,
         [switch]$StableRelease
     )
 
     if ($PreviewRelease) {
-        return 'preview'
+        return Get-NovaPreviewReleaseLabel -CurrentVersion $CurrentVersion
     }
 
     if ($StableRelease) {
@@ -14,4 +15,34 @@ function Get-NovaVersionPreReleaseLabel {
     }
 
     return $null
+}
+
+function Get-NovaPreviewReleaseLabel {
+    [CmdletBinding()]
+    param(
+        [AllowNull()][semver]$CurrentVersion
+    )
+
+    if ($null -eq $CurrentVersion -or [string]::IsNullOrWhiteSpace($CurrentVersion.PreReleaseLabel)) {
+        return 'preview'
+    }
+
+    return Get-NovaNextPreReleaseLabel -PreReleaseLabel $CurrentVersion.PreReleaseLabel
+}
+
+function Get-NovaNextPreReleaseLabel {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$PreReleaseLabel
+    )
+
+    $match = [regex]::Match($PreReleaseLabel, '^(?<Stem>.*?)(?<Number>\d+)?$')
+    $stem = $match.Groups['Stem'].Value
+    $preReleaseNumber = $match.Groups['Number'].Value
+
+    if ( [string]::IsNullOrWhiteSpace($preReleaseNumber)) {
+        return "$stem`1"
+    }
+
+    return "$stem$( [int]$preReleaseNumber + 1 )"
 }

--- a/src/private/release/GetNovaVersionUpdatePlan.ps1
+++ b/src/private/release/GetNovaVersionUpdatePlan.ps1
@@ -10,8 +10,8 @@ function Get-NovaVersionUpdatePlan {
     $projectInfo = Get-NovaProjectInfo
     $jsonContent = Get-Content -LiteralPath $projectInfo.ProjectJSON -Raw | ConvertFrom-Json
     [semver]$currentVersion = $jsonContent.Version
-    $versionPart = Get-NovaVersionPartForLabel -CurrentVersion $currentVersion -Label $Label
-    $releaseType = Get-NovaVersionPreReleaseLabel -PreviewRelease:$PreviewRelease -StableRelease:$StableRelease
+    $versionPart = Get-NovaVersionPartForUpdatePlan -CurrentVersion $currentVersion -Label $Label -PreviewRelease:$PreviewRelease
+    $releaseType = Get-NovaVersionPreReleaseLabel -CurrentVersion $currentVersion -PreviewRelease:$PreviewRelease -StableRelease:$StableRelease
     $newVersion = [semver]::new($versionPart.Major, $versionPart.Minor, $versionPart.Patch, $releaseType, $null)
 
     return [pscustomobject]@{
@@ -19,4 +19,19 @@ function Get-NovaVersionUpdatePlan {
         CurrentVersion = $currentVersion
         NewVersion = $newVersion
     }
+}
+
+function Get-NovaVersionPartForUpdatePlan {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][semver]$CurrentVersion,
+        [Parameter(Mandatory)][string]$Label,
+        [switch]$PreviewRelease
+    )
+
+    if ($PreviewRelease -and -not [string]::IsNullOrWhiteSpace($CurrentVersion.PreReleaseLabel)) {
+        return Get-NovaVersionPartObject -CurrentVersion $CurrentVersion
+    }
+
+    return Get-NovaVersionPartForLabel -CurrentVersion $CurrentVersion -Label $Label
 }

--- a/src/public/InvokeNovaCli.ps1
+++ b/src/public/InvokeNovaCli.ps1
@@ -39,7 +39,8 @@ function Invoke-NovaCli {
             return Invoke-NovaCliInitCommand -Arguments $Arguments -ForwardedParameters $mutatingCommonParameters -WhatIfEnabled:$WhatIfPreference
         }
         'bump' {
-            return Update-NovaModuleVersion @mutatingCommonParameters
+            $options = ConvertFrom-NovaBumpCliArgument -Arguments $Arguments
+            return Update-NovaModuleVersion @options @mutatingCommonParameters
         }
         'update' {
             $result = Invoke-NovaCliUpdateCommand -Arguments $Arguments -ForwardedParameters $mutatingCommonParameters

--- a/src/public/UpdateNovaModuleVersion.ps1
+++ b/src/public/UpdateNovaModuleVersion.ps1
@@ -1,7 +1,8 @@
 function Update-NovaModuleVersion {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(
-        [string]$Path = (Get-Location).Path
+        [string]$Path = (Get-Location).Path,
+        [switch]$Preview
     )
 
     $projectRoot = (Resolve-Path -LiteralPath $Path).Path
@@ -13,7 +14,7 @@ function Update-NovaModuleVersion {
 
     Push-Location -LiteralPath $projectRoot
     try {
-        $versionUpdatePlan = Get-NovaVersionUpdatePlan -Label $label
+        $versionUpdatePlan = Get-NovaVersionUpdatePlan -Label $label -PreviewRelease:$Preview
         $target = [System.IO.Path]::GetFileName($before.ProjectJSON)
         $action = "Update module version using $label release label"
         $nextVersion = $versionUpdatePlan.NewVersion.ToString()
@@ -26,7 +27,7 @@ function Update-NovaModuleVersion {
         }
 
         if ( $PSCmdlet.ShouldProcess($target, $action)) {
-            Set-NovaModuleVersion -Label $label -Confirm:$false
+            Set-NovaModuleVersion -Label $label -PreviewRelease:$Preview -Confirm:$false
             $shouldReturnResult = $true
         }
     }

--- a/tests/CoverageGaps.Cli.Tests.ps1
+++ b/tests/CoverageGaps.Cli.Tests.ps1
@@ -72,10 +72,22 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
             Invoke-NovaCli -Command init -Arguments @('-Example') | Should -Be 'init-example-default'
             Invoke-NovaCli -Command init -Arguments @('-Example', '-Path', '/tmp/demo') | Should -Be 'init-example:/tmp/demo'
             Invoke-NovaCli bump | Should -Be 'bump-value'
+            Invoke-NovaCli bump -Preview | Should -Be 'bump-value'
             (Invoke-NovaCli notification).Mode | Should -Be 'status'
             (Invoke-NovaCli notification -disable).Disabled | Should -BeTrue
             (Invoke-NovaCli notification -enable).Enabled | Should -BeTrue
             (Invoke-NovaCli release --repository PSGallery --apikey key123).Repository | Should -Be 'PSGallery'
+
+            Assert-MockCalled Update-NovaModuleVersion -Times 1 -ParameterFilter {-not $Preview}
+            Assert-MockCalled Update-NovaModuleVersion -Times 1 -ParameterFilter {$Preview}
+        }
+    }
+
+    It 'ConvertFrom-NovaBumpCliArgument parses the preview switch and rejects unsupported bump arguments' {
+        InModuleScope $script:moduleName {
+            (ConvertFrom-NovaBumpCliArgument -Arguments @('--preview')).Preview | Should -BeTrue
+            (ConvertFrom-NovaBumpCliArgument -Arguments @('-Preview')).Preview | Should -BeTrue
+            {ConvertFrom-NovaBumpCliArgument -Arguments @('--bogus')} | Should -Throw 'Unknown argument: --bogus'
         }
     }
 

--- a/tests/CoverageGaps.ReleaseInternals.Tests.ps1
+++ b/tests/CoverageGaps.ReleaseInternals.Tests.ps1
@@ -74,10 +74,24 @@ Describe 'Coverage gaps for release and git internals' {
 
     It 'Get-NovaVersionPreReleaseLabel returns preview or stable output without preserving prerelease labels by default' {
         InModuleScope $script:moduleName {
-            Get-NovaVersionPreReleaseLabel -PreviewRelease | Should -Be 'preview'
+            Get-NovaVersionPreReleaseLabel -CurrentVersion ([semver]'1.2.3') -PreviewRelease | Should -Be 'preview'
             $stable = Get-NovaVersionPreReleaseLabel -StableRelease
             $stable | Should -BeNullOrEmpty
             Get-NovaVersionPreReleaseLabel | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'Get-NovaVersionPreReleaseLabel increments existing prerelease labels generically when preview mode is requested' -ForEach @(
+        @{CurrentVersion = '1.2.3-preview'; Expected = 'preview1'}
+        @{CurrentVersion = '1.2.3-preview1'; Expected = 'preview2'}
+        @{CurrentVersion = '1.2.3-preview.7'; Expected = 'preview.8'}
+        @{CurrentVersion = '1.2.3-rc1'; Expected = 'rc2'}
+        @{CurrentVersion = '1.2.3-SNAPSHOT'; Expected = 'SNAPSHOT1'}
+    ) {
+        InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+            param($TestCase)
+
+            Get-NovaVersionPreReleaseLabel -CurrentVersion ([semver]$TestCase.CurrentVersion) -PreviewRelease | Should -Be $TestCase.Expected
         }
     }
 
@@ -104,6 +118,38 @@ Describe 'Coverage gaps for release and git internals' {
             Mock Get-Content {([ordered]@{Version = $TestCase.CurrentVersion} | ConvertTo-Json -Compress)} -ParameterFilter {$LiteralPath -eq '/tmp/project.json' -and $Raw}
 
             (Get-NovaVersionUpdatePlan -Label $TestCase.Label).NewVersion.ToString() | Should -Be $TestCase.ExpectedVersion
+        }
+    }
+
+    It 'Get-NovaVersionUpdatePlan appends a preview label to the normal bump target when preview mode starts from stable' -ForEach @(
+        @{CurrentVersion = '1.5.3'; Label = 'Major'; ExpectedVersion = '2.0.0-preview'}
+        @{CurrentVersion = '1.5.3'; Label = 'Minor'; ExpectedVersion = '1.6.0-preview'}
+        @{CurrentVersion = '1.5.3'; Label = 'Patch'; ExpectedVersion = '1.5.4-preview'}
+    ) {
+        InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+            param($TestCase)
+
+            Mock Get-NovaProjectInfo {[pscustomobject]@{ProjectJSON = '/tmp/project.json'}}
+            Mock Get-Content {([ordered]@{Version = $TestCase.CurrentVersion} | ConvertTo-Json -Compress)} -ParameterFilter {$LiteralPath -eq '/tmp/project.json' -and $Raw}
+
+            (Get-NovaVersionUpdatePlan -Label $TestCase.Label -PreviewRelease).NewVersion.ToString() | Should -Be $TestCase.ExpectedVersion
+        }
+    }
+
+    It 'Get-NovaVersionUpdatePlan keeps the semantic core and increments an existing prerelease label when preview mode continues a prerelease' -ForEach @(
+        @{CurrentVersion = '1.5.3-preview'; ExpectedVersion = '1.5.3-preview1'}
+        @{CurrentVersion = '1.5.3-preview1'; ExpectedVersion = '1.5.3-preview2'}
+        @{CurrentVersion = '1.5.3-preview2'; ExpectedVersion = '1.5.3-preview3'}
+        @{CurrentVersion = '1.5.3-rc1'; ExpectedVersion = '1.5.3-rc2'}
+        @{CurrentVersion = '1.5.3-SNAPSHOT'; ExpectedVersion = '1.5.3-SNAPSHOT1'}
+    ) {
+        InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+            param($TestCase)
+
+            Mock Get-NovaProjectInfo {[pscustomobject]@{ProjectJSON = '/tmp/project.json'}}
+            Mock Get-Content {([ordered]@{Version = $TestCase.CurrentVersion} | ConvertTo-Json -Compress)} -ParameterFilter {$LiteralPath -eq '/tmp/project.json' -and $Raw}
+
+            (Get-NovaVersionUpdatePlan -Label Minor -PreviewRelease).NewVersion.ToString() | Should -Be $TestCase.ExpectedVersion
         }
     }
 

--- a/tests/NovaCommandModel.BumpAndCli.Tests.ps1
+++ b/tests/NovaCommandModel.BumpAndCli.Tests.ps1
@@ -60,30 +60,46 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
         }
     }
 
-    It 'Update-NovaModuleVersion -WhatIf previews the calculated next version without persisting it' {
-        InModuleScope $script:moduleName {
+    It 'Update-NovaModuleVersion -WhatIf returns the expected next version without persisting it when <Name>' -ForEach @(
+        @{Name = 'the default bump flow is used'; CurrentVersion = '1.0.0'; CommitMessages = @('feat: add change'); Label = 'Minor'; NewVersion = '1.1.0'; Preview = $false}
+        @{Name = 'preview mode starts from a stable version'; CurrentVersion = '1.5.3'; CommitMessages = @('feat: add change'); Label = 'Minor'; NewVersion = '1.6.0-preview'; Preview = $true}
+        @{Name = 'preview mode continues an existing prerelease version'; CurrentVersion = '1.5.3-rc1'; CommitMessages = @('feat!: breaking api'); Label = 'Major'; NewVersion = '1.5.3-rc2'; Preview = $true}
+    ) {
+        InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+            param($TestCase)
+
             Mock Get-NovaProjectInfo {
                 [pscustomobject]@{
-                    Version = '1.0.0'
+                    Version = $TestCase.CurrentVersion
                     ProjectJSON = '/tmp/project.json'
                 }
             }
-            Mock Get-GitCommitMessageForVersionBump {@('feat: add change')}
-            Mock Get-VersionLabelFromCommitSet {'Minor'}
+            Mock Get-GitCommitMessageForVersionBump {$TestCase.CommitMessages}
+            Mock Get-VersionLabelFromCommitSet {$TestCase.Label}
             Mock Get-NovaVersionUpdatePlan {
                 [pscustomobject]@{
                     ProjectFile = '/tmp/project.json'
-                    CurrentVersion = [semver]'1.0.0'
-                    NewVersion = [semver]'1.1.0'
+                    CurrentVersion = [semver]$TestCase.CurrentVersion
+                    NewVersion = [semver]$TestCase.NewVersion
                 }
             }
             Mock Set-NovaModuleVersion {}
 
-            $result = Update-NovaModuleVersion -Path (Get-Location).Path -WhatIf
+            $parameters = @{Path = (Get-Location).Path; WhatIf = $true}
+            if ($TestCase.Preview) {
+                $parameters.Preview = $true
+            }
 
-            $result.PreviousVersion | Should -Be '1.0.0'
-            $result.NewVersion | Should -Be '1.1.0'
-            $result.Label | Should -Be 'Minor'
+            $result = Update-NovaModuleVersion @parameters
+
+            $result.PreviousVersion | Should -Be $TestCase.CurrentVersion
+            $result.NewVersion | Should -Be $TestCase.NewVersion
+            $result.Label | Should -Be $TestCase.Label
+            Assert-MockCalled Get-NovaVersionUpdatePlan -Times 1 -ParameterFilter {$Label -eq $TestCase.Label}
+            if ($TestCase.Preview) {
+                Assert-MockCalled Get-NovaVersionUpdatePlan -Times 1 -ParameterFilter {$Label -eq $TestCase.Label -and $PreviewRelease}
+            }
+
             Assert-MockCalled Set-NovaModuleVersion -Times 0
         }
     }

--- a/tests/NovaCommandModel.StandaloneCli.Tests.ps1
+++ b/tests/NovaCommandModel.StandaloneCli.Tests.ps1
@@ -186,20 +186,65 @@ function Invoke-TestCliVerbose {
             $buildResult = Invoke-TestInstalledNovaCommand -InstalledPath $installedPath -WorkingDirectory $projectRoot -Arguments @('build', '-WhatIf')
             $publishResult = Invoke-TestInstalledNovaCommand -InstalledPath $installedPath -WorkingDirectory $projectRoot -Arguments @('publish', '--local', '-WhatIf')
             $bumpResult = Invoke-TestInstalledNovaCommand -InstalledPath $installedPath -WorkingDirectory $projectRoot -Arguments @('bump', '-WhatIf')
+            $previewBumpResult = Invoke-TestInstalledNovaCommand -InstalledPath $installedPath -WorkingDirectory $projectRoot -Arguments @('bump', '-Preview', '-WhatIf')
             $versionAfterBump = (Get-Content -LiteralPath $projectJsonPath -Raw | ConvertFrom-Json).Version
 
             $buildResult.ExitCode | Should -Be 0
             $publishResult.ExitCode | Should -Be 0
             $bumpResult.ExitCode | Should -Be 0
+            $previewBumpResult.ExitCode | Should -Be 0
             $buildResult.Text | Should -Match 'What if:'
             $publishResult.Text | Should -Match 'What if:'
             $publishResult.Text | Should -Not -Match 'Unknown argument:'
             $bumpResult.Text | Should -Match 'What if:'
             $bumpResult.Text | Should -Match '0\.0\.1\s+0\.1\.0\s+Minor\s+1'
+            $previewBumpResult.Text | Should -Match 'What if:'
+            $previewBumpResult.Text | Should -Match '0\.0\.1\s+0\.1\.0-preview\s+Minor\s+1'
             $bumpResult.Text | Should -Not -Match 'Version bumped to :'
+            $previewBumpResult.Text | Should -Not -Match 'Unknown argument:'
+            $previewBumpResult.Text | Should -Not -Match 'Version bumped to :'
             $versionAfterBump | Should -Be '0.0.1'
             (Test-Path -LiteralPath $builtModulePath) | Should -BeFalse
             (Test-Path -LiteralPath $testResultPath) | Should -BeFalse
+        }
+        finally {
+            $env:PSModulePath = $originalModulePath
+        }
+    }
+
+    It 'Install-NovaCli forwards -Preview so prerelease bumps keep the same semantic core and increment the current prerelease label' {
+        $targetDirectory = Join-Path $TestDrive 'preview-bump-bin'
+        $installedPath = Join-Path $targetDirectory 'nova'
+        $projectRoot = Join-Path $TestDrive 'CliPreviewBumpProject'
+        $projectJsonPath = Join-Path $projectRoot 'project.json'
+        $originalModulePath = $env:PSModulePath
+        $modulePathSeparator = [string][System.IO.Path]::PathSeparator
+        $distParent = Split-Path -Parent $script:distModuleDir
+
+        $env:PSModulePath = "$distParent$modulePathSeparator$originalModulePath"
+
+        Initialize-TestNovaCliProjectLayout -ProjectRoot $projectRoot
+        Write-TestNovaCliProjectJson -ProjectRoot $projectRoot -ProjectName 'CliPreviewBumpProject' -ProjectGuid '44444444-4444-4444-4444-444444444444'
+        Write-TestNovaCliPublicFunction -ProjectRoot $projectRoot -FunctionName 'Invoke-TestCliPreviewBump'
+
+        $projectData = Get-Content -LiteralPath $projectJsonPath -Raw | ConvertFrom-Json
+        $projectData.Version = '0.0.1-rc1'
+        $projectData | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $projectJsonPath -Encoding utf8
+
+        try {
+            Initialize-TestNovaCliGitRepository -ProjectRoot $projectRoot -CommitMessage 'feat!: add prerelease cli bump coverage'
+
+            Install-NovaCli -DestinationDirectory $targetDirectory -Force | Out-Null
+
+            $previewBumpResult = Invoke-TestInstalledNovaCommand -InstalledPath $installedPath -WorkingDirectory $projectRoot -Arguments @('bump', '-Preview', '-WhatIf')
+            $versionAfterBump = (Get-Content -LiteralPath $projectJsonPath -Raw | ConvertFrom-Json).Version
+
+            $previewBumpResult.ExitCode | Should -Be 0
+            $previewBumpResult.Text | Should -Match 'What if:'
+            $previewBumpResult.Text | Should -Match '0\.0\.1-rc1\s+0\.0\.1-rc2\s+Major\s+1'
+            $previewBumpResult.Text | Should -Not -Match 'Unknown argument:'
+            $previewBumpResult.Text | Should -Not -Match 'Version bumped to :'
+            $versionAfterBump | Should -Be '0.0.1-rc1'
         }
         finally {
             $env:PSModulePath = $originalModulePath


### PR DESCRIPTION
## Summary

- Added opt-in `-Preview` support to `Update-NovaModuleVersion` and `nova bump`.
- Stable versions now keep the existing bump-label selection and append `-preview` to the calculated semantic target.
- Existing prerelease versions now keep the same semantic core and increment trailing digits on the current prerelease label instead of always forcing `preview`.
  - Examples:
    - `1.5.3` + patch + `-Preview` -> `1.5.4-preview`
    - `1.5.3-preview` + `-Preview` -> `1.5.3-preview1`
    - `1.5.3-rc1` + `-Preview` -> `1.5.3-rc2`
    - `1.5.3-SNAPSHOT` + `-Preview` -> `1.5.3-SNAPSHOT1`
- Updated routed CLI parsing, standalone CLI coverage, command help, end-user docs, and changelog to reflect the new `-Preview` behavior.

Why this change was needed:
- The existing bump flow correctly chose major/minor/patch targets and finalized prerelease versions in the default path, but it did not provide an explicit preview-iteration mode.
- Release workflows needed a way to keep a version in prerelease mode without manual edits to `project.json`.
- The follow-up clarification also required generic prerelease continuation, not just `preview`-specific incrementation.

Link / follow-up:
- Follow-up to the preview bump discussion and implementation prompt for `nova bump -Preview`.

## Affected area

- [x] `nova` CLI or command routing
- [x] Public PowerShell cmdlet behavior
- [ ] Scaffolding or `project.json` handling
- [x] Build, test, analyzer, coverage, or CI helper flow
- [ ] Package, raw upload, or package metadata workflow
- [ ] Publish, release, semantic-release, or GitHub Actions automation
- [ ] Self-update or notification preference behavior
- [ ] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
- [x] End-user docs (`docs/*.html`)
- [x] Command help (`docs/NovaModuleTools/en-US/*.md`)
- [ ] `src/resources/example/`
- [ ] Dependency or manifest changes (`package.json`, workflow dependencies, release tooling)
- [ ] Security-sensitive change
- [ ] Documentation-only change
- [ ] Other

## Review guidance

- Start with the bump flow in `src/public/UpdateNovaModuleVersion.ps1`, `src/public/InvokeNovaCli.ps1`, and `src/private/cli/ConvertFromNovaBumpCliArgument.ps1`.
- Then review the version-planning logic in:
  - `src/private/release/GetNovaVersionUpdatePlan.ps1`
  - `src/private/release/GetNovaVersionPreReleaseLabel.ps1`
- Finally, review the regression coverage in:
  - `tests/CoverageGaps.ReleaseInternals.Tests.ps1`
  - `tests/NovaCommandModel.BumpAndCli.Tests.ps1`
  - `tests/NovaCommandModel.StandaloneCli.Tests.ps1`
  - `tests/CoverageGaps.Cli.Tests.ps1`

Primary files/folders changed:
- `src/public/`
- `src/private/cli/`
- `src/private/release/`
- `tests/`
- `docs/NovaModuleTools/en-US/`
- `docs/`
- `CHANGELOG.md`

Trade-offs / limitations / follow-up:
- The default non-preview bump behavior remains unchanged by design.
- `-Preview` now preserves the existing prerelease stem and only appends or increments trailing digits; this is intentionally generic and not limited to `preview`.
- This change focuses on bump semantics and CLI/docs coverage only; it does not change release/publish/package workflows.

## Validation

- [x] `Invoke-NovaBuild`
- [ ] `Test-NovaBuild`
- [ ] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
- [x] Targeted Nova workflow validated (`nova build`, `nova test`, `nova merge`, `nova deploy`, `nova publish`,
  `nova release`, `nova update`, `nova notification`, or `nova init` as relevant)
- [ ] Docs/example only; executable validation not needed

Validation notes:

```text
Ran:

pwsh -NoLogo -NoProfile -Command 'Set-Location "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools"; Invoke-NovaBuild'

pwsh -NoLogo -NoProfile -Command 'Set-Location "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools"; Invoke-Pester ./tests/CoverageGaps.ReleaseInternals.Tests.ps1 -Output Detailed'
- Passed: 40

pwsh -NoLogo -NoProfile -Command 'Set-Location "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools"; Invoke-Pester ./tests/NovaCommandModel.BumpAndCli.Tests.ps1 -Output Detailed'
- Passed: 9

pwsh -NoLogo -NoProfile -Command 'Set-Location "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools"; Invoke-Pester ./tests/NovaCommandModel.StandaloneCli.Tests.ps1 -Output Detailed'
- Passed: 23

pwsh -NoLogo -NoProfile -Command 'Set-Location "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools"; Invoke-Pester ./tests/CoverageGaps.Cli.Tests.ps1 -Output Detailed'
- Passed: 20

git -C "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools" --no-pager diff --check
- Passed

Targeted workflow coverage included:
- `Update-NovaModuleVersion -Preview -WhatIf`
- `nova bump -Preview -WhatIf`
- stable-to-preview behavior
- prerelease-to-next-prerelease behavior for `preview`, `rc`, and `SNAPSHOT`
- standalone launcher routing for `nova bump -Preview`
```

## Documentation and release follow-up

- [x] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
- [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
- [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [x] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
- [x] `docs/*.html` updated if end-user workflows or examples changed
- [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
  changed
- [ ] No documentation, changelog, or example updates were needed

## Maintainability, compatibility, and risk

- [x] Code Health / maintainability impact considered
- [x] No breaking change
- [ ] Breaking change
- [ ] Security-sensitive change
- [ ] CI, workflow, or release-pipeline impact
- [ ] Dependency-review impact

Risk, rollout, or rollback notes:

```text
Compatibility impact is low because the new behavior is opt-in behind `-Preview`.
Existing `Update-NovaModuleVersion` / `nova bump` behavior remains unchanged when `-Preview` is not used.

Rollback is straightforward:
- revert the `-Preview` CLI/parser changes
- revert the prerelease-label increment logic
- revert the associated tests/docs/changelog entries

Maintainability was checked with Code Health safeguards, and the updated prerelease helper remained at Code Health 10.0.
```

> [!IMPORTANT]
> Do not use a public pull request to disclose a vulnerability before coordinated handling.
> Use the private reporting path in `SECURITY.md` for new security issues.