### PR TITLE
feat(#92): centralize project.json writing and improve serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change the project to a Nova command model, replacing the previous mixed MT/Nova workflow.
     - All public commands are now Nova commands, and the `nova` CLI/Powershell alias is the primary entry point for all
       operations.
+- Centralize runtime `project.json` writing behind one shared helper so scaffold and version-bump flows use the same
+  serialization policy for nested arrays, nested objects, JSON depth, and UTF-8 output.
 - **BREAKING CHANGE**: Rename the public Nova scaffold cmdlets to approved verbs.
     - `New-NovaModule` → `Initialize-NovaModule`
     - No compatibility aliases are exported for the retired cmdlet names or CLI subcommands.

--- a/src/private/release/SetNovaModuleVersion.ps1
+++ b/src/private/release/SetNovaModuleVersion.ps1
@@ -9,20 +9,14 @@ function Set-NovaModuleVersion {
     Write-Verbose 'Running Version Update'
 
     $versionUpdatePlan = Get-NovaVersionUpdatePlan -Label $Label -PreviewRelease:$PreviewRelease -StableRelease:$StableRelease
-    $jsonContent = Get-Content -LiteralPath $versionUpdatePlan.ProjectFile -Raw | ConvertFrom-Json
+    $jsonContent = Read-ProjectJsonData -ProjectJsonPath $versionUpdatePlan.ProjectFile
     $newVersion = $versionUpdatePlan.NewVersion.ToString()
     $target = [System.IO.Path]::GetFileName($versionUpdatePlan.ProjectFile)
     $action = "Set module version to $newVersion"
 
     if ( $PSCmdlet.ShouldProcess($target, $action)) {
-        # Update the version in the JSON object
         $jsonContent.Version = $newVersion
         Write-Host "Version bumped to : $newVersion"
-
-        # Convert the JSON object back to JSON format
-        $newJsonContent = $jsonContent | ConvertTo-Json -Depth 20
-
-        # Write the updated JSON back to the file
-        $newJsonContent | Set-Content -LiteralPath $versionUpdatePlan.ProjectFile
+        Write-ProjectJsonData -ProjectJsonPath $versionUpdatePlan.ProjectFile -Data $jsonContent
     }
 }

--- a/src/private/scaffold/WriteNovaModuleProjectJson.ps1
+++ b/src/private/scaffold/WriteNovaModuleProjectJson.ps1
@@ -6,7 +6,8 @@ function Write-NovaModuleProjectJson {
         [switch]$Example
     )
 
-    $jsonData = Get-Content (Get-NovaModuleProjectTemplatePath -Example:$Example) -Raw | ConvertFrom-Json -AsHashtable
+    $projectTemplatePath = Get-NovaModuleProjectTemplatePath -Example:$Example
+    $jsonData = Read-ProjectJsonData -ProjectJsonPath $projectTemplatePath
 
     $jsonData.ProjectName = $Answer.ProjectName
     $jsonData.Description = $Answer.Description
@@ -22,5 +23,5 @@ function Write-NovaModuleProjectJson {
     }
 
     Write-Verbose $jsonData
-    $jsonData | ConvertTo-Json -Depth 10 | Out-File $ProjectJsonFile
+    Write-ProjectJsonData -ProjectJsonPath $ProjectJsonFile -Data $jsonData
 }

--- a/src/private/shared/Write-ProjectJsonData.ps1
+++ b/src/private/shared/Write-ProjectJsonData.ps1
@@ -1,0 +1,11 @@
+function Write-ProjectJsonData {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ProjectJsonPath,
+        [Parameter(Mandatory)][hashtable]$Data
+    )
+
+    $projectJsonContent = $Data | ConvertTo-Json -Depth 20
+    Set-Content -LiteralPath $ProjectJsonPath -Value $projectJsonContent -Encoding utf8
+}
+

--- a/tests/CoverageGaps.ReleaseInternals.Tests.ps1
+++ b/tests/CoverageGaps.ReleaseInternals.Tests.ps1
@@ -203,6 +203,40 @@ Describe 'Coverage gaps for release and git internals' {
         }
     }
 
+    It 'Set-NovaModuleVersion delegates project.json persistence to Write-ProjectJsonData' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaVersionUpdatePlan {
+                [pscustomobject]@{
+                    ProjectFile = '/tmp/project.json'
+                    NewVersion = [semver]'1.3.0-preview'
+                }
+            }
+            Mock Read-ProjectJsonData {
+                [ordered]@{
+                    Version = '1.2.3'
+                    Package = [ordered]@{
+                        Repositories = @(
+                            [ordered]@{
+                                Name = 'staging'
+                            }
+                        )
+                    }
+                }
+            }
+            Mock Write-ProjectJsonData {}
+            Mock Write-Host {}
+
+            Set-NovaModuleVersion -Label Minor -PreviewRelease -Confirm:$false
+
+            Assert-MockCalled Read-ProjectJsonData -Times 1 -ParameterFilter {$ProjectJsonPath -eq '/tmp/project.json'}
+            Assert-MockCalled Write-ProjectJsonData -Times 1 -ParameterFilter {
+                $ProjectJsonPath -eq '/tmp/project.json' -and
+                        $Data.Version -eq '1.3.0-preview' -and
+                        $Data.Package.Repositories[0].Name -eq 'staging'
+            }
+        }
+    }
+
     It 'Publish-NovaBuiltModuleToRepository uses the PSGallery fallback api key when needed' {
         InModuleScope $script:moduleName {
             $originalApiKey = $env:PSGALLERY_API

--- a/tests/CoverageGaps.Tests.ps1
+++ b/tests/CoverageGaps.Tests.ps1
@@ -289,6 +289,8 @@ Describe 'Coverage gaps for scaffold internals' {
             $project.Manifest.Author | Should -Be 'Test Author'
             $project.Manifest.PowerShellHostVersion | Should -Be '7.4'
             $project.Manifest.GUID | Should -Be '11111111-1111-1111-1111-111111111111'
+            $project.Package.OutputDirectory.Path | Should -Be 'artifacts/packages'
+            $project.Package.OutputDirectory.Clean | Should -BeTrue
             $project.ContainsKey('Pester') | Should -BeFalse
         }
     }
@@ -314,7 +316,58 @@ Describe 'Coverage gaps for scaffold internals' {
             $project.Manifest.Author | Should -Be 'Example Author'
             $project.Manifest.PowerShellHostVersion | Should -Be '7.5'
             $project.Manifest.GUID | Should -Be 'b3b4ca64-a274-4768-872d-2b3c8bc12a39'
+            $project.Package.OutputDirectory.Path | Should -Be 'artifacts/packages'
+            $project.Package.Repositories[0].Headers.'X-Repository' | Should -Be 'example-raw'
+            $project.Package.Repositories[0].Auth.TokenEnvironmentVariable | Should -Be 'NOVA_EXAMPLE_PACKAGE_TOKEN'
             $project.ContainsKey('Pester') | Should -BeTrue
+        }
+    }
+
+    It 'Write-NovaModuleProjectJson delegates final persistence to Write-ProjectJsonData' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaModuleProjectTemplatePath {'/tmp/project-template.json'}
+            Mock Read-ProjectJsonData {
+                [ordered]@{
+                    ProjectName = ''
+                    Description = ''
+                    Version = ''
+                    Manifest = [ordered]@{
+                        Author = ''
+                        PowerShellHostVersion = ''
+                        GUID = ''
+                    }
+                    Package = [ordered]@{
+                        OutputDirectory = [ordered]@{
+                            Path = 'artifacts/packages'
+                            Clean = $true
+                        }
+                    }
+                    Pester = [ordered]@{
+                        TestResult = [ordered]@{
+                            Enabled = $true
+                        }
+                    }
+                }
+            }
+            Mock New-Guid {[guid]'22222222-2222-2222-2222-222222222222'}
+            Mock Write-ProjectJsonData {}
+
+            Write-NovaModuleProjectJson -Answer @{
+                ProjectName = 'NovaDelegated'
+                Description = 'Shared writer path'
+                Version = '3.2.1'
+                Author = 'Writer Test'
+                PowerShellHostVersion = '7.4'
+                EnablePester = 'Yes'
+            } -ProjectJsonFile '/tmp/project.json'
+
+            Assert-MockCalled Read-ProjectJsonData -Times 1 -ParameterFilter {$ProjectJsonPath -eq '/tmp/project-template.json'}
+            Assert-MockCalled Write-ProjectJsonData -Times 1 -ParameterFilter {
+                $ProjectJsonPath -eq '/tmp/project.json' -and
+                        $Data.ProjectName -eq 'NovaDelegated' -and
+                        $Data.Manifest.GUID -eq '22222222-2222-2222-2222-222222222222' -and
+                        $Data.Package.OutputDirectory.Path -eq 'artifacts/packages'
+            }
         }
     }
 

--- a/tests/RemainingHelperCoverage.Tests.ps1
+++ b/tests/RemainingHelperCoverage.Tests.ps1
@@ -276,6 +276,46 @@ function Get-Second {
         }
     }
 
+    It 'Write-ProjectJsonData preserves nested objects, arrays, and unicode text when writing project.json' {
+        $projectJsonPath = Join-Path $TestDrive 'written-project.json'
+
+        InModuleScope $script:moduleName -Parameters @{ProjectJsonPath = $projectJsonPath} {
+            param($ProjectJsonPath)
+
+            $projectData = [ordered]@{
+                ProjectName = 'NovaModuleTools'
+                Description = 'ÆØÅ nested output'
+                Version = '1.2.3'
+                Manifest = [ordered]@{
+                    Author = 'Stiwi'
+                }
+                Package = [ordered]@{
+                    OutputDirectory = [ordered]@{
+                        Path = 'artifacts/packages'
+                        Clean = $true
+                    }
+                    Repositories = @(
+                        [ordered]@{
+                            Name = 'staging'
+                            Auth = [ordered]@{
+                                TokenEnvironmentVariable = 'NOVA_TOKEN'
+                            }
+                        }
+                    )
+                }
+            }
+
+            Write-ProjectJsonData -ProjectJsonPath $ProjectJsonPath -Data $projectData
+
+            $result = Read-ProjectJsonData -ProjectJsonPath $ProjectJsonPath
+
+            $result.Description | Should -Be 'ÆØÅ nested output'
+            $result.Package.OutputDirectory.Path | Should -Be 'artifacts/packages'
+            $result.Package.Repositories[0].Name | Should -Be 'staging'
+            $result.Package.Repositories[0].Auth.TokenEnvironmentVariable | Should -Be 'NOVA_TOKEN'
+        }
+    }
+
     It 'Get-NovaHelpLocale defaults to en-US when docs metadata has no locale' {
         $docPath = Join-Path $TestDrive 'No-Locale.md'
         @'


### PR DESCRIPTION
## Summary

- Introduced `Write-ProjectJsonData` in `src/private/shared/` as the shared runtime writer for full `project.json` persistence.
- Updated `Set-NovaModuleVersion` and `Write-NovaModuleProjectJson` to stop serializing JSON inline and instead use the shared read/write path.
- Added regression coverage to prove nested objects, arrays, and UTF-8 content round-trip safely through the shared helper and both migrated flows.

Why this change was needed:
- Runtime `project.json` writes previously used separate JSON serialization patterns in the bump and scaffold flows.
- That duplication already caused real nested-object corruption risk in the version bump path and made future maintenance harder.
- Centralizing writes behind one helper gives one consistent policy for JSON depth, encoding, and nested object preservation.

Link / follow-up:
- Follow-up maintainability refactor after the earlier nested `project.json` serialization bug in the bump flow.

## Affected area

- [ ] `nova` CLI or command routing
- [ ] Public PowerShell cmdlet behavior
- [x] Scaffolding or `project.json` handling
- [x] Build, test, analyzer, coverage, or CI helper flow
- [ ] Package, raw upload, or package metadata workflow
- [ ] Publish, release, semantic-release, or GitHub Actions automation
- [ ] Self-update or notification preference behavior
- [ ] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
- [ ] End-user docs (`docs/*.html`)
- [ ] Command help (`docs/NovaModuleTools/en-US/*.md`)
- [ ] `src/resources/example/`
- [ ] Dependency or manifest changes (`package.json`, workflow dependencies, release tooling)
- [ ] Security-sensitive change
- [ ] Documentation-only change
- [ ] Other

## Review guidance

- Start with `src/private/shared/Write-ProjectJsonData.ps1` to see the new shared serialization policy.
- Then review the two migrated runtime write paths:
  - `src/private/release/SetNovaModuleVersion.ps1`
  - `src/private/scaffold/WriteNovaModuleProjectJson.ps1`
- Finally, review the targeted regression coverage in:
  - `tests/RemainingHelperCoverage.Tests.ps1`
  - `tests/CoverageGaps.ReleaseInternals.Tests.ps1`
  - `tests/CoverageGaps.Tests.ps1`

Primary files/folders changed:
- `src/private/shared/`
- `src/private/release/`
- `src/private/scaffold/`
- `tests/`
- `CHANGELOG.md`

Trade-offs / limitations / follow-up:
- This change centralizes real runtime `project.json` writes in `src/`, but it does not attempt to unify every JSON helper used in non-runtime script tooling.
- The shared helper currently uses a fixed `ConvertTo-Json -Depth 20` policy, which is intentional for predictable nested-object handling.
- A later cleanup could align release-script JSON helpers with the same policy if the repository wants one broader JSON story beyond runtime flows.

## Validation

- [x] `Invoke-NovaBuild`
- [ ] `Test-NovaBuild`
- [ ] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
- [x] Targeted Nova workflow validated (`nova build`, `nova test`, `nova merge`, `nova deploy`, `nova publish`,
  `nova release`, `nova update`, `nova notification`, or `nova init` as relevant)
- [ ] Docs/example only; executable validation not needed

Validation notes:

```text
Ran:

pwsh -NoLogo -NoProfile -Command 'Set-Location "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools"; Invoke-NovaBuild'

pwsh -NoLogo -NoProfile -Command 'Set-Location "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools"; Invoke-Pester ./tests/RemainingHelperCoverage.Tests.ps1 -Output Detailed'
- Passed: 30

pwsh -NoLogo -NoProfile -Command 'Set-Location "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools"; Invoke-Pester ./tests/CoverageGaps.ReleaseInternals.Tests.ps1 -Output Detailed'
- Passed: 47

pwsh -NoLogo -NoProfile -Command 'Set-Location "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools"; Invoke-Pester ./tests/NovaCommandModel.BumpAndCli.Tests.ps1 -Output Detailed'
- Passed: 11

pwsh -NoLogo -NoProfile -Command 'Set-Location "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools"; Invoke-Pester ./tests/CoverageGaps.Tests.ps1 -Output Detailed'
- Passed: 17

git -C "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools" --no-pager diff --check
- Passed

Targeted runtime workflow coverage included:
- `Update-NovaModuleVersion` / `Set-NovaModuleVersion`
- `Initialize-NovaModule` / `Write-NovaModuleProjectJson`
- direct shared helper round-trip validation for nested objects, arrays, and UTF-8 text
```

## Documentation and release follow-up

- [ ] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
- [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
- [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [ ] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
- [ ] `docs/*.html` updated if end-user workflows or examples changed
- [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
  changed
- [ ] No documentation, changelog, or example updates were needed

## Maintainability, compatibility, and risk

- [x] Code Health / maintainability impact considered
- [x] No breaking change
- [ ] Breaking change
- [ ] Security-sensitive change
- [ ] CI, workflow, or release-pipeline impact
- [ ] Dependency-review impact

Risk, rollout, or rollback notes:

```text
Compatibility risk is low because this is a focused refactor of runtime persistence behavior, not a change to command semantics.

Rollback is straightforward:
- revert `Write-ProjectJsonData.ps1`
- revert the two migrated write paths
- revert the regression tests and changelog entry

Code Health was checked after the change:
- pre-commit safeguard passed
- `Write-ProjectJsonData.ps1` = 10.0
- `SetNovaModuleVersion.ps1` = 10.0
- `WriteNovaModuleProjectJson.ps1` = 10.0

Docs review outcome:
- `README.md`, `docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md`, `docs/NovaModuleTools/en-US/Initialize-NovaModule.md`, and `docs/project-json-reference.html` were reviewed.
- No additional doc updates were needed because this change centralizes internal persistence behavior without changing public command usage or configuration shape.
```

> [!IMPORTANT]
> Do not use a public pull request to disclose a vulnerability before coordinated handling.
> Use the private reporting path in `SECURITY.md` for new security issues.

