### PR TITLE
Feature/94 clarify the boundaries between public commands domain logic and infrastructure concerns in novamoduletools

### DIFF
--- a/.codescene/code-health-rules.json
+++ b/.codescene/code-health-rules.json
@@ -1,0 +1,70 @@
+{
+  "usage": "Persist this file inside your repositories as .codescene/code-health-rules.json Keep the rules you want to override, remove the rest for simplicity and an easy overview.Override the code health rules by changing the default 1.0 value to a lower relative weight. A value of 0.0 disables the rule. A value of 0.5 still implies a code health hit but only at 50% of the default impact. Note that you can specify multiple rule sets and use the matching-content-path to control to which parts or languages the rules apply. This makes it possible to differentiate between test vs application code, or tailor rules to specific languages. In case multiple rule sets match a piece of content, then we prioritize the first mathcing set of rules.",
+  "rule_sets": [
+    {
+      "thresholds": [
+        {
+          "name": "constructor_max_arguments",
+          "value": "4"
+        },
+        {
+          "name": "file_mean_cyclomatic_complexity_warning",
+          "value": "26"
+        },
+        {
+          "name": "function_complex_conditional_branches_alert",
+          "value": "11"
+        },
+        {
+          "name": "function_complex_conditional_branches_warning",
+          "value": "6"
+        },
+        {
+          "name": "function_cyclomatic_complexity_alert",
+          "value": "11"
+        },
+        {
+          "name": "function_cyclomatic_complexity_warning",
+          "value": "6"
+        },
+        {
+          "name": "function_duplication_min_lines_of_code_for_check",
+          "value": "6"
+        },
+        {
+          "name": "function_duplication_min_similarity_percentage",
+          "value": "89"
+        },
+        {
+          "name": "function_lines_of_code_alert",
+          "value": "31"
+        },
+        {
+          "name": "function_lines_of_code_warning",
+          "value": "16"
+        },
+        {
+          "name": "function_max_arguments",
+          "value": "4"
+        },
+        {
+          "name": "function_nesting_depth_warning",
+          "value": "6"
+        }
+      ],
+      "thresholds_doc": "The thresholds are configured to align CodeScene’s code health analysis with SIG’s recommended software quality principles. This ensures that code quality assessments follow established, research-based standards for maintainability and complexity, and that deviations from these thresholds should only be introduced with strong justification.",
+      "matching_content_path": "**/src/**",
+      "matching_content_path_doc": "Specify a glob pattern relative to this repository root. The pattern is intentionally limited to **/src/main/** so that production code is evaluated according to SIG’s recommended software quality principles, while test code under **/src/test/** continues to follow CodeScene’s default thresholds.",
+      "rules": []
+    }
+  ],
+  "rule_sets": [
+    {
+      "thresholds": [],
+      "thresholds_doc": "The thresholds let you redefine the details of the code health issues. For example, specifying what a Complex Method means to you. Be restrictive with overrides.",
+      "matching_content_path": "**/tests/**",
+      "matching_content_path_doc": "Specify a glob pattern relative to this repository root. The pattern is limited to **/docs/**. Code under this path represents generated or semi-generated documentation (e.g. Spring REST Docs), where a higher level of verbosity, repetition, and structural similarity is often required for clarity and completeness. Therefore, selected CodeScene rules such as complexity- and duplication-related findings are deliberately disabled to avoid noise and false positives.",
+      "rules": []
+    }
+  ]
+}

--- a/.codescene/code-health-rules.json
+++ b/.codescene/code-health-rules.json
@@ -54,7 +54,7 @@
       ],
       "thresholds_doc": "The thresholds are configured to align CodeScene’s code health analysis with SIG’s recommended software quality principles. This ensures that code quality assessments follow established, research-based standards for maintainability and complexity, and that deviations from these thresholds should only be introduced with strong justification.",
       "matching_content_path": "**/src/**",
-      "matching_content_path_doc": "Specify a glob pattern relative to this repository root. The pattern is intentionally limited to **/src/main/** so that production code is evaluated according to SIG’s recommended software quality principles, while test code under **/src/test/** continues to follow CodeScene’s default thresholds.",
+      "matching_content_path_doc": "Specify a glob pattern relative to this repository root. The pattern is intentionally limited to **/src/** so that production code is evaluated according to SIG’s recommended software quality principles, while test code under **/tests/** continues to follow CodeScene’s default thresholds.",
       "rules": []
     }
   ],
@@ -63,7 +63,7 @@
       "thresholds": [],
       "thresholds_doc": "The thresholds let you redefine the details of the code health issues. For example, specifying what a Complex Method means to you. Be restrictive with overrides.",
       "matching_content_path": "**/tests/**",
-      "matching_content_path_doc": "Specify a glob pattern relative to this repository root. The pattern is limited to **/docs/**. Code under this path represents generated or semi-generated documentation (e.g. Spring REST Docs), where a higher level of verbosity, repetition, and structural similarity is often required for clarity and completeness. Therefore, selected CodeScene rules such as complexity- and duplication-related findings are deliberately disabled to avoid noise and false positives.",
+      "matching_content_path_doc": "Specify a glob pattern relative to this repository root.",
       "rules": []
     }
   ]

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 run.ps1
 reload.ps1
 .tmp-nova-bin/
+/plan.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change the project to a Nova command model, replacing the previous mixed MT/Nova workflow.
     - All public commands are now Nova commands, and the `nova` CLI/Powershell alias is the primary entry point for all
       operations.
+- Clarify publish and release layering so public commands focus on orchestration while private workflow helpers own
+  publish/release sequencing and shared publish context resolution.
 - Centralize runtime `project.json` writing behind one shared helper so scaffold and version-bump flows use the same
   serialization policy for nested arrays, nested objects, JSON depth, and UTF-8 output.
 - **BREAKING CHANGE**: Rename the public Nova scaffold cmdlets to approved verbs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   workflow context, sequencing, and explicit reuse of resolved project metadata.
 - Clarify `Test-NovaBuild` layering so the public command focuses on orchestration while private helpers own Pester
   workflow context, artifact preparation, and pass/fail translation.
+- Clarify `New-NovaModulePackage` layering so the public command focuses on orchestration while private helpers own
+  package workflow context, build/test/package sequencing, and package-helper reload fallback.
 - Clarify `Update-NovaModuleVersion` layering so the public command focuses on orchestration while private helpers own
   bump workflow context, result shaping, and version persistence.
 - Clarify publish and release layering so public commands focus on orchestration while private workflow helpers own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change the project to a Nova command model, replacing the previous mixed MT/Nova workflow.
     - All public commands are now Nova commands, and the `nova` CLI/Powershell alias is the primary entry point for all
       operations.
+- Clarify `Update-NovaModuleVersion` layering so the public command focuses on orchestration while private helpers own
+  bump workflow context, result shaping, and version persistence.
 - Clarify publish and release layering so public commands focus on orchestration while private workflow helpers own
   publish/release sequencing and shared publish context resolution.
 - Centralize runtime `project.json` writing behind one shared helper so scaffold and version-bump flows use the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       operations.
 - Clarify `Invoke-NovaBuild` layering so the public command focuses on orchestration while private helpers own build
   workflow context, sequencing, and explicit reuse of resolved project metadata.
+- Clarify `Test-NovaBuild` layering so the public command focuses on orchestration while private helpers own Pester
+  workflow context, artifact preparation, and pass/fail translation.
 - Clarify `Update-NovaModuleVersion` layering so the public command focuses on orchestration while private helpers own
   bump workflow context, result shaping, and version persistence.
 - Clarify publish and release layering so public commands focus on orchestration while private workflow helpers own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       operations.
 - Clarify `Invoke-NovaBuild` layering so the public command focuses on orchestration while private helpers own build
   workflow context, sequencing, and explicit reuse of resolved project metadata.
+- Clarify `Get-NovaProjectInfo` layering so the public command focuses on orchestration while private helpers own
+  project-info context resolution and result shaping.
 - Clarify `Test-NovaBuild` layering so the public command focuses on orchestration while private helpers own Pester
   workflow context, artifact preparation, and pass/fail translation.
 - Clarify `New-NovaModulePackage` layering so the public command focuses on orchestration while private helpers own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   workflow context resolution and launcher install execution.
 - Clarify `Initialize-NovaModule` layering so the public command focuses on orchestration while private helpers own
   scaffold workflow context resolution and scaffold/project-file execution.
+- Clarify `Invoke-NovaCli` layering so the public command focuses on orchestration while private helpers own CLI
+  invocation-context preparation and command routing.
 - Clarify `Test-NovaBuild` layering so the public command focuses on orchestration while private helpers own Pester
   workflow context, artifact preparation, and pass/fail translation.
 - Clarify `New-NovaModulePackage` layering so the public command focuses on orchestration while private helpers own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   workflow context, sequencing, and explicit reuse of resolved project metadata.
 - Clarify `Get-NovaProjectInfo` layering so the public command focuses on orchestration while private helpers own
   project-info context resolution and result shaping.
+- Clarify `Get-NovaUpdateNotificationPreference` layering so the public command focuses on orchestration while private
+  helpers own notification-status shaping and settings-path resolution.
 - Clarify `Test-NovaBuild` layering so the public command focuses on orchestration while private helpers own Pester
   workflow context, artifact preparation, and pass/fail translation.
 - Clarify `New-NovaModulePackage` layering so the public command focuses on orchestration while private helpers own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   self-update workflow context resolution and update/release-notes execution.
 - Clarify `Install-NovaCli` layering so the public command focuses on orchestration while private helpers own install
   workflow context resolution and launcher install execution.
+- Clarify `Initialize-NovaModule` layering so the public command focuses on orchestration while private helpers own
+  scaffold workflow context resolution and scaffold/project-file execution.
 - Clarify `Test-NovaBuild` layering so the public command focuses on orchestration while private helpers own Pester
   workflow context, artifact preparation, and pass/fail translation.
 - Clarify `New-NovaModulePackage` layering so the public command focuses on orchestration while private helpers own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   project-info context resolution and result shaping.
 - Clarify `Get-NovaUpdateNotificationPreference` layering so the public command focuses on orchestration while private
   helpers own notification-status shaping and settings-path resolution.
+- Clarify `Set-NovaUpdateNotificationPreference` layering so the public command focuses on orchestration while private
+  helpers own preference-change context resolution and write/status sequencing.
 - Clarify `Test-NovaBuild` layering so the public command focuses on orchestration while private helpers own Pester
   workflow context, artifact preparation, and pass/fail translation.
 - Clarify `New-NovaModulePackage` layering so the public command focuses on orchestration while private helpers own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   helpers own notification-status shaping and settings-path resolution.
 - Clarify `Set-NovaUpdateNotificationPreference` layering so the public command focuses on orchestration while private
   helpers own preference-change context resolution and write/status sequencing.
+- Clarify `Update-NovaModuleTool` layering so the public command focuses on orchestration while private helpers own
+  self-update workflow context resolution and update/release-notes execution.
 - Clarify `Test-NovaBuild` layering so the public command focuses on orchestration while private helpers own Pester
   workflow context, artifact preparation, and pass/fail translation.
 - Clarify `New-NovaModulePackage` layering so the public command focuses on orchestration while private helpers own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   helpers own preference-change context resolution and write/status sequencing.
 - Clarify `Update-NovaModuleTool` layering so the public command focuses on orchestration while private helpers own
   self-update workflow context resolution and update/release-notes execution.
+- Clarify `Install-NovaCli` layering so the public command focuses on orchestration while private helpers own install
+  workflow context resolution and launcher install execution.
 - Clarify `Test-NovaBuild` layering so the public command focuses on orchestration while private helpers own Pester
   workflow context, artifact preparation, and pass/fail translation.
 - Clarify `New-NovaModulePackage` layering so the public command focuses on orchestration while private helpers own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change the project to a Nova command model, replacing the previous mixed MT/Nova workflow.
     - All public commands are now Nova commands, and the `nova` CLI/Powershell alias is the primary entry point for all
       operations.
+- Clarify `Invoke-NovaBuild` layering so the public command focuses on orchestration while private helpers own build
+  workflow context, sequencing, and explicit reuse of resolved project metadata.
 - Clarify `Update-NovaModuleVersion` layering so the public command focuses on orchestration while private helpers own
   bump workflow context, result shaping, and version persistence.
 - Clarify publish and release layering so public commands focus on orchestration while private workflow helpers own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   workflow context, artifact preparation, and pass/fail translation.
 - Clarify `New-NovaModulePackage` layering so the public command focuses on orchestration while private helpers own
   package workflow context, build/test/package sequencing, and package-helper reload fallback.
+- Clarify `Deploy-NovaPackage` layering so the public command focuses on orchestration while private helpers own upload
+  workflow context, upload planning, and artifact upload sequencing.
 - Clarify `Update-NovaModuleVersion` layering so the public command focuses on orchestration while private helpers own
   bump workflow context, result shaping, and version persistence.
 - Clarify publish and release layering so public commands focus on orchestration while private workflow helpers own

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 95%

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,4 +5,4 @@ coverage:
         target: auto
     patch:
       default:
-        target: 95%
+        target: 100%

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,4 +2,4 @@ coverage:
   status:
     project:
       default:
-        target: 95%
+        target: auto

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,3 +3,6 @@ coverage:
     project:
       default:
         target: auto
+    patch:
+      default:
+        target: 95%

--- a/project.json
+++ b/project.json
@@ -8,6 +8,7 @@
   ],
   "Manifest": {
     "Author": "Stiwi Gabriel Courage",
+    "CompanyName": "Terra Nova Community",
     "PowerShellHostVersion": "7.4",
     "GUID": "6b9202c8-0353-473b-b73c-afab632125a6",
     "RequiredModules": [

--- a/src/private/build/BuildHelp.ps1
+++ b/src/private/build/BuildHelp.ps1
@@ -1,10 +1,11 @@
 function Build-Help {
     [CmdletBinding()]
     param(
+        [pscustomobject]$ProjectInfo
     )
     Write-Verbose 'Running Help update'
 
-    $data = Get-NovaProjectInfo
+    $data = Get-NovaBuildProjectInfo -ProjectInfo $ProjectInfo
     $helpMarkdownFiles = Get-ChildItem -Path $data.DocsDir -Filter '*.md' -Recurse
 
     if (-not $helpMarkdownFiles) {

--- a/src/private/build/BuildManifest.ps1
+++ b/src/private/build/BuildManifest.ps1
@@ -1,9 +1,11 @@
 function Build-Manifest {
     [CmdletBinding()]
-    param()
+    param(
+        [pscustomobject]$ProjectInfo
+    )
 
     Write-Verbose 'Building psd1 data file Manifest'
-    $data = Get-NovaProjectInfo
+    $data = Get-NovaBuildProjectInfo -ProjectInfo $ProjectInfo
 
     $PubFunctionFiles = @(Get-ChildItem -Path $data.PublicDir -Filter *.ps1)
     $functionToExport = @()

--- a/src/private/build/BuildModule.ps1
+++ b/src/private/build/BuildModule.ps1
@@ -1,5 +1,10 @@
 function Build-Module {
-    $data = Get-NovaProjectInfo
+    [CmdletBinding()]
+    param(
+        [pscustomobject]$ProjectInfo
+    )
+
+    $data = Get-NovaBuildProjectInfo -ProjectInfo $ProjectInfo
     $novaBuildVersion = (Get-Command Invoke-NovaBuild).Version
     Write-Verbose "Running NovaModuleTools Version: $novaBuildVersion"
     Write-Verbose 'Buidling module psm1 file'

--- a/src/private/build/CopyProjectResource.ps1
+++ b/src/private/build/CopyProjectResource.ps1
@@ -1,5 +1,10 @@
 function Copy-ProjectResource {
-    $data = Get-NovaProjectInfo
+    [CmdletBinding()]
+    param(
+        [pscustomobject]$ProjectInfo
+    )
+
+    $data = Get-NovaBuildProjectInfo -ProjectInfo $ProjectInfo
     $resourceFolder = Get-ProjectResourceFolderPath -ProjectRoot $data.ProjectRoot
     if (-not (Test-Path $resourceFolder)) {
         return

--- a/src/private/build/GetNovaBuildProjectInfo.ps1
+++ b/src/private/build/GetNovaBuildProjectInfo.ps1
@@ -1,0 +1,13 @@
+function Get-NovaBuildProjectInfo {
+    [CmdletBinding()]
+    param(
+        [pscustomobject]$ProjectInfo
+    )
+
+    if ($null -ne $ProjectInfo) {
+        return $ProjectInfo
+    }
+
+    return Get-NovaProjectInfo
+}
+

--- a/src/private/build/GetNovaBuildWorkflowContext.ps1
+++ b/src/private/build/GetNovaBuildWorkflowContext.ps1
@@ -1,0 +1,15 @@
+function Get-NovaBuildWorkflowContext {
+    [CmdletBinding()]
+    param(
+        [pscustomobject]$ProjectInfo
+    )
+
+    $projectInfo = Get-NovaBuildProjectInfo -ProjectInfo $ProjectInfo
+
+    return [pscustomobject]@{
+        ProjectInfo = $projectInfo
+        Target = $projectInfo.OutputModuleDir
+        Operation = 'Build Nova module output'
+    }
+}
+

--- a/src/private/build/InvokeNovaBuildWorkflow.ps1
+++ b/src/private/build/InvokeNovaBuildWorkflow.ps1
@@ -1,0 +1,42 @@
+function Invoke-NovaBuildWorkflow {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext
+    )
+
+    $projectInfo = $WorkflowContext.ProjectInfo
+
+    Reset-ProjectDist -ProjectInfo $projectInfo -Confirm:$false
+    Build-Module -ProjectInfo $projectInfo
+    Invoke-NovaBuildDuplicateValidation -ProjectInfo $projectInfo
+    Build-Manifest -ProjectInfo $projectInfo
+    Build-Help -ProjectInfo $projectInfo
+    Copy-ProjectResource -ProjectInfo $projectInfo
+    Invoke-NovaBuildUpdateNotificationSafely
+}
+
+function Invoke-NovaBuildDuplicateValidation {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo
+    )
+
+    if (-not $ProjectInfo.FailOnDuplicateFunctionNames) {
+        return
+    }
+
+    Assert-BuiltModuleHasNoDuplicateFunctionName -ProjectInfo $ProjectInfo
+}
+
+function Invoke-NovaBuildUpdateNotificationSafely {
+    [CmdletBinding()]
+    param()
+
+    try {
+        Invoke-NovaBuildUpdateNotification
+    }
+    catch {
+        $null = $_
+    }
+}
+

--- a/src/private/build/ResetProjectDist.ps1
+++ b/src/private/build/ResetProjectDist.ps1
@@ -1,8 +1,9 @@
 function Reset-ProjectDist {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
+        [pscustomobject]$ProjectInfo
     )
-    $data = Get-NovaProjectInfo
+    $data = Get-NovaBuildProjectInfo -ProjectInfo $ProjectInfo
     try {
         Write-Verbose 'Running dist folder reset'
         if (Test-Path $data.OutputDir) {

--- a/src/private/cli/GetNovaCliInstallWorkflowContext.ps1
+++ b/src/private/cli/GetNovaCliInstallWorkflowContext.ps1
@@ -1,0 +1,27 @@
+function Get-NovaCliInstallWorkflowContext {
+    [CmdletBinding()]
+    param(
+        [string]$DestinationDirectory,
+        [switch]$Force
+    )
+
+    if ($IsWindows) {
+        throw 'Install-NovaCli currently supports macOS/Linux only. On Windows, use the nova alias inside pwsh after importing NovaModuleTools.'
+    }
+
+    $targetDirectory = Get-NovaCliInstallDirectory -DestinationDirectory $DestinationDirectory
+    $sourcePath = Get-NovaCliLauncherPath
+    $targetPath = Join-Path $targetDirectory 'nova'
+
+    if ((Test-Path -LiteralPath $targetPath) -and -not $Force) {
+        throw "Target file already exists: $targetPath. Use -Force to overwrite it."
+    }
+
+    return [pscustomobject]@{
+        SourcePath = $sourcePath
+        TargetPath = $targetPath
+        TargetDirectory = $targetDirectory
+        Force = $Force.IsPresent
+        Action = 'Install nova CLI launcher'
+    }
+}

--- a/src/private/cli/GetNovaCliInvocationContext.ps1
+++ b/src/private/cli/GetNovaCliInvocationContext.ps1
@@ -1,0 +1,23 @@
+function Get-NovaCliInvocationContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Command,
+        [Parameter(Mandatory)][hashtable]$BoundParameters,
+        [AllowNull()][string[]]$Arguments,
+        [switch]$WhatIfEnabled
+    )
+
+    $commonParameters = Get-NovaCliForwardingParameterSet -BoundParameters $BoundParameters
+    $mutatingCommonParameters = Get-NovaCliForwardingParameterSet -BoundParameters $BoundParameters -IncludeShouldProcess
+    $normalizedArguments = ConvertTo-NovaCliArgumentArray -BoundParameters $BoundParameters -Arguments $Arguments
+
+    return [pscustomobject]@{
+        Command = $Command
+        Arguments = $normalizedArguments
+        CommonParameters = $commonParameters
+        MutatingCommonParameters = $mutatingCommonParameters
+        IsHelpRequest = Test-NovaCliHelpRequest -Arguments $normalizedArguments
+        ModuleName = $ExecutionContext.SessionState.Module.Name
+        WhatIfEnabled = $WhatIfEnabled.IsPresent
+    }
+}

--- a/src/private/cli/InvokeNovaCliCommandRoute.ps1
+++ b/src/private/cli/InvokeNovaCliCommandRoute.ps1
@@ -1,0 +1,72 @@
+function Invoke-NovaCliCommandRoute {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$InvocationContext
+    )
+
+    if ($InvocationContext.IsHelpRequest) {
+        return Get-NovaCliCommandHelp -Command $InvocationContext.Command
+    }
+
+    $command = $InvocationContext.Command
+    $arguments = $InvocationContext.Arguments
+    $commonParameters = $InvocationContext.CommonParameters
+    $mutatingCommonParameters = $InvocationContext.MutatingCommonParameters
+
+    $commandHandlerMap = @{
+        'info' = {
+            Get-NovaProjectInfo @commonParameters
+        }
+        'version' = {
+            Invoke-NovaCliVersionCommand -Arguments $arguments -ForwardedParameters $commonParameters
+        }
+        'build' = {
+            Invoke-NovaBuild @mutatingCommonParameters
+        }
+        'test' = {
+            Test-NovaBuild @mutatingCommonParameters
+        }
+        'package' = {
+            New-NovaModulePackage @mutatingCommonParameters
+        }
+        'deploy' = {
+            Invoke-NovaCliDeployCommand -Arguments $arguments -ForwardedParameters $mutatingCommonParameters
+        }
+        'init' = {
+            Invoke-NovaCliInitCommand -Arguments $arguments -ForwardedParameters $mutatingCommonParameters -WhatIfEnabled:$InvocationContext.WhatIfEnabled
+        }
+        'bump' = {
+            $options = ConvertFrom-NovaBumpCliArgument -Arguments $arguments
+            Update-NovaModuleVersion @options @mutatingCommonParameters
+        }
+        'update' = {
+            $result = Invoke-NovaCliUpdateCommand -Arguments $arguments -ForwardedParameters $mutatingCommonParameters
+            Format-NovaCliCommandResult -Command $command -Result $result
+        }
+        'publish' = {
+            $options = ConvertFrom-NovaCliArgument -Arguments $arguments
+            Publish-NovaModule @options @mutatingCommonParameters
+        }
+        'release' = {
+            $options = ConvertFrom-NovaCliArgument -Arguments $arguments
+            Invoke-NovaRelease -PublishOption $options @mutatingCommonParameters
+        }
+        'notification' = {
+            Invoke-NovaCliNotificationCommand -Arguments $arguments -CommonParameters $commonParameters -MutatingCommonParameters $mutatingCommonParameters
+        }
+        '--version' = {
+            $moduleVersion = Get-NovaCliInstalledVersion
+            Format-NovaCliVersionString -Name $InvocationContext.ModuleName -Version $moduleVersion
+        }
+        '--help' = {
+            Get-NovaCliHelp
+        }
+    }
+
+    $commandHandler = $commandHandlerMap[$command]
+    if ($null -eq $commandHandler) {
+        throw "Unknown command: <$command> | Use 'nova --help' to see available commands."
+    }
+
+    return & $commandHandler
+}

--- a/src/private/cli/InvokeNovaCliInstallWorkflow.ps1
+++ b/src/private/cli/InvokeNovaCliInstallWorkflow.ps1
@@ -1,0 +1,21 @@
+function Invoke-NovaCliInstallWorkflow {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext
+    )
+
+    $installedPath = Copy-NovaCliLauncher -SourcePath $WorkflowContext.SourcePath -TargetPath $WorkflowContext.TargetPath -Force:$WorkflowContext.Force
+    $directoryOnPath = Test-NovaCliDirectoryOnPath -Directory $WorkflowContext.TargetDirectory
+    if (-not $directoryOnPath) {
+        Write-Warning "Installed nova to $( $WorkflowContext.TargetDirectory ), but that directory is not currently in PATH. Add it to your shell profile before using nova directly from zsh/bash."
+    }
+
+    Write-NovaModuleReleaseNotesLink
+
+    return [pscustomobject]@{
+        CommandName = 'nova'
+        InstalledPath = $installedPath
+        DestinationDirectory = $WorkflowContext.TargetDirectory
+        DirectoryOnPath = $directoryOnPath
+    }
+}

--- a/src/private/cli/TestNovaCliBumpConfirmationIsEnabled.ps1
+++ b/src/private/cli/TestNovaCliBumpConfirmationIsEnabled.ps1
@@ -1,0 +1,7 @@
+function Test-NovaCliBumpConfirmationIsEnabled {
+    [CmdletBinding()]
+    param()
+
+    return $env:NOVA_CLI_CONFIRM_BUMP -eq '1'
+}
+

--- a/src/private/package/GetNovaPackageUploadArtifact.ps1
+++ b/src/private/package/GetNovaPackageUploadArtifact.ps1
@@ -1,0 +1,18 @@
+function Get-NovaPackageUploadArtifact {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$PackageFileInfo,
+        [Parameter(Mandatory)][pscustomobject]$UploadTarget,
+        [Parameter(Mandatory)][object]$UploadHeaders
+    )
+
+    return [pscustomobject]@{
+        Type = $PackageFileInfo.Type
+        PackagePath = $PackageFileInfo.PackagePath
+        PackageFileName = $PackageFileInfo.PackageFileName
+        Repository = $UploadTarget.Repository
+        Headers = $UploadHeaders
+        UploadUrl = Join-NovaPackageUploadUrl -Url $UploadTarget.Url -UploadPath $UploadTarget.UploadPath -PackageFileName $PackageFileInfo.PackageFileName
+    }
+}
+

--- a/src/private/package/GetNovaPackageUploadTargetSettingBundle.ps1
+++ b/src/private/package/GetNovaPackageUploadTargetSettingBundle.ps1
@@ -1,0 +1,14 @@
+function Get-NovaPackageUploadTargetSettingBundle {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]$PackageSettings,
+        [AllowNull()]$RepositorySettings
+    )
+
+    return [pscustomobject]@{
+        Repository = "$( Get-NovaPackageSettingValue -InputObject $RepositorySettings -Name 'Name' )".Trim()
+        Headers = Merge-NovaPackageSettingTable -BaseSettings (Get-NovaPackageSettingValue -InputObject $PackageSettings -Name 'Headers') -OverrideSettings (Get-NovaPackageSettingValue -InputObject $RepositorySettings -Name 'Headers')
+        Auth = Merge-NovaPackageSettingTable -BaseSettings (Get-NovaPackageSettingValue -InputObject $PackageSettings -Name 'Auth') -OverrideSettings (Get-NovaPackageSettingValue -InputObject $RepositorySettings -Name 'Auth')
+    }
+}
+

--- a/src/private/package/GetNovaPackageUploadWorkflowContext.ps1
+++ b/src/private/package/GetNovaPackageUploadWorkflowContext.ps1
@@ -1,0 +1,28 @@
+function Get-NovaPackageUploadWorkflowContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][hashtable]$BoundParameters,
+        [pscustomobject]$ProjectInfo,
+        [pscustomobject]$UploadOption
+    )
+
+    $resolvedProjectInfo = if ($null -ne $ProjectInfo) {
+        $ProjectInfo
+    }
+    else {
+        Get-NovaProjectInfo
+    }
+    $resolvedUploadOption = if ($null -ne $UploadOption) {
+        $UploadOption
+    }
+    else {
+        New-NovaPackageUploadOption -BoundParameters $BoundParameters
+    }
+
+    return [pscustomobject]@{
+        ProjectInfo = $resolvedProjectInfo
+        UploadOption = $resolvedUploadOption
+        UploadArtifactList = @(Resolve-NovaPackageUploadInvocation -ProjectInfo $resolvedProjectInfo -UploadOption $resolvedUploadOption)
+    }
+}
+

--- a/src/private/package/GetNovaPackageWorkflowContext.ps1
+++ b/src/private/package/GetNovaPackageWorkflowContext.ps1
@@ -1,0 +1,58 @@
+function Get-NovaPackageWorkflowContext {
+    [CmdletBinding()]
+    param(
+        [pscustomobject]$ProjectInfo,
+        [hashtable]$WorkflowParams = @{},
+        [string]$ModulePath = $ExecutionContext.SessionState.Module.Path
+    )
+
+    $projectInfo = Get-NovaPackageWorkflowProjectInfo -ProjectInfo $ProjectInfo
+    $packageMetadataList = @(Get-NovaPackageMetadataList -ProjectInfo $projectInfo)
+    foreach ($packageMetadata in $packageMetadataList) {
+        Assert-NovaPackageMetadata -PackageMetadata $packageMetadata
+    }
+
+    return [pscustomobject]@{
+        ProjectInfo = $projectInfo
+        WorkflowParams = $WorkflowParams
+        PackageMetadataList = $packageMetadataList
+        ModulePath = $ModulePath
+        Target = Get-NovaPackageWorkflowTarget -PackageMetadataList $packageMetadataList
+        Operation = Get-NovaPackageWorkflowOperation -PackageMetadataList $packageMetadataList
+    }
+}
+
+function Get-NovaPackageWorkflowProjectInfo {
+    [CmdletBinding()]
+    param(
+        [pscustomobject]$ProjectInfo
+    )
+
+    if ($null -ne $ProjectInfo) {
+        return $ProjectInfo
+    }
+
+    return Get-NovaProjectInfo
+}
+
+function Get-NovaPackageWorkflowTarget {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object[]]$PackageMetadataList
+    )
+
+    return (@($PackageMetadataList.PackagePath) -join ', ')
+}
+
+function Get-NovaPackageWorkflowOperation {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object[]]$PackageMetadataList
+    )
+
+    if (@($PackageMetadataList).Count -eq 1) {
+        return "Create $( $PackageMetadataList[0].Type ) package from built module output"
+    }
+
+    return 'Create package artifacts from built module output'
+}

--- a/src/private/package/InvokeNovaPackageArtifactCreation.ps1
+++ b/src/private/package/InvokeNovaPackageArtifactCreation.ps1
@@ -1,0 +1,24 @@
+function Invoke-NovaPackageArtifactCreation {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext
+    )
+
+    $projectInfo = $WorkflowContext.ProjectInfo
+    $packageMetadataList = $WorkflowContext.PackageMetadataList
+    $modulePath = $WorkflowContext.ModulePath
+
+    $packageHelper = Get-Command -Name New-NovaPackageArtifacts -CommandType Function -ErrorAction SilentlyContinue
+    if ($null -ne $packageHelper) {
+        return New-NovaPackageArtifacts -ProjectInfo $projectInfo -PackageMetadataList $packageMetadataList
+    }
+
+    $packagingModule = Import-Module $modulePath -Force -PassThru
+    $packageCreation = {
+        param($ProjectInfo, $PackageMetadataList)
+
+        New-NovaPackageArtifacts -ProjectInfo $ProjectInfo -PackageMetadataList $PackageMetadataList
+    }
+
+    return & $packagingModule $packageCreation $projectInfo $packageMetadataList
+}

--- a/src/private/package/InvokeNovaPackageUploadWorkflow.ps1
+++ b/src/private/package/InvokeNovaPackageUploadWorkflow.ps1
@@ -1,0 +1,18 @@
+function Invoke-NovaPackageUploadWorkflow {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext,
+        [object[]]$UploadArtifactList = @()
+    )
+
+    $resolvedUploadArtifactList = @($UploadArtifactList)
+    if ($resolvedUploadArtifactList.Count -eq 0 -and @($WorkflowContext.UploadArtifactList).Count -eq 0) {
+        return @()
+    }
+
+    return @(
+    $resolvedUploadArtifactList | ForEach-Object {
+        Invoke-NovaPackageArtifactUpload -UploadArtifact $_
+    }
+    )
+}

--- a/src/private/package/InvokeNovaPackageWorkflow.ps1
+++ b/src/private/package/InvokeNovaPackageWorkflow.ps1
@@ -1,0 +1,18 @@
+function Invoke-NovaPackageWorkflow {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext,
+        [switch]$ShouldRun
+    )
+
+    $workflowParams = $WorkflowContext.WorkflowParams
+
+    Invoke-NovaBuild @workflowParams
+    Test-NovaBuild @workflowParams
+
+    if (-not $ShouldRun) {
+        return
+    }
+
+    return Invoke-NovaPackageArtifactCreation -WorkflowContext $WorkflowContext
+}

--- a/src/private/package/ResolveNovaPackageUploadAuthHeaderEntry.ps1
+++ b/src/private/package/ResolveNovaPackageUploadAuthHeaderEntry.ps1
@@ -1,0 +1,19 @@
+function Resolve-NovaPackageUploadAuthHeaderEntry {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]$AuthSettings,
+        [Parameter(Mandatory)][pscustomobject]$UploadOption
+    )
+
+    $resolvedToken = Get-NovaPackageUploadToken -AuthSettings $AuthSettings -Token $UploadOption.Token -TokenEnvironmentVariable $UploadOption.TokenEnvironmentVariable
+    if ( [string]::IsNullOrWhiteSpace($resolvedToken)) {
+        return $null
+    }
+
+    $headerName = Get-NovaPackageUploadAuthHeaderName -AuthSettings $AuthSettings
+    return [pscustomobject]@{
+        Name = $headerName
+        Value = Get-NovaPackageUploadAuthHeaderValue -AuthSettings $AuthSettings -AuthenticationScheme $UploadOption.AuthenticationScheme -HeaderName $headerName -Token $resolvedToken
+    }
+}
+

--- a/src/private/package/ResolveNovaPackageUploadHeaders.ps1
+++ b/src/private/package/ResolveNovaPackageUploadHeaders.ps1
@@ -7,13 +7,12 @@ function Resolve-NovaPackageUploadHeaders {
     )
 
     $resolvedHeaders = Merge-NovaPackageSettingTable -BaseSettings $UploadTarget.Headers -OverrideSettings $UploadOption.Headers
-    $resolvedToken = Get-NovaPackageUploadToken -AuthSettings $UploadTarget.Auth -Token $UploadOption.Token -TokenEnvironmentVariable $UploadOption.TokenEnvironmentVariable
-    if ( [string]::IsNullOrWhiteSpace($resolvedToken)) {
+    $authHeaderEntry = Resolve-NovaPackageUploadAuthHeaderEntry -AuthSettings $UploadTarget.Auth -UploadOption $UploadOption
+    if ($null -eq $authHeaderEntry) {
         return $resolvedHeaders
     }
 
-    $headerName = Get-NovaPackageUploadAuthHeaderName -AuthSettings $UploadTarget.Auth
-    $resolvedHeaders[$headerName] = Get-NovaPackageUploadAuthHeaderValue -AuthSettings $UploadTarget.Auth -AuthenticationScheme $UploadOption.AuthenticationScheme -HeaderName $headerName -Token $resolvedToken
+    $resolvedHeaders[$authHeaderEntry.Name] = $authHeaderEntry.Value
     return $resolvedHeaders
 }
 

--- a/src/private/package/ResolveNovaPackageUploadInvocation.ps1
+++ b/src/private/package/ResolveNovaPackageUploadInvocation.ps1
@@ -12,14 +12,7 @@ function Resolve-NovaPackageUploadInvocation {
 
     return @(
     $uploadFileList | ForEach-Object {
-        [pscustomobject]@{
-            Type = $_.Type
-            PackagePath = $_.PackagePath
-            PackageFileName = $_.PackageFileName
-            Repository = $uploadTarget.Repository
-            Headers = $uploadHeaders
-            UploadUrl = Join-NovaPackageUploadUrl -Url $uploadTarget.Url -UploadPath $uploadTarget.UploadPath -PackageFileName $_.PackageFileName
-        }
+        Get-NovaPackageUploadArtifact -PackageFileInfo $_ -UploadTarget $uploadTarget -UploadHeaders $uploadHeaders
     }
     )
 }

--- a/src/private/package/ResolveNovaPackageUploadTarget.ps1
+++ b/src/private/package/ResolveNovaPackageUploadTarget.ps1
@@ -11,13 +11,14 @@ function Resolve-NovaPackageUploadTarget {
     $repositorySettings = Get-NovaPackageRepository -ProjectInfo $ProjectInfo -Repository $Repository
     $resolvedUrl = Get-NovaPackageUploadTargetUrl -PackageSettings $packageSettings -RepositorySettings $repositorySettings -Url $Url
     $resolvedUploadPath = Get-NovaPackageUploadPath -PackageSettings $packageSettings -RepositorySettings $repositorySettings -UploadPath $UploadPath
+    $targetSettings = Get-NovaPackageUploadTargetSettingBundle -PackageSettings $packageSettings -RepositorySettings $repositorySettings
 
     return [pscustomobject]@{
-        Repository = "$( Get-NovaPackageSettingValue -InputObject $repositorySettings -Name 'Name' )".Trim()
+        Repository = $targetSettings.Repository
         Url = $resolvedUrl
         UploadPath = $resolvedUploadPath
-        Headers = Merge-NovaPackageSettingTable -BaseSettings (Get-NovaPackageSettingValue -InputObject $packageSettings -Name 'Headers') -OverrideSettings (Get-NovaPackageSettingValue -InputObject $repositorySettings -Name 'Headers')
-        Auth = Merge-NovaPackageSettingTable -BaseSettings (Get-NovaPackageSettingValue -InputObject $packageSettings -Name 'Auth') -OverrideSettings (Get-NovaPackageSettingValue -InputObject $repositorySettings -Name 'Auth')
+        Headers = $targetSettings.Headers
+        Auth = $targetSettings.Auth
     }
 }
 

--- a/src/private/quality/GetNovaTestWorkflowContext.ps1
+++ b/src/private/quality/GetNovaTestWorkflowContext.ps1
@@ -1,0 +1,50 @@
+function Get-NovaTestWorkflowContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][hashtable]$TestOption,
+        [Parameter(Mandatory)][hashtable]$BoundParameters
+    )
+
+    Test-ProjectSchema Pester | Out-Null
+    $projectInfo = Get-NovaProjectInfo
+    $pesterConfig = New-PesterConfiguration -Hashtable $projectInfo.Pester
+
+    $pesterConfig.Run.Path = Get-NovaPesterRunPath -ProjectInfo $projectInfo
+    $pesterConfig.Run.PassThru = $true
+    $pesterConfig.Run.Exit = $true
+    $pesterConfig.Run.Throw = $true
+    $pesterConfig.Filter.Tag = Get-NovaTestOptionValue -TestOption $TestOption -Name TagFilter
+    $pesterConfig.Filter.ExcludeTag = Get-NovaTestOptionValue -TestOption $TestOption -Name ExcludeTagFilter
+    Initialize-NovaPesterExecutionConfiguration -PesterConfig $pesterConfig -BoundParameters $BoundParameters -OutputVerbosity (Get-NovaTestOptionValue -TestOption $TestOption -Name OutputVerbosity) -OutputRenderMode (Get-NovaTestOptionValue -TestOption $TestOption -Name OutputRenderMode)
+
+    $testResultPath = Get-NovaPesterTestResultPath -ProjectRoot $projectInfo.ProjectRoot
+
+    return [pscustomobject]@{
+        ProjectInfo = $projectInfo
+        PesterConfig = $pesterConfig
+        TestResultPath = $testResultPath
+        TestResultDirectory = Split-Path -Parent $testResultPath
+        TestResultArtifactWriter = Get-Command -Name Write-NovaPesterTestResultArtifact -CommandType Function -ErrorAction Stop
+        TestResultReportWriter = Get-Command -Name Write-NovaPesterTestResultReport -CommandType Function -ErrorAction Stop
+        Target = $testResultPath
+        Operation = 'Run Pester tests and write test results'
+    }
+}
+
+function Get-NovaTestOptionValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][hashtable]$TestOption,
+        [Parameter(Mandatory)][string]$Name
+    )
+
+    if ( $TestOption.ContainsKey($Name)) {
+        return $TestOption[$Name]
+    }
+
+    return $null
+}
+
+
+
+

--- a/src/private/quality/InvokeNovaTestWorkflow.ps1
+++ b/src/private/quality/InvokeNovaTestWorkflow.ps1
@@ -1,0 +1,30 @@
+function Invoke-NovaTestWorkflow {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext
+    )
+
+    Initialize-NovaPesterArtifactDirectory -WorkflowContext $WorkflowContext
+    $WorkflowContext.PesterConfig.TestResult.OutputPath = $WorkflowContext.TestResultPath
+    $testResult = Invoke-NovaPester -Configuration $WorkflowContext.PesterConfig
+    & $WorkflowContext.TestResultArtifactWriter.ScriptBlock -TestResult $testResult -OutputPath $WorkflowContext.TestResultPath -ReportWriter $WorkflowContext.TestResultReportWriter.ScriptBlock
+
+    if ($testResult.Result -ne 'Passed') {
+        throw 'Tests failed'
+    }
+}
+
+function Initialize-NovaPesterArtifactDirectory {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext
+    )
+
+    if (Test-Path -LiteralPath $WorkflowContext.TestResultDirectory) {
+        return
+    }
+
+    $null = New-Item -ItemType Directory -Path $WorkflowContext.TestResultDirectory -Force
+}
+
+

--- a/src/private/release/GetNovaPublishWorkflowContext.ps1
+++ b/src/private/release/GetNovaPublishWorkflowContext.ps1
@@ -1,0 +1,32 @@
+function Get-NovaPublishWorkflowContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
+        [Parameter(Mandatory)][hashtable]$PublishOption,
+        [hashtable]$WorkflowParams = @{},
+        [Parameter(Mandatory)][hashtable]$WorkflowSettings
+    )
+
+    $repository = Get-NovaPublishOptionValue -PublishOption $PublishOption -Name Repository
+    $moduleDirectoryPath = Get-NovaPublishOptionValue -PublishOption $PublishOption -Name ModuleDirectoryPath
+    $apiKey = Get-NovaPublishOptionValue -PublishOption $PublishOption -Name ApiKey
+    $includeLocalPublishActivation = $WorkflowSettings.ContainsKey('IncludeLocalPublishActivation') -and $WorkflowSettings.IncludeLocalPublishActivation
+    $release = $WorkflowSettings.ContainsKey('Release') -and $WorkflowSettings.Release
+    $publishInvocation = Resolve-NovaPublishInvocation -ProjectInfo $ProjectInfo -Repository $repository -ModuleDirectoryPath $moduleDirectoryPath -ApiKey $apiKey
+
+    $localPublishActivation = $null
+    if ($includeLocalPublishActivation) {
+        $localPublishActivation = Get-NovaLocalPublishActivation -PublishInvocation $publishInvocation
+    }
+
+    return [pscustomobject]@{
+        WorkflowName = $WorkflowSettings.WorkflowName
+        LocalRequested = [bool]($PublishOption.ContainsKey('Local') -and $PublishOption.Local)
+        WorkflowParams = $WorkflowParams
+        PublishInvocation = $publishInvocation
+        PublishParams = Get-NovaResolvedPublishParameterMap -PublishInvocation $publishInvocation -WorkflowParams $WorkflowParams
+        LocalPublishActivation = $localPublishActivation
+        Target = $publishInvocation.Target
+        Operation = Get-NovaPublishWorkflowOperation -IsLocal:$publishInvocation.IsLocal -Release:$release
+    }
+}

--- a/src/private/release/GetNovaVersionUpdatePlan.ps1
+++ b/src/private/release/GetNovaVersionUpdatePlan.ps1
@@ -4,12 +4,12 @@ function Get-NovaVersionUpdatePlan {
         [ValidateSet('Major', 'Minor', 'Patch')]
         [string]$Label = 'Patch',
         [switch]$PreviewRelease,
-        [switch]$StableRelease
+        [switch]$StableRelease,
+        [pscustomobject]$ProjectInfo
     )
 
-    $projectInfo = Get-NovaProjectInfo
-    $jsonContent = Get-Content -LiteralPath $projectInfo.ProjectJSON -Raw | ConvertFrom-Json
-    [semver]$currentVersion = $jsonContent.Version
+    $projectInfo = Get-NovaVersionUpdateProjectInfo -ProjectInfo $ProjectInfo
+    $currentVersion = Get-NovaCurrentVersionForUpdatePlan -ProjectInfo $projectInfo
     $versionPart = Get-NovaVersionPartForUpdatePlan -CurrentVersion $currentVersion -Label $Label -PreviewRelease:$PreviewRelease
     $releaseType = Get-NovaVersionPreReleaseLabel -CurrentVersion $currentVersion -PreviewRelease:$PreviewRelease -StableRelease:$StableRelease
     $newVersion = [semver]::new($versionPart.Major, $versionPart.Minor, $versionPart.Patch, $releaseType, $null)
@@ -19,6 +19,34 @@ function Get-NovaVersionUpdatePlan {
         CurrentVersion = $currentVersion
         NewVersion = $newVersion
     }
+}
+
+function Get-NovaVersionUpdateProjectInfo {
+    [CmdletBinding()]
+    param(
+        [pscustomobject]$ProjectInfo
+    )
+
+    if ($null -ne $ProjectInfo) {
+        return $ProjectInfo
+    }
+
+    return Get-NovaProjectInfo
+}
+
+function Get-NovaCurrentVersionForUpdatePlan {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo
+    )
+
+    $hasVersion = $ProjectInfo.PSObject.Properties.Name -contains 'Version'
+    if ($hasVersion -and -not [string]::IsNullOrWhiteSpace($ProjectInfo.Version)) {
+        return [semver]$ProjectInfo.Version
+    }
+
+    $projectJsonData = Read-ProjectJsonData -ProjectJsonPath $ProjectInfo.ProjectJSON
+    return [semver]$projectJsonData.Version
 }
 
 function Get-NovaVersionPartForUpdatePlan {

--- a/src/private/release/GetNovaVersionUpdateWorkflowContext.ps1
+++ b/src/private/release/GetNovaVersionUpdateWorkflowContext.ps1
@@ -1,0 +1,39 @@
+function Get-NovaVersionUpdateWorkflowContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ProjectRoot,
+        [switch]$PreviewRelease
+    )
+
+    $projectInfo = Get-NovaProjectInfo -Path $ProjectRoot
+    $commitMessages = @(Get-GitCommitMessageForVersionBump -ProjectRoot $ProjectRoot)
+    $label = Get-NovaVersionLabelForBump -ProjectRoot $ProjectRoot -CommitMessages $commitMessages
+    $versionUpdatePlan = Get-NovaVersionUpdatePlan -ProjectInfo $projectInfo -Label $label -PreviewRelease:$PreviewRelease
+
+    return Get-NovaVersionUpdateWorkflowContextObject -ProjectRoot $ProjectRoot -ProjectInfo $projectInfo -CommitMessages $commitMessages -Label $label -VersionUpdatePlan $versionUpdatePlan -PreviewRelease:$PreviewRelease
+}
+
+function Get-NovaVersionUpdateWorkflowContextObject {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ProjectRoot,
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
+        [AllowEmptyCollection()][string[]]$CommitMessages = @(),
+        [Parameter(Mandatory)][string]$Label,
+        [Parameter(Mandatory)][pscustomobject]$VersionUpdatePlan,
+        [switch]$PreviewRelease
+    )
+
+    return [pscustomobject]@{
+        ProjectRoot = $ProjectRoot
+        ProjectInfo = $ProjectInfo
+        CommitMessages = $CommitMessages
+        CommitCount = $CommitMessages.Count
+        Label = $Label
+        PreviewRelease = [bool]$PreviewRelease
+        Target = [System.IO.Path]::GetFileName($ProjectInfo.ProjectJSON)
+        Action = "Update module version using $Label release label"
+        PreviousVersion = $ProjectInfo.Version
+        NewVersion = $VersionUpdatePlan.NewVersion.ToString()
+    }
+}

--- a/src/private/release/InvokeNovaPublishWorkflow.ps1
+++ b/src/private/release/InvokeNovaPublishWorkflow.ps1
@@ -1,0 +1,22 @@
+function Invoke-NovaPublishWorkflow {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext,
+        [switch]$ShouldRun
+    )
+
+    $workflowParams = $WorkflowContext.WorkflowParams
+    $publishParams = $WorkflowContext.PublishParams
+
+    Invoke-NovaBuild @workflowParams
+    Test-NovaBuild @workflowParams
+
+    & $WorkflowContext.PublishInvocation.Action @publishParams
+
+    if (-not $ShouldRun -or -not $WorkflowContext.LocalPublishActivation) {
+        return
+    }
+
+    $null = & $WorkflowContext.LocalPublishActivation.ImportAction -ProjectName $WorkflowContext.PublishInvocation.Parameters.ProjectInfo.ProjectName -ManifestPath $WorkflowContext.LocalPublishActivation.ManifestPath
+    Write-Verbose "Module copy to local path complete and imported from $( $WorkflowContext.LocalPublishActivation.ManifestPath )"
+}

--- a/src/private/release/InvokeNovaReleaseWorkflow.ps1
+++ b/src/private/release/InvokeNovaReleaseWorkflow.ps1
@@ -1,0 +1,18 @@
+function Invoke-NovaReleaseWorkflow {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext
+    )
+
+    $workflowParams = $WorkflowContext.WorkflowParams
+    $publishParams = $WorkflowContext.PublishParams
+
+    Invoke-NovaBuild @workflowParams
+    Test-NovaBuild @workflowParams
+    $versionResult = Update-NovaModuleVersion @workflowParams
+    Invoke-NovaBuild @workflowParams
+
+    & $WorkflowContext.PublishInvocation.Action @publishParams
+
+    return $versionResult
+}

--- a/src/private/release/InvokeNovaVersionUpdateWorkflow.ps1
+++ b/src/private/release/InvokeNovaVersionUpdateWorkflow.ps1
@@ -1,0 +1,42 @@
+function Invoke-NovaVersionUpdateWorkflow {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext,
+        [switch]$ShouldRun,
+        [switch]$WhatIfEnabled
+    )
+
+    if ($ShouldRun) {
+        Set-NovaModuleVersion -ProjectInfo $WorkflowContext.ProjectInfo -Label $WorkflowContext.Label -PreviewRelease:$WorkflowContext.PreviewRelease -Confirm:$false
+    }
+
+    if (-not (Test-NovaVersionUpdateResultRequired -ShouldRun:$ShouldRun -WhatIfEnabled:$WhatIfEnabled)) {
+        return
+    }
+
+    return Get-NovaVersionUpdateResult -WorkflowContext $WorkflowContext
+}
+
+function Test-NovaVersionUpdateResultRequired {
+    [CmdletBinding()]
+    param(
+        [switch]$ShouldRun,
+        [switch]$WhatIfEnabled
+    )
+
+    return $ShouldRun -or $WhatIfEnabled
+}
+
+function Get-NovaVersionUpdateResult {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext
+    )
+
+    return [pscustomobject]@{
+        PreviousVersion = $WorkflowContext.PreviousVersion
+        NewVersion = $WorkflowContext.NewVersion
+        Label = $WorkflowContext.Label
+        CommitCount = $WorkflowContext.CommitCount
+    }
+}

--- a/src/private/release/SetNovaModuleVersion.ps1
+++ b/src/private/release/SetNovaModuleVersion.ps1
@@ -4,11 +4,12 @@ function Set-NovaModuleVersion {
         [ValidateSet('Major', 'Minor', 'Patch')]
         [string]$Label = 'Patch',
         [switch]$PreviewRelease,
-        [switch]$StableRelease
+        [switch]$StableRelease,
+        [pscustomobject]$ProjectInfo
     )
     Write-Verbose 'Running Version Update'
 
-    $versionUpdatePlan = Get-NovaVersionUpdatePlan -Label $Label -PreviewRelease:$PreviewRelease -StableRelease:$StableRelease
+    $versionUpdatePlan = Get-NovaVersionUpdatePlan -ProjectInfo $ProjectInfo -Label $Label -PreviewRelease:$PreviewRelease -StableRelease:$StableRelease
     $jsonContent = Read-ProjectJsonData -ProjectJsonPath $versionUpdatePlan.ProjectFile
     $newVersion = $versionUpdatePlan.NewVersion.ToString()
     $target = [System.IO.Path]::GetFileName($versionUpdatePlan.ProjectFile)

--- a/src/private/release/WriteNovaPublishWorkflowContext.ps1
+++ b/src/private/release/WriteNovaPublishWorkflowContext.ps1
@@ -1,0 +1,10 @@
+function Write-NovaPublishWorkflowContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext
+    )
+
+    Write-NovaLocalWorkflowMode -WorkflowName $WorkflowContext.WorkflowName -LocalRequested:$WorkflowContext.LocalRequested
+    Write-NovaResolvedLocalPublishTarget -PublishInvocation $WorkflowContext.PublishInvocation
+}
+

--- a/src/private/scaffold/GetNovaModuleInitializationWorkflowContext.ps1
+++ b/src/private/scaffold/GetNovaModuleInitializationWorkflowContext.ps1
@@ -1,0 +1,22 @@
+function Get-NovaModuleInitializationWorkflowContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [switch]$Example
+    )
+
+    $basePath = Resolve-NovaModuleScaffoldBasePath -Path $Path
+    $questionSet = Get-NovaModuleQuestionSet -Example:$Example
+    $answerSet = Read-NovaModuleAnswerSet -Questions $questionSet
+    $layout = Get-NovaModuleScaffoldLayout -Path $basePath -ProjectName $answerSet.ProjectName
+
+    return [pscustomobject]@{
+        BasePath = $basePath
+        QuestionSet = $questionSet
+        AnswerSet = $answerSet
+        Layout = $layout
+        Example = $Example.IsPresent
+        Target = $layout.Project
+        Action = 'Create Nova module scaffold'
+    }
+}

--- a/src/private/scaffold/InvokeNovaModuleInitializationWorkflow.ps1
+++ b/src/private/scaffold/InvokeNovaModuleInitializationWorkflow.ps1
@@ -1,0 +1,11 @@
+function Invoke-NovaModuleInitializationWorkflow {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext
+    )
+
+    Initialize-NovaModuleScaffold -Answer $WorkflowContext.AnswerSet -Paths $WorkflowContext.Layout -Example:$WorkflowContext.Example
+    Write-NovaModuleProjectJson -Answer $WorkflowContext.AnswerSet -ProjectJsonFile $WorkflowContext.Layout.ProjectJsonFile -Example:$WorkflowContext.Example
+
+    'Module {0} scaffolding complete' -f $WorkflowContext.AnswerSet.ProjectName | Write-Message -color Green
+}

--- a/src/private/shared/GetNovaProjectInfoContext.ps1
+++ b/src/private/shared/GetNovaProjectInfoContext.ps1
@@ -1,0 +1,19 @@
+function Get-NovaProjectInfoContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    $projectRoot = (Resolve-Path -LiteralPath $Path).Path
+    $projectJson = [System.IO.Path]::Join($projectRoot, 'project.json')
+    if (-not (Test-Path -LiteralPath $projectJson)) {
+        throw "Not a project folder. project.json not found: $projectJson"
+    }
+
+    return [pscustomobject]@{
+        ProjectRoot = $projectRoot
+        ProjectJson = $projectJson
+        JsonData = Read-ProjectJsonData -ProjectJsonPath $projectJson
+    }
+}
+

--- a/src/private/shared/GetNovaProjectInfoResult.ps1
+++ b/src/private/shared/GetNovaProjectInfoResult.ps1
@@ -1,0 +1,48 @@
+function Get-NovaProjectInfoResult {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext,
+        [switch]$Version
+    )
+
+    $projectRoot = $WorkflowContext.ProjectRoot
+    $projectJson = $WorkflowContext.ProjectJson
+    $jsonData = $WorkflowContext.JsonData
+    if ($Version) {
+        return $jsonData.Version
+    }
+
+    $projectData = [ordered]@{ProjectJSON = $projectJson}
+    foreach ($key in $jsonData.Keys) {
+        $projectData[$key] = $jsonData[$key]
+    }
+
+    $booleanDefaults = [ordered]@{BuildRecursiveFolders = $true; FailOnDuplicateFunctionNames = $true; SetSourcePath = $true; CopyResourcesToModuleRoot = $false}
+    foreach ($defaultEntry in $booleanDefaults.GetEnumerator()) {
+        $projectData[$defaultEntry.Key] = if ( $projectData.Contains($defaultEntry.Key)) {
+            [bool]$projectData[$defaultEntry.Key]
+        } else {
+            $defaultEntry.Value
+        }
+    }
+
+    $projectData['Preamble'] = @(Get-ProjectPreamble -ProjectData $jsonData)
+    $projectData.PSTypeName = 'MTProjectInfo'
+    $projectName = $jsonData.ProjectName
+    $manifestSettings = Get-NovaResolvedProjectManifestSettings -ProjectData $projectData
+    $projectData['Manifest'] = $manifestSettings
+    $projectData['Package'] = Get-NovaResolvedProjectPackageSettings -ProjectData $projectData -ManifestSettings $manifestSettings -ProjectRoot $projectRoot
+    $projectData['ProjectRoot'] = $projectRoot
+    $projectData['PublicDir'] = [System.IO.Path]::Join($projectRoot, 'src', 'public')
+    $projectData['PrivateDir'] = [System.IO.Path]::Join($projectRoot, 'src', 'private')
+    $projectData['ClassesDir'] = [System.IO.Path]::Join($projectRoot, 'src', 'classes')
+    $projectData['ResourcesDir'] = [System.IO.Path]::Join($projectRoot, 'src', 'resources')
+    $projectData['TestsDir'] = [System.IO.Path]::Join($projectRoot, 'tests')
+    $projectData['DocsDir'] = [System.IO.Path]::Join($projectRoot, 'docs')
+    $projectData['OutputDir'] = [System.IO.Path]::Join($projectRoot, 'dist')
+    $projectData['OutputModuleDir'] = [System.IO.Path]::Join($projectData.OutputDir, $projectName)
+    $projectData['ModuleFilePSM1'] = [System.IO.Path]::Join($projectData.OutputModuleDir, "$projectName.psm1")
+    $projectData['ManifestFilePSD1'] = [System.IO.Path]::Join($projectData.OutputModuleDir, "$projectName.psd1")
+
+    return [pscustomobject]$projectData
+}

--- a/src/private/update/GetNovaModuleSelfUpdateWorkflowContext.ps1
+++ b/src/private/update/GetNovaModuleSelfUpdateWorkflowContext.ps1
@@ -1,0 +1,48 @@
+function Get-NovaModuleSelfUpdateWorkflowContext {
+    [CmdletBinding()]
+    param(
+        [pscustomobject]$Preference,
+        [pscustomobject]$InstalledModule,
+        [pscustomobject]$LookupResult,
+        [int]$TimeoutMilliseconds = 10000
+    )
+
+    $resolvedPreference = if ($null -ne $Preference) {
+        $Preference
+    }
+    else {
+        Read-NovaUpdateNotificationPreference
+    }
+    $resolvedInstalledModule = if ($null -ne $InstalledModule) {
+        $InstalledModule
+    }
+    else {
+        Get-NovaInstalledModuleVersionInfo
+    }
+    $resolvedLookupResult = if ($null -ne $LookupResult) {
+        $LookupResult
+    }
+    else {
+        Invoke-NovaModuleUpdateLookup -AllowPrereleaseNotifications:$resolvedPreference.PrereleaseNotificationsEnabled -TimeoutMilliseconds $TimeoutMilliseconds
+    }
+
+    if ($null -eq $resolvedLookupResult) {
+        throw 'Unable to determine a NovaModuleTools update candidate. Try again when the PowerShell Gallery is reachable.'
+    }
+
+    $plan = Get-NovaModuleSelfUpdatePlan -InstalledModule $resolvedInstalledModule -LookupResult $resolvedLookupResult -PrereleaseNotificationsEnabled $resolvedPreference.PrereleaseNotificationsEnabled
+    $action = if ($plan.IsPrereleaseTarget) {
+        "Update NovaModuleTools to prerelease version $( $plan.TargetVersion )"
+    }
+    else {
+        "Update NovaModuleTools to version $( $plan.TargetVersion )"
+    }
+
+    return [pscustomobject]@{
+        Preference = $resolvedPreference
+        InstalledModule = $resolvedInstalledModule
+        LookupResult = $resolvedLookupResult
+        Plan = $plan
+        Action = $action
+    }
+}

--- a/src/private/update/GetNovaUpdateNotificationPreferenceChangeContext.ps1
+++ b/src/private/update/GetNovaUpdateNotificationPreferenceChangeContext.ps1
@@ -1,0 +1,25 @@
+function Get-NovaUpdateNotificationPreferenceChangeContext {
+    [CmdletBinding()]
+    param(
+        [switch]$EnablePrereleaseNotifications,
+        [switch]$DisablePrereleaseNotifications
+    )
+
+    if ($EnablePrereleaseNotifications.IsPresent) {
+        return [pscustomobject]@{
+            PrereleaseNotificationsEnabled = $true
+            Target = Get-NovaUpdateSettingsFilePath
+            Action = 'Enable prerelease update notifications'
+        }
+    }
+
+    if ($DisablePrereleaseNotifications.IsPresent) {
+        return [pscustomobject]@{
+            PrereleaseNotificationsEnabled = $false
+            Target = Get-NovaUpdateSettingsFilePath
+            Action = 'Disable prerelease update notifications'
+        }
+    }
+
+    throw 'Specify either -EnablePrereleaseNotifications or -DisablePrereleaseNotifications.'
+}

--- a/src/private/update/GetNovaUpdateNotificationPreferenceStatus.ps1
+++ b/src/private/update/GetNovaUpdateNotificationPreferenceStatus.ps1
@@ -1,0 +1,12 @@
+function Get-NovaUpdateNotificationPreferenceStatus {
+    [CmdletBinding()]
+    param()
+
+    $preference = Read-NovaUpdateNotificationPreference
+
+    return [pscustomobject]@{
+        PrereleaseNotificationsEnabled = $preference.PrereleaseNotificationsEnabled
+        StableReleaseNotificationsEnabled = $true
+        SettingsPath = Get-NovaUpdateSettingsFilePath
+    }
+}

--- a/src/private/update/InvokeNovaModuleSelfUpdateWorkflow.ps1
+++ b/src/private/update/InvokeNovaModuleSelfUpdateWorkflow.ps1
@@ -1,0 +1,16 @@
+function Invoke-NovaModuleSelfUpdateWorkflow {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext
+    )
+
+    $plan = $WorkflowContext.Plan
+    if (-not $plan.UpdateAvailable) {
+        return $plan
+    }
+
+    $null = Invoke-NovaModuleSelfUpdate -ModuleName $plan.ModuleName -AllowPrerelease:$plan.UsedAllowPrerelease
+    $plan.Updated = $true
+    Write-NovaModuleReleaseNotesLink
+    return $plan
+}

--- a/src/private/update/InvokeNovaUpdateNotificationPreferenceChange.ps1
+++ b/src/private/update/InvokeNovaUpdateNotificationPreferenceChange.ps1
@@ -1,0 +1,9 @@
+function Invoke-NovaUpdateNotificationPreferenceChange {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext
+    )
+
+    Write-NovaUpdateNotificationPreference -PrereleaseNotificationsEnabled:$WorkflowContext.PrereleaseNotificationsEnabled
+    return Get-NovaUpdateNotificationPreferenceStatus
+}

--- a/src/public/DeployNovaPackage.ps1
+++ b/src/public/DeployNovaPackage.ps1
@@ -14,19 +14,19 @@ function Deploy-NovaPackage {
     end {
         $projectInfo = Get-NovaProjectInfo
         $uploadOption = New-NovaPackageUploadOption -BoundParameters $PSBoundParameters
-        $uploadArtifactList = @(Resolve-NovaPackageUploadInvocation -ProjectInfo $projectInfo -UploadOption $uploadOption)
-        $uploadResultList = @()
-
-        foreach ($uploadArtifact in $uploadArtifactList) {
+        $workflowContext = Get-NovaPackageUploadWorkflowContext -BoundParameters $PSBoundParameters -ProjectInfo $projectInfo -UploadOption $uploadOption
+        $approvedUploadArtifactList = @(
+        foreach ($uploadArtifact in $workflowContext.UploadArtifactList) {
             $uploadAction = "Upload $( $uploadArtifact.Type ) package artifact $( $uploadArtifact.PackageFileName )"
             if (-not $PSCmdlet.ShouldProcess($uploadArtifact.UploadUrl, $uploadAction)) {
                 continue
             }
 
-            $uploadResultList += Invoke-NovaPackageArtifactUpload -UploadArtifact $uploadArtifact
+            $uploadArtifact
         }
+        )
 
-        return $uploadResultList
+        return @(Invoke-NovaPackageUploadWorkflow -WorkflowContext $workflowContext -UploadArtifactList $approvedUploadArtifactList)
     }
 }
 

--- a/src/public/GetNovaProjectInfo.ps1
+++ b/src/public/GetNovaProjectInfo.ps1
@@ -5,63 +5,6 @@ function Get-NovaProjectInfo {
         [string]$Path = (Get-Location).Path,
         [switch]$Version
     )
-    $ProjectRoot = (Resolve-Path -LiteralPath $Path).Path
-    $ProjectJson = [System.IO.Path]::Join($ProjectRoot, 'project.json')
-
-    if (-not (Test-Path -LiteralPath $projectJson)) {
-        throw "Not a project folder. project.json not found: $projectJson"
-    }
-
-    $jsonData = Read-ProjectJsonData -ProjectJsonPath $projectJson
-
-    if ($Version) {
-        return $jsonData.Version
-    }
-
-    $Out = @{}
-    $Out['ProjectJSON'] = $ProjectJson
-
-    foreach ($key in $jsonData.Keys) {
-        $Out[$key] = $jsonData[$key]
-    }
-
-    $booleanDefaults = [ordered]@{
-        BuildRecursiveFolders = $true
-        FailOnDuplicateFunctionNames = $true
-        SetSourcePath = $true
-        CopyResourcesToModuleRoot = $false
-    }
-
-    foreach ($boolKey in $booleanDefaults.Keys) {
-        if (-not $Out.ContainsKey($boolKey)) {
-            $Out[$boolKey] = $booleanDefaults[$boolKey]
-            continue
-        }
-
-        $Out[$boolKey] = [bool]$Out[$boolKey]
-    }
-
-    $Out['Preamble'] = @(Get-ProjectPreamble -ProjectData $jsonData)
-
-    $Out.ProjectJson = $projectJson
-    $Out.PSTypeName = 'MTProjectInfo'
-    $ProjectName = $jsonData.ProjectName
-    $manifestSettings = Get-NovaResolvedProjectManifestSettings -ProjectData $Out
-    $Out['Manifest'] = $manifestSettings
-    $Out['Package'] = Get-NovaResolvedProjectPackageSettings -ProjectData $Out -ManifestSettings $manifestSettings -ProjectRoot $ProjectRoot
-
-    ## Folders
-    $Out['ProjectRoot'] = $ProjectRoot
-    $Out['PublicDir'] = [System.IO.Path]::Join($ProjectRoot, 'src', 'public')
-    $Out['PrivateDir'] = [System.IO.Path]::Join($ProjectRoot, 'src', 'private')
-    $Out['ClassesDir'] = [System.IO.Path]::Join($ProjectRoot, 'src', 'classes')
-    $Out['ResourcesDir'] = [System.IO.Path]::Join($ProjectRoot, 'src', 'resources')
-    $Out['TestsDir'] = [System.IO.Path]::Join($ProjectRoot, 'tests')
-    $Out['DocsDir'] = [System.IO.Path]::Join($ProjectRoot, 'docs')
-    $Out['OutputDir'] = [System.IO.Path]::Join($ProjectRoot, 'dist')
-    $Out['OutputModuleDir'] = [System.IO.Path]::Join($Out.OutputDir, $ProjectName)
-    $Out['ModuleFilePSM1'] = [System.IO.Path]::Join($Out.OutputModuleDir, "$ProjectName.psm1")
-    $Out['ManifestFilePSD1'] = [System.IO.Path]::Join($Out.OutputModuleDir, "$ProjectName.psd1")
-
-    return [pscustomobject]$out
+    $workflowContext = Get-NovaProjectInfoContext -Path $Path
+    return Get-NovaProjectInfoResult -WorkflowContext $workflowContext -Version:$Version
 }

--- a/src/public/GetNovaUpdateNotificationPreference.ps1
+++ b/src/public/GetNovaUpdateNotificationPreference.ps1
@@ -2,11 +2,5 @@ function Get-NovaUpdateNotificationPreference {
     [CmdletBinding()]
     param()
 
-    $preference = Read-NovaUpdateNotificationPreference
-
-    return [pscustomobject]@{
-        PrereleaseNotificationsEnabled = $preference.PrereleaseNotificationsEnabled
-        StableReleaseNotificationsEnabled = $true
-        SettingsPath = Get-NovaUpdateSettingsFilePath
-    }
+    return Get-NovaUpdateNotificationPreferenceStatus
 }

--- a/src/public/InitializeNovaModule.ps1
+++ b/src/public/InitializeNovaModule.ps1
@@ -5,18 +5,12 @@ function Initialize-NovaModule {
         [switch]$Example
     )
 
-    $basePath = Resolve-NovaModuleScaffoldBasePath -Path $Path
-    $questionSet = Get-NovaModuleQuestionSet -Example:$Example
-    $answerSet = Read-NovaModuleAnswerSet -Questions $questionSet
-    $layout = Get-NovaModuleScaffoldLayout -Path $basePath -ProjectName $answerSet.ProjectName
+    $workflowContext = Get-NovaModuleInitializationWorkflowContext -Path $Path -Example:$Example
 
-    if (-not $PSCmdlet.ShouldProcess($layout.Project, 'Create Nova module scaffold')) {
+    if (-not $PSCmdlet.ShouldProcess($workflowContext.Target, $workflowContext.Action)) {
         return
     }
 
-    Initialize-NovaModuleScaffold -Answer $answerSet -Paths $layout -Example:$Example
-    Write-NovaModuleProjectJson -Answer $answerSet -ProjectJsonFile $layout.ProjectJsonFile -Example:$Example
-
-    'Module {0} scaffolding complete' -f $answerSet.ProjectName | Write-Message -color Green
+    Invoke-NovaModuleInitializationWorkflow -WorkflowContext $workflowContext
 }
 

--- a/src/public/InstallNovaCli.ps1
+++ b/src/public/InstallNovaCli.ps1
@@ -5,33 +5,11 @@ function Install-NovaCli {
         [switch]$Force
     )
 
-    if ($IsWindows) {
-        throw 'Install-NovaCli currently supports macOS/Linux only. On Windows, use the nova alias inside pwsh after importing NovaModuleTools.'
-    }
+    $workflowContext = Get-NovaCliInstallWorkflowContext -DestinationDirectory $DestinationDirectory -Force:$Force
 
-    $targetDirectory = Get-NovaCliInstallDirectory -DestinationDirectory $DestinationDirectory
-    $sourcePath = Get-NovaCliLauncherPath
-    $targetPath = Join-Path $targetDirectory 'nova'
-    if ((Test-Path -LiteralPath $targetPath) -and -not $Force) {
-        throw "Target file already exists: $targetPath. Use -Force to overwrite it."
-    }
-
-    if (-not $PSCmdlet.ShouldProcess($targetPath, 'Install nova CLI launcher')) {
+    if (-not $PSCmdlet.ShouldProcess($workflowContext.TargetPath, $workflowContext.Action)) {
         return
     }
 
-    $installedPath = Copy-NovaCliLauncher -SourcePath $sourcePath -TargetPath $targetPath -Force:$Force
-    $directoryOnPath = Test-NovaCliDirectoryOnPath -Directory $targetDirectory
-    if (-not $directoryOnPath) {
-        Write-Warning "Installed nova to $targetDirectory, but that directory is not currently in PATH. Add it to your shell profile before using nova directly from zsh/bash."
-    }
-
-    Write-NovaModuleReleaseNotesLink
-
-    return [pscustomobject]@{
-        CommandName = 'nova'
-        InstalledPath = $installedPath
-        DestinationDirectory = $targetDirectory
-        DirectoryOnPath = $directoryOnPath
-    }
+    return Invoke-NovaCliInstallWorkflow -WorkflowContext $workflowContext
 }

--- a/src/public/InvokeNovaBuild.ps1
+++ b/src/public/InvokeNovaBuild.ps1
@@ -2,27 +2,11 @@ function Invoke-NovaBuild {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
     )
-    $data = Get-NovaProjectInfo
+    $workflowContext = Get-NovaBuildWorkflowContext
 
-    if (-not $PSCmdlet.ShouldProcess($data.OutputModuleDir, 'Build Nova module output')) {
+    if (-not $PSCmdlet.ShouldProcess($workflowContext.Target, $workflowContext.Operation)) {
         return
     }
 
-    Reset-ProjectDist -Confirm:$false
-    Build-Module
-
-    if ($data.FailOnDuplicateFunctionNames) {
-        Assert-BuiltModuleHasNoDuplicateFunctionName -ProjectInfo $data
-    }
-
-    Build-Manifest
-    Build-Help
-    Copy-ProjectResource
-
-    try {
-        Invoke-NovaBuildUpdateNotification
-    }
-    catch {
-        $null = $_
-    }
+    Invoke-NovaBuildWorkflow -WorkflowContext $workflowContext
 }

--- a/src/public/InvokeNovaCli.ps1
+++ b/src/public/InvokeNovaCli.ps1
@@ -1,4 +1,5 @@
 function Invoke-NovaCli {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSShouldProcess', '', Justification = 'The public CLI entrypoint forwards WhatIf/Confirm semantics to the routed commands that own the actual ShouldProcess decisions.')]
     [CmdletBinding(SupportsShouldProcess = $true)]
     [Alias('nova')]
     param(
@@ -8,65 +9,6 @@ function Invoke-NovaCli {
         [string[]]$Arguments
     )
 
-    $commonParameters = Get-NovaCliForwardingParameterSet -BoundParameters $PSBoundParameters; $mutatingCommonParameters = Get-NovaCliForwardingParameterSet -BoundParameters $PSBoundParameters -IncludeShouldProcess
-
-    $Arguments = ConvertTo-NovaCliArgumentArray -BoundParameters $PSBoundParameters -Arguments $Arguments
-
-    if (Test-NovaCliHelpRequest -Arguments $Arguments) {
-        return Get-NovaCliCommandHelp -Command $Command
-    }
-
-    switch ($Command) {
-        'info' {
-            return Get-NovaProjectInfo @commonParameters
-        }
-        'version' {
-            return Invoke-NovaCliVersionCommand -Arguments $Arguments -ForwardedParameters $commonParameters
-        }
-        'build' {
-            return Invoke-NovaBuild @mutatingCommonParameters
-        }
-        'test' {
-            return Test-NovaBuild @mutatingCommonParameters
-        }
-        'package' {
-            return New-NovaModulePackage @mutatingCommonParameters
-        }
-        'deploy' {
-            return Invoke-NovaCliDeployCommand -Arguments $Arguments -ForwardedParameters $mutatingCommonParameters
-        }
-        'init' {
-            return Invoke-NovaCliInitCommand -Arguments $Arguments -ForwardedParameters $mutatingCommonParameters -WhatIfEnabled:$WhatIfPreference
-        }
-        'bump' {
-            $options = ConvertFrom-NovaBumpCliArgument -Arguments $Arguments
-            return Update-NovaModuleVersion @options @mutatingCommonParameters
-        }
-        'update' {
-            $result = Invoke-NovaCliUpdateCommand -Arguments $Arguments -ForwardedParameters $mutatingCommonParameters
-            return Format-NovaCliCommandResult -Command $Command -Result $result
-        }
-        'publish' {
-            $options = ConvertFrom-NovaCliArgument -Arguments $Arguments
-            return Publish-NovaModule @options @mutatingCommonParameters
-        }
-        'release' {
-            $options = ConvertFrom-NovaCliArgument -Arguments $Arguments
-            return Invoke-NovaRelease -PublishOption $options @mutatingCommonParameters
-        }
-        'notification' {
-            return Invoke-NovaCliNotificationCommand -Arguments $Arguments -CommonParameters $commonParameters -MutatingCommonParameters $mutatingCommonParameters
-        }
-        '--version' {
-            $moduleName = $ExecutionContext.SessionState.Module.Name
-            $moduleVersion = Get-NovaCliInstalledVersion
-            return Format-NovaCliVersionString -Name $moduleName -Version $moduleVersion
-        }
-        '--help' {
-            return Get-NovaCliHelp
-        }
-        default {
-            throw "Unknown command: <$Command> | Use 'nova --help' to see available commands."
-        }
-    }
+    $invocationContext = Get-NovaCliInvocationContext -Command $Command -BoundParameters $PSBoundParameters -Arguments $Arguments -WhatIfEnabled:$WhatIfPreference
+    return Invoke-NovaCliCommandRoute -InvocationContext $invocationContext
 }

--- a/src/public/InvokeNovaRelease.ps1
+++ b/src/public/InvokeNovaRelease.ps1
@@ -7,36 +7,19 @@ function Invoke-NovaRelease {
 
     Push-Location -LiteralPath $Path
     try {
-        $projectInfo = Get-NovaProjectInfo
-        $workflowParams = Get-NovaShouldProcessForwardingParameter -WhatIfEnabled:$WhatIfPreference
-        $repository = Get-NovaPublishOptionValue -PublishOption $PublishOption -Name Repository
-        $moduleDirectoryPath = Get-NovaPublishOptionValue -PublishOption $PublishOption -Name ModuleDirectoryPath
-        $apiKey = Get-NovaPublishOptionValue -PublishOption $PublishOption -Name ApiKey
-        $publishInvocation = Resolve-NovaPublishInvocation -ProjectInfo $projectInfo -Repository $repository -ModuleDirectoryPath $moduleDirectoryPath -ApiKey $apiKey
+        $workflowContext = Get-NovaPublishWorkflowContext -ProjectInfo (Get-NovaProjectInfo) -PublishOption $PublishOption -WorkflowParams (Get-NovaShouldProcessForwardingParameter -WhatIfEnabled:$WhatIfPreference) -WorkflowSettings @{
+            WorkflowName = 'release'
+            Release = $true
+        }
 
-        Write-NovaLocalWorkflowMode -WorkflowName release -LocalRequested:($PublishOption.ContainsKey('Local') -and $PublishOption.Local)
-        Write-NovaResolvedLocalPublishTarget -PublishInvocation $publishInvocation
+        Write-NovaPublishWorkflowContext -WorkflowContext $workflowContext
 
-        $releaseOperation = Get-NovaPublishWorkflowOperation -IsLocal:$publishInvocation.IsLocal -Release
-        $publishParams = Get-NovaResolvedPublishParameterMap -PublishInvocation $publishInvocation -WorkflowParams $workflowParams
-
-        $shouldRun = $PSCmdlet.ShouldProcess($publishInvocation.Target, $releaseOperation)
+        $shouldRun = $PSCmdlet.ShouldProcess($workflowContext.Target, $workflowContext.Operation)
         if (-not $shouldRun -and -not $WhatIfPreference) {
             return
         }
 
-        Invoke-NovaBuild @workflowParams
-        Test-NovaBuild @workflowParams
-        $versionResult = Update-NovaModuleVersion @workflowParams
-        Invoke-NovaBuild @workflowParams
-
-
-        & $publishInvocation.Action @publishParams
-
-        return $versionResult
-    }
-    catch {
-        throw
+        return Invoke-NovaReleaseWorkflow -WorkflowContext $workflowContext
     }
     finally {
         Pop-Location

--- a/src/public/NewNovaModulePackage.ps1
+++ b/src/public/NewNovaModulePackage.ps1
@@ -2,44 +2,8 @@ function New-NovaModulePackage {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param()
 
-    $moduleContext = $ExecutionContext.SessionState.Module
-    $workflowParams = Get-NovaShouldProcessForwardingParameter -WhatIfEnabled:$WhatIfPreference
-    $projectInfo = Get-NovaProjectInfo
-    $packageMetadataList = @(Get-NovaPackageMetadataList -ProjectInfo $projectInfo)
-    foreach ($packageMetadata in $packageMetadataList) {
-        Assert-NovaPackageMetadata -PackageMetadata $packageMetadata
-    }
+    $workflowContext = Get-NovaPackageWorkflowContext -WorkflowParams (Get-NovaShouldProcessForwardingParameter -WhatIfEnabled:$WhatIfPreference)
+    $shouldRun = $PSCmdlet.ShouldProcess($workflowContext.Target, $workflowContext.Operation)
 
-    Invoke-NovaBuild @workflowParams
-    Test-NovaBuild @workflowParams
-
-    $packagePathList = @($packageMetadataList.PackagePath)
-    $packageTarget = $packagePathList -join ', '
-    $packageAction = if ($packageMetadataList.Count -eq 1) {
-        "Create $( $packageMetadataList[0].Type ) package from built module output"
-    }
-    else {
-        'Create package artifacts from built module output'
-    }
-
-    if (-not $PSCmdlet.ShouldProcess($packageTarget, $packageAction)) {
-        return
-    }
-
-    $packageHelper = Get-Command -Name New-NovaPackageArtifacts -CommandType Function -ErrorAction SilentlyContinue
-    if ($null -ne $packageHelper) {
-        return New-NovaPackageArtifacts -ProjectInfo $projectInfo -PackageMetadataList $packageMetadataList
-    }
-
-    $packagingModule = Import-Module $moduleContext.Path -Force -PassThru
-    $packageCreation = {
-        param($ProjectInfo, $PackageMetadataList)
-
-        New-NovaPackageArtifacts -ProjectInfo $ProjectInfo -PackageMetadataList $PackageMetadataList
-    }
-
-    return & $packagingModule $packageCreation $projectInfo $packageMetadataList
+    return Invoke-NovaPackageWorkflow -WorkflowContext $workflowContext -ShouldRun:$shouldRun
 }
-
-
-

--- a/src/public/PublishNovaModule.ps1
+++ b/src/public/PublishNovaModule.ps1
@@ -11,29 +11,22 @@ function Publish-NovaModule {
         [string]$ApiKey
     )
 
-    $projectInfo = Get-NovaProjectInfo
-    $workflowParams = Get-NovaShouldProcessForwardingParameter -WhatIfEnabled:$WhatIfPreference
-    $publishInvocation = Resolve-NovaPublishInvocation -ProjectInfo $projectInfo -Repository $Repository -ModuleDirectoryPath $ModuleDirectoryPath -ApiKey $ApiKey
+    $workflowContext = Get-NovaPublishWorkflowContext -ProjectInfo (Get-NovaProjectInfo) -PublishOption @{
+        Local = [bool]$Local
+        Repository = $Repository
+        ModuleDirectoryPath = $ModuleDirectoryPath
+        ApiKey = $ApiKey
+    } -WorkflowParams (Get-NovaShouldProcessForwardingParameter -WhatIfEnabled:$WhatIfPreference) -WorkflowSettings @{
+        WorkflowName = 'publish'
+        IncludeLocalPublishActivation = $true
+    }
 
-    Write-NovaLocalWorkflowMode -WorkflowName publish -LocalRequested:$Local
-    Write-NovaResolvedLocalPublishTarget -PublishInvocation $publishInvocation
+    Write-NovaPublishWorkflowContext -WorkflowContext $workflowContext
 
-    $publishOperation = Get-NovaPublishWorkflowOperation -IsLocal:$publishInvocation.IsLocal
-    $localPublishActivation = Get-NovaLocalPublishActivation -PublishInvocation $publishInvocation
-    $publishParams = Get-NovaResolvedPublishParameterMap -PublishInvocation $publishInvocation -WorkflowParams $workflowParams
-
-    $shouldRun = $PSCmdlet.ShouldProcess($publishInvocation.Target, $publishOperation)
+    $shouldRun = $PSCmdlet.ShouldProcess($workflowContext.Target, $workflowContext.Operation)
     if (-not $shouldRun -and -not $WhatIfPreference) {
         return
     }
 
-    Invoke-NovaBuild @workflowParams
-    Test-NovaBuild @workflowParams
-
-    & $publishInvocation.Action @publishParams
-
-    if ($shouldRun -and $localPublishActivation) {
-        $null = & $localPublishActivation.ImportAction -ProjectName $projectInfo.ProjectName -ManifestPath $localPublishActivation.ManifestPath
-        Write-Verbose "Module copy to local path complete and imported from $( $localPublishActivation.ManifestPath )"
-    }
+    Invoke-NovaPublishWorkflow -WorkflowContext $workflowContext -ShouldRun:$shouldRun
 }

--- a/src/public/SetNovaUpdateNotificationPreference.ps1
+++ b/src/public/SetNovaUpdateNotificationPreference.ps1
@@ -8,22 +8,11 @@ function Set-NovaUpdateNotificationPreference {
         [switch]$DisablePrereleaseNotifications
     )
 
-    $enablePrerelease = $EnablePrereleaseNotifications.IsPresent
-    $target = Get-NovaUpdateSettingsFilePath
-    $action = if ($enablePrerelease) {
-        'Enable prerelease update notifications'
-    }
-    elseif ($DisablePrereleaseNotifications.IsPresent) {
-        'Disable prerelease update notifications'
-    }
-    else {
-        throw 'Specify either -EnablePrereleaseNotifications or -DisablePrereleaseNotifications.'
-    }
+    $workflowContext = Get-NovaUpdateNotificationPreferenceChangeContext -EnablePrereleaseNotifications:$EnablePrereleaseNotifications -DisablePrereleaseNotifications:$DisablePrereleaseNotifications
 
-    if (-not $PSCmdlet.ShouldProcess($target, $action)) {
+    if (-not $PSCmdlet.ShouldProcess($workflowContext.Target, $workflowContext.Action)) {
         return
     }
 
-    Write-NovaUpdateNotificationPreference -PrereleaseNotificationsEnabled:$enablePrerelease
-    return Get-NovaUpdateNotificationPreference
+    return Invoke-NovaUpdateNotificationPreferenceChange -WorkflowContext $workflowContext
 }

--- a/src/public/TestNovaBuild.ps1
+++ b/src/public/TestNovaBuild.ps1
@@ -8,37 +8,16 @@ function Test-NovaBuild {
         [ValidateSet('Auto', 'Ansi')]
         [string]$OutputRenderMode
     )
-    Test-ProjectSchema Pester | Out-Null
-    $Script:data = Get-NovaProjectInfo
-    $pesterConfig = New-PesterConfiguration -Hashtable $data.Pester
+    $workflowContext = Get-NovaTestWorkflowContext -TestOption @{
+        TagFilter = $TagFilter
+        ExcludeTagFilter = $ExcludeTagFilter
+        OutputVerbosity = $OutputVerbosity
+        OutputRenderMode = $OutputRenderMode
+    } -BoundParameters $PSBoundParameters
 
-    $pesterConfig.Run.Path = Get-NovaPesterRunPath -ProjectInfo $data
-    $pesterConfig.Run.PassThru = $true
-    $pesterConfig.Run.Exit = $true
-    $pesterConfig.Run.Throw = $true
-    $pesterConfig.Filter.Tag = $TagFilter
-    $pesterConfig.Filter.ExcludeTag = $ExcludeTagFilter
-    Initialize-NovaPesterExecutionConfiguration -PesterConfig $pesterConfig -BoundParameters $PSBoundParameters -OutputVerbosity $OutputVerbosity -OutputRenderMode $OutputRenderMode
-
-    $testResultPath = Get-NovaPesterTestResultPath -ProjectRoot $data.ProjectRoot
-    $testResultDirectory = Split-Path -Parent $testResultPath
-
-    if (-not $PSCmdlet.ShouldProcess($testResultPath, 'Run Pester tests and write test results')) {
+    if (-not $PSCmdlet.ShouldProcess($workflowContext.Target, $workflowContext.Operation)) {
         return
     }
 
-    if (-not (Test-Path -LiteralPath $testResultDirectory)) {
-        $null = New-Item -ItemType Directory -Path $testResultDirectory -Force
-    }
-
-    $testResultArtifactWriter = Get-Command -Name Write-NovaPesterTestResultArtifact -CommandType Function -ErrorAction Stop
-    $testResultReportWriter = Get-Command -Name Write-NovaPesterTestResultReport -CommandType Function -ErrorAction Stop
-    $pesterConfig.TestResult.OutputPath = $testResultPath
-    $TestResult = Invoke-NovaPester -Configuration $pesterConfig
-    & $testResultArtifactWriter.ScriptBlock -TestResult $TestResult -OutputPath $testResultPath -ReportWriter $testResultReportWriter.ScriptBlock
-
-    if ($TestResult.Result -ne 'Passed') {
-        throw 'Tests failed'
-        return $LASTEXITCODE
-    }
+    Invoke-NovaTestWorkflow -WorkflowContext $workflowContext
 }

--- a/src/public/UpdateNovaModuleTools.ps1
+++ b/src/public/UpdateNovaModuleTools.ps1
@@ -3,14 +3,8 @@ function Update-NovaModuleTool {
     [Alias('Update-NovaModuleTools')]
     param()
 
-    $preference = Read-NovaUpdateNotificationPreference
-    $installedModule = Get-NovaInstalledModuleVersionInfo
-    $lookupResult = Invoke-NovaModuleUpdateLookup -AllowPrereleaseNotifications:$preference.PrereleaseNotificationsEnabled -TimeoutMilliseconds 10000
-    if ($null -eq $lookupResult) {
-        throw 'Unable to determine a NovaModuleTools update candidate. Try again when the PowerShell Gallery is reachable.'
-    }
-
-    $plan = Get-NovaModuleSelfUpdatePlan -InstalledModule $installedModule -LookupResult $lookupResult -PrereleaseNotificationsEnabled $preference.PrereleaseNotificationsEnabled
+    $workflowContext = Get-NovaModuleSelfUpdateWorkflowContext
+    $plan = $workflowContext.Plan
     if (-not $plan.UpdateAvailable) {
         return $plan
     }
@@ -20,19 +14,9 @@ function Update-NovaModuleTool {
         return $plan
     }
 
-    $action = if ($plan.IsPrereleaseTarget) {
-        "Update NovaModuleTools to prerelease version $( $plan.TargetVersion )"
-    }
-    else {
-        "Update NovaModuleTools to version $( $plan.TargetVersion )"
-    }
-
-    if (-not $PSCmdlet.ShouldProcess($plan.ModuleName, $action)) {
+    if (-not $PSCmdlet.ShouldProcess($plan.ModuleName, $workflowContext.Action)) {
         return $plan
     }
 
-    $null = Invoke-NovaModuleSelfUpdate -ModuleName $plan.ModuleName -AllowPrerelease:$plan.UsedAllowPrerelease
-    $plan.Updated = $true
-    Write-NovaModuleReleaseNotesLink
-    return $plan
+    return Invoke-NovaModuleSelfUpdateWorkflow -WorkflowContext $workflowContext
 }

--- a/src/public/UpdateNovaModuleVersion.ps1
+++ b/src/public/UpdateNovaModuleVersion.ps1
@@ -6,43 +6,16 @@ function Update-NovaModuleVersion {
     )
 
     $projectRoot = (Resolve-Path -LiteralPath $Path).Path
-    $before = Get-NovaProjectInfo -Path $projectRoot
-    $commitMessages = @(Get-GitCommitMessageForVersionBump -ProjectRoot $projectRoot)
-    $label = Get-NovaVersionLabelForBump -ProjectRoot $projectRoot -CommitMessages $commitMessages
-    $nextVersion = $null
-    $shouldReturnResult = $WhatIfPreference
+    $workflowContext = Get-NovaVersionUpdateWorkflowContext -ProjectRoot $projectRoot -PreviewRelease:$Preview
 
-    Push-Location -LiteralPath $projectRoot
-    try {
-        $versionUpdatePlan = Get-NovaVersionUpdatePlan -Label $label -PreviewRelease:$Preview
-        $target = [System.IO.Path]::GetFileName($before.ProjectJSON)
-        $action = "Update module version using $label release label"
-        $nextVersion = $versionUpdatePlan.NewVersion.ToString()
-
-        if ($env:NOVA_CLI_CONFIRM_BUMP -eq '1' -and -not $WhatIfPreference) {
-            $confirmedFromCli = Confirm-NovaCliBumpAction -Target $target -Action $action
-            if (-not $confirmedFromCli) {
-                return
-            }
-        }
-
-        if ( $PSCmdlet.ShouldProcess($target, $action)) {
-            Set-NovaModuleVersion -Label $label -PreviewRelease:$Preview -Confirm:$false
-            $shouldReturnResult = $true
+    if ((Test-NovaCliBumpConfirmationIsEnabled) -and -not $WhatIfPreference) {
+        $confirmedFromCli = Confirm-NovaCliBumpAction -Target $workflowContext.Target -Action $workflowContext.Action
+        if (-not $confirmedFromCli) {
+            return
         }
     }
-    finally {
-        Pop-Location
-    }
 
-    if (-not $shouldReturnResult) {
-        return
-    }
+    $shouldRun = $PSCmdlet.ShouldProcess($workflowContext.Target, $workflowContext.Action)
 
-    return [pscustomobject]@{
-        PreviousVersion = $before.Version
-        NewVersion = $nextVersion
-        Label = $label
-        CommitCount = $commitMessages.Count
-    }
+    return Invoke-NovaVersionUpdateWorkflow -WorkflowContext $workflowContext -ShouldRun:$shouldRun -WhatIfEnabled:$WhatIfPreference
 }

--- a/tests/CoverageGaps.BuildInternals.Tests.ps1
+++ b/tests/CoverageGaps.BuildInternals.Tests.ps1
@@ -33,9 +33,47 @@ BeforeAll {
 }
 
 Describe 'Coverage gaps for build and duplicate-analysis internals' {
+    It 'Get-NovaBuildWorkflowContext resolves project info once and returns the public build operation metadata' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaBuildProjectInfo {
+                [pscustomobject]@{
+                    ProjectName = 'NovaModuleTools'
+                    OutputModuleDir = '/tmp/dist/NovaModuleTools'
+                }
+            }
+
+            $result = Get-NovaBuildWorkflowContext
+
+            $result.ProjectInfo.ProjectName | Should -Be 'NovaModuleTools'
+            $result.Target | Should -Be '/tmp/dist/NovaModuleTools'
+            $result.Operation | Should -Be 'Build Nova module output'
+            Assert-MockCalled Get-NovaBuildProjectInfo -Times 1 -ParameterFilter {$null -eq $ProjectInfo}
+        }
+    }
+
+    It 'Invoke-NovaBuildDuplicateValidation skips duplicate analysis when the project disables that quality gate' {
+        InModuleScope $script:moduleName {
+            Mock Assert-BuiltModuleHasNoDuplicateFunctionName {throw 'should not validate duplicates'}
+
+            $result = Invoke-NovaBuildDuplicateValidation -ProjectInfo ([pscustomobject]@{FailOnDuplicateFunctionNames = $false})
+
+            $result | Should -BeNullOrEmpty
+            Assert-MockCalled Assert-BuiltModuleHasNoDuplicateFunctionName -Times 0
+        }
+    }
+
+    It 'Invoke-NovaBuildUpdateNotificationSafely swallows update lookup failures' {
+        InModuleScope $script:moduleName {
+            Mock Invoke-NovaBuildUpdateNotification {throw 'network issue'}
+
+            {Invoke-NovaBuildUpdateNotificationSafely} | Should -Not -Throw
+            Assert-MockCalled Invoke-NovaBuildUpdateNotification -Times 1
+        }
+    }
+
     It 'Build-Help skips when no markdown files exist' {
         InModuleScope $script:moduleName {
-            Mock Get-NovaProjectInfo {[pscustomobject]@{DocsDir = '/tmp/docs'}}
+            Mock Get-NovaBuildProjectInfo {[pscustomobject]@{DocsDir = '/tmp/docs'}}
             Mock Get-ChildItem {@()}
             Mock Get-Module {}
 
@@ -47,7 +85,7 @@ Describe 'Coverage gaps for build and duplicate-analysis internals' {
 
     It 'Build-Help throws when PlatyPS is unavailable and docs exist' {
         InModuleScope $script:moduleName {
-            Mock Get-NovaProjectInfo {[pscustomobject]@{DocsDir = '/tmp/docs'}}
+            Mock Get-NovaBuildProjectInfo {[pscustomobject]@{DocsDir = '/tmp/docs'}}
             Mock Get-ChildItem {@([pscustomobject]@{FullName = '/tmp/docs/Invoke-NovaBuild.md'})}
             Mock Get-Module {$null}
 
@@ -60,7 +98,7 @@ Describe 'Coverage gaps for build and duplicate-analysis internals' {
             $docPath = Join-Path $TestDrive 'Invoke-NovaBuild.md'
             Set-Content -LiteralPath $docPath -Value "---`nLocale: da-DK`n---"
 
-            Mock Get-NovaProjectInfo {
+            Mock Get-NovaBuildProjectInfo {
                 [pscustomobject]@{
                     DocsDir = '/tmp/docs'
                     OutputModuleDir = '/tmp/dist'
@@ -142,7 +180,7 @@ Describe 'Coverage gaps for build and duplicate-analysis internals' {
                 ProjectName = 'NovaModuleTools'
                 ManifestFilePSD1 = '/tmp/NovaModuleTools.psd1'
             }
-            Mock Get-NovaProjectInfo {$projectInfo}
+            Mock Get-NovaBuildProjectInfo {$projectInfo}
             Mock Get-ChildItem {@([pscustomobject]@{FullName = '/tmp/public/Get-Thing.ps1'})} -ParameterFilter {$Path -eq '/tmp/public'}
             Mock Get-ChildItem {@([pscustomobject]@{Name = 'Nova.Format.ps1xml'})} -ParameterFilter {$Filter -eq '*Format.ps1xml'}
             Mock Get-ChildItem {@([pscustomobject]@{Name = 'Nova.Types.ps1xml'})} -ParameterFilter {$Filter -eq '*Types.ps1xml'}
@@ -151,7 +189,7 @@ Describe 'Coverage gaps for build and duplicate-analysis internals' {
             Mock Assert-ManifestSchema {}
             Mock New-ModuleManifest {}
 
-            Build-Manifest
+            Build-Manifest -ProjectInfo $projectInfo
 
             Assert-MockCalled New-ModuleManifest -Times 1 -ParameterFilter {
                 $Path -eq '/tmp/NovaModuleTools.psd1' -and
@@ -168,7 +206,7 @@ Describe 'Coverage gaps for build and duplicate-analysis internals' {
 
     It 'Build-Manifest reports manifest creation failures' {
         InModuleScope $script:moduleName {
-            Mock Get-NovaProjectInfo {
+            Mock Get-NovaBuildProjectInfo {
                 [pscustomobject]@{
                     PublicDir = '/tmp/public'
                     ResourcesDir = '/tmp/resources'
@@ -188,7 +226,18 @@ Describe 'Coverage gaps for build and duplicate-analysis internals' {
             Mock Assert-ManifestSchema {}
             Mock New-ModuleManifest {throw 'manifest failed'}
 
-            {Build-Manifest} | Should -Throw 'Failed to create Manifest*'
+            {
+                Build-Manifest -ProjectInfo ([pscustomobject]@{
+                    PublicDir = '/tmp/public'
+                    ResourcesDir = '/tmp/resources'
+                    CopyResourcesToModuleRoot = $false
+                    Manifest = [ordered]@{Author = 'Tester'; CompanyName = 'Nova'}
+                    Version = '1.2.3-preview'
+                    Description = 'Example'
+                    ProjectName = 'NovaModuleTools'
+                    ManifestFilePSD1 = '/tmp/NovaModuleTools.psd1'
+                })
+            } | Should -Throw 'Failed to create Manifest*'
         }
     }
 

--- a/tests/CoverageGaps.Cli.Tests.ps1
+++ b/tests/CoverageGaps.Cli.Tests.ps1
@@ -33,6 +33,85 @@ BeforeAll {
 }
 
 Describe 'Coverage gaps for CLI and installed-version internals' {
+    It 'Get-NovaCliInvocationContext resolves forwarded parameter sets, normalized arguments, and help detection' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaCliForwardingParameterSet {
+                if ($IncludeShouldProcess) {
+                    return @{WhatIf = $true}
+                }
+
+                return @{Verbose = $true}
+            }
+            Mock ConvertTo-NovaCliArgumentArray {@('--help')}
+            Mock Test-NovaCliHelpRequest {$true}
+
+            $result = Get-NovaCliInvocationContext -Command 'publish' -BoundParameters @{Verbose = $true; Arguments = @('--help')} -Arguments @('--help') -WhatIfEnabled
+
+            $result.Command | Should -Be 'publish'
+            $result.Arguments | Should -Be @('--help')
+            $result.CommonParameters.Verbose | Should -BeTrue
+            $result.MutatingCommonParameters.WhatIf | Should -BeTrue
+            $result.IsHelpRequest | Should -BeTrue
+            $result.ModuleName | Should -Be 'NovaModuleTools'
+            $result.WhatIfEnabled | Should -BeTrue
+            Assert-MockCalled Get-NovaCliForwardingParameterSet -Times 1 -ParameterFilter {
+                $BoundParameters.ContainsKey('Verbose') -and -not $IncludeShouldProcess
+            }
+            Assert-MockCalled Get-NovaCliForwardingParameterSet -Times 1 -ParameterFilter {
+                $BoundParameters.ContainsKey('Verbose') -and $IncludeShouldProcess
+            }
+        }
+    }
+
+    It 'Invoke-NovaCliCommandRoute returns routed command help when the invocation requests help' {
+        InModuleScope $script:moduleName {
+            $invocationContext = [pscustomobject]@{
+                Command = 'package'
+                Arguments = @('--help')
+                CommonParameters = @{}
+                MutatingCommonParameters = @{}
+                IsHelpRequest = $true
+                ModuleName = 'NovaModuleTools'
+                WhatIfEnabled = $false
+            }
+            Mock Get-NovaCliCommandHelp {'package-help'}
+
+            $result = Invoke-NovaCliCommandRoute -InvocationContext $invocationContext
+
+            $result | Should -Be 'package-help'
+            Assert-MockCalled Get-NovaCliCommandHelp -Times 1 -ParameterFilter {$Command -eq 'package'}
+        }
+    }
+
+    It 'Invoke-NovaCli delegates invocation preparation and routing to private helpers' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaCliInvocationContext {
+                [pscustomobject]@{
+                    Command = 'build'
+                    Arguments = @()
+                    CommonParameters = @{}
+                    MutatingCommonParameters = @{WhatIf = $true}
+                    IsHelpRequest = $false
+                    ModuleName = 'NovaModuleTools'
+                    WhatIfEnabled = $true
+                }
+            }
+            Mock Invoke-NovaCliCommandRoute {'delegated-build'}
+
+            $result = Invoke-NovaCli build -WhatIf
+
+            $result | Should -Be 'delegated-build'
+            Assert-MockCalled Get-NovaCliInvocationContext -Times 1 -ParameterFilter {
+                $Command -eq 'build' -and
+                        $BoundParameters.ContainsKey('WhatIf') -and
+                        $WhatIfEnabled
+            }
+            Assert-MockCalled Invoke-NovaCliCommandRoute -Times 1 -ParameterFilter {
+                $InvocationContext.Command -eq 'build' -and $InvocationContext.WhatIfEnabled
+            }
+        }
+    }
+
     It 'Invoke-NovaCli dispatches the remaining public command branches' {
         InModuleScope $script:moduleName {
             Mock Get-NovaProjectInfo {'info-value'} -ParameterFilter {-not $Version}

--- a/tests/CoverageGaps.ReleaseInternals.Tests.ps1
+++ b/tests/CoverageGaps.ReleaseInternals.Tests.ps1
@@ -118,8 +118,12 @@ Describe 'Coverage gaps for release and git internals' {
         InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
             param($TestCase)
 
-            Mock Get-NovaProjectInfo {[pscustomobject]@{ProjectJSON = '/tmp/project.json'}}
-            Mock Get-Content {([ordered]@{Version = $TestCase.CurrentVersion} | ConvertTo-Json -Compress)} -ParameterFilter {$LiteralPath -eq '/tmp/project.json' -and $Raw}
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    ProjectJSON = '/tmp/project.json'
+                    Version = $TestCase.CurrentVersion
+                }
+            }
 
             (Get-NovaVersionUpdatePlan -Label $TestCase.Label).NewVersion.ToString() | Should -Be $TestCase.ExpectedVersion
         }
@@ -133,8 +137,12 @@ Describe 'Coverage gaps for release and git internals' {
         InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
             param($TestCase)
 
-            Mock Get-NovaProjectInfo {[pscustomobject]@{ProjectJSON = '/tmp/project.json'}}
-            Mock Get-Content {([ordered]@{Version = $TestCase.CurrentVersion} | ConvertTo-Json -Compress)} -ParameterFilter {$LiteralPath -eq '/tmp/project.json' -and $Raw}
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    ProjectJSON = '/tmp/project.json'
+                    Version = $TestCase.CurrentVersion
+                }
+            }
 
             (Get-NovaVersionUpdatePlan -Label $TestCase.Label -PreviewRelease).NewVersion.ToString() | Should -Be $TestCase.ExpectedVersion
         }
@@ -152,8 +160,12 @@ Describe 'Coverage gaps for release and git internals' {
         InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
             param($TestCase)
 
-            Mock Get-NovaProjectInfo {[pscustomobject]@{ProjectJSON = '/tmp/project.json'}}
-            Mock Get-Content {([ordered]@{Version = $TestCase.CurrentVersion} | ConvertTo-Json -Compress)} -ParameterFilter {$LiteralPath -eq '/tmp/project.json' -and $Raw}
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    ProjectJSON = '/tmp/project.json'
+                    Version = $TestCase.CurrentVersion
+                }
+            }
 
             (Get-NovaVersionUpdatePlan -Label Minor -PreviewRelease).NewVersion.ToString() | Should -Be $TestCase.ExpectedVersion
         }

--- a/tests/CoverageGaps.Tests.ps1
+++ b/tests/CoverageGaps.Tests.ps1
@@ -395,6 +395,95 @@ Describe 'Coverage gaps for scaffold internals' {
         }
     }
 
+    It 'Get-NovaModuleInitializationWorkflowContext resolves scaffold inputs and ShouldProcess metadata' {
+        InModuleScope $script:moduleName {
+            Mock Resolve-NovaModuleScaffoldBasePath {'/tmp/base'}
+            Mock Get-NovaModuleQuestionSet {[ordered]@{ProjectName = @{Prompt = 'Name?'}}}
+            Mock Read-NovaModuleAnswerSet {
+                [ordered]@{
+                    ProjectName = 'NovaContext'
+                    EnableGit = 'No'
+                }
+            }
+            Mock Get-NovaModuleScaffoldLayout {
+                [pscustomobject]@{
+                    Project = '/tmp/base/NovaContext'
+                    ProjectJsonFile = '/tmp/base/NovaContext/project.json'
+                }
+            }
+
+            $result = Get-NovaModuleInitializationWorkflowContext -Path '/tmp/base' -Example
+
+            $result.BasePath | Should -Be '/tmp/base'
+            $result.AnswerSet.ProjectName | Should -Be 'NovaContext'
+            $result.Layout.Project | Should -Be '/tmp/base/NovaContext'
+            $result.Example | Should -BeTrue
+            $result.Target | Should -Be '/tmp/base/NovaContext'
+            $result.Action | Should -Be 'Create Nova module scaffold'
+            Assert-MockCalled Get-NovaModuleQuestionSet -Times 1 -ParameterFilter {$Example}
+            Assert-MockCalled Get-NovaModuleScaffoldLayout -Times 1 -ParameterFilter {
+                $Path -eq '/tmp/base' -and $ProjectName -eq 'NovaContext'
+            }
+        }
+    }
+
+    It 'Invoke-NovaModuleInitializationWorkflow runs scaffold creation, project.json writing, and completion messaging' {
+        InModuleScope $script:moduleName {
+            $workflowContext = [pscustomobject]@{
+                AnswerSet = [ordered]@{ProjectName = 'NovaWorkflow'}
+                Layout = [pscustomobject]@{
+                    Project = '/tmp/base/NovaWorkflow'
+                    ProjectJsonFile = '/tmp/base/NovaWorkflow/project.json'
+                }
+                Example = $true
+            }
+            Mock Initialize-NovaModuleScaffold {}
+            Mock Write-NovaModuleProjectJson {}
+            Mock Write-Message {}
+
+            Invoke-NovaModuleInitializationWorkflow -WorkflowContext $workflowContext
+
+            Assert-MockCalled Initialize-NovaModuleScaffold -Times 1 -ParameterFilter {
+                $Answer.ProjectName -eq 'NovaWorkflow' -and
+                        $Paths.Project -eq '/tmp/base/NovaWorkflow' -and
+                        $Example
+            }
+            Assert-MockCalled Write-NovaModuleProjectJson -Times 1 -ParameterFilter {
+                $Answer.ProjectName -eq 'NovaWorkflow' -and
+                        $ProjectJsonFile -eq '/tmp/base/NovaWorkflow/project.json' -and
+                        $Example
+            }
+            Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
+                $Text -eq 'Module NovaWorkflow scaffolding complete' -and $color -eq 'Green'
+            }
+        }
+    }
+
+    It 'Initialize-NovaModule delegates workflow context resolution and execution to private helpers' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaModuleInitializationWorkflowContext {
+                [pscustomobject]@{
+                    Target = '/tmp/base/NovaDelegation'
+                    Action = 'Create Nova module scaffold'
+                    AnswerSet = [ordered]@{ProjectName = 'NovaDelegation'}
+                    Layout = [pscustomobject]@{Project = '/tmp/base/NovaDelegation'}
+                    Example = $false
+                }
+            }
+            Mock Invoke-NovaModuleInitializationWorkflow {}
+
+            Initialize-NovaModule -Path '/tmp/base' -Confirm:$false
+
+            Assert-MockCalled Get-NovaModuleInitializationWorkflowContext -Times 1 -ParameterFilter {
+                $Path -eq '/tmp/base' -and -not $Example
+            }
+            Assert-MockCalled Invoke-NovaModuleInitializationWorkflow -Times 1 -ParameterFilter {
+                $WorkflowContext.Target -eq '/tmp/base/NovaDelegation' -and
+                        $WorkflowContext.Action -eq 'Create Nova module scaffold'
+            }
+        }
+    }
+
     It 'Initialize-NovaModule -Example creates the packaged example scaffold without asking about Pester' {
         InModuleScope $script:moduleName {
             $answer = @{

--- a/tests/NovaCommandModel.BumpAndCli.Tests.ps1
+++ b/tests/NovaCommandModel.BumpAndCli.Tests.ps1
@@ -60,6 +60,91 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
         }
     }
 
+    It 'Get-NovaVersionUpdateWorkflowContext prepares version bump state from project info and commit history' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    ProjectName = 'NovaModuleTools'
+                    Version = '1.0.0'
+                    ProjectJSON = '/tmp/project.json'
+                }
+            }
+            Mock Get-GitCommitMessageForVersionBump {@('feat: add change', 'fix: patch bug')}
+            Mock Get-NovaVersionLabelForBump {'Minor'}
+            Mock Get-NovaVersionUpdatePlan {
+                [pscustomobject]@{
+                    NewVersion = [semver]'1.1.0'
+                }
+            }
+
+            $result = Get-NovaVersionUpdateWorkflowContext -ProjectRoot '/tmp/project'
+
+            $result.ProjectRoot | Should -Be '/tmp/project'
+            $result.PreviousVersion | Should -Be '1.0.0'
+            $result.NewVersion | Should -Be '1.1.0'
+            $result.Label | Should -Be 'Minor'
+            $result.CommitCount | Should -Be 2
+            $result.Target | Should -Be 'project.json'
+            $result.Action | Should -Be 'Update module version using Minor release label'
+            Assert-MockCalled Get-NovaVersionUpdatePlan -Times 1 -ParameterFilter {
+                $ProjectInfo.ProjectName -eq 'NovaModuleTools' -and
+                        $Label -eq 'Minor' -and
+                        -not $PreviewRelease
+            }
+        }
+    }
+
+    It 'Invoke-NovaVersionUpdateWorkflow writes only when requested and still returns WhatIf results' {
+        InModuleScope $script:moduleName {
+            $workflowContext = [pscustomobject]@{
+                ProjectInfo = [pscustomobject]@{ProjectName = 'NovaModuleTools'}
+                Label = 'Minor'
+                PreviewRelease = $true
+                PreviousVersion = '1.0.0'
+                NewVersion = '1.1.0-preview'
+                CommitCount = 2
+            }
+            Mock Set-NovaModuleVersion {}
+
+            $whatIfResult = Invoke-NovaVersionUpdateWorkflow -WorkflowContext $workflowContext -WhatIfEnabled
+            $runResult = Invoke-NovaVersionUpdateWorkflow -WorkflowContext $workflowContext -ShouldRun
+
+            $whatIfResult.NewVersion | Should -Be '1.1.0-preview'
+            $runResult.NewVersion | Should -Be '1.1.0-preview'
+            Assert-MockCalled Set-NovaModuleVersion -Times 1 -ParameterFilter {
+                $ProjectInfo.ProjectName -eq 'NovaModuleTools' -and
+                        $Label -eq 'Minor' -and
+                        $PreviewRelease -and
+                        -not $Confirm
+            }
+        }
+    }
+
+    It 'Update-NovaModuleVersion delegates orchestration to private bump workflow helpers' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaVersionUpdateWorkflowContext {
+                [pscustomobject]@{
+                    Target = 'project.json'
+                    Action = 'Update module version using Minor release label'
+                }
+            }
+            Mock Test-NovaCliBumpConfirmationIsEnabled {$false}
+            Mock Invoke-NovaVersionUpdateWorkflow {
+                [pscustomobject]@{NewVersion = '1.1.0'}
+            }
+
+            $result = Update-NovaModuleVersion -Path (Get-Location).Path -Confirm:$false
+
+            $result.NewVersion | Should -Be '1.1.0'
+            Assert-MockCalled Get-NovaVersionUpdateWorkflowContext -Times 1
+            Assert-MockCalled Invoke-NovaVersionUpdateWorkflow -Times 1 -ParameterFilter {
+                $WorkflowContext.Target -eq 'project.json' -and
+                        $ShouldRun -and
+                        -not $WhatIfEnabled
+            }
+        }
+    }
+
     It 'Update-NovaModuleVersion -WhatIf returns the expected next version without persisting it when <Name>' -ForEach @(
         @{Name = 'the default bump flow is used'; CurrentVersion = '1.0.0'; CommitMessages = @('feat: add change'); Label = 'Minor'; NewVersion = '1.1.0'; Preview = $false}
         @{Name = 'preview mode starts from a stable version'; CurrentVersion = '1.5.3'; CommitMessages = @('feat: add change'); Label = 'Minor'; NewVersion = '1.6.0-preview'; Preview = $true}
@@ -278,7 +363,3 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
         }
     }
 }
-
-
-
-

--- a/tests/NovaCommandModel.PackageUpload.TestSupport.ps1
+++ b/tests/NovaCommandModel.PackageUpload.TestSupport.ps1
@@ -4,6 +4,10 @@ $global:novaCommandModelPackageUploadTestSupportFunctionNameList = @(
     'New-TestNovaPackageUploadProjectInfo'
     'New-TestNovaPackageArtifactFile'
     'New-TestNovaPackageArtifactSet'
+    'Get-TestNovaPackageUploadTargetResolutionCases'
+    'Get-TestNovaPackageUploadHeaderResolutionCases'
+    'Get-TestNovaPackageUploadArtifactResolutionCases'
+    'Get-TestNovaPackageUploadFailureCases'
 )
 
 function Get-TestNovaPackageUploadOptionValue {
@@ -109,6 +113,186 @@ function New-TestNovaPackageArtifactSet {
             New-TestNovaPackageArtifactFile -Directory $Directory -Name "PackageProject.latest$extension"
         }
     }
+    )
+}
+
+function Get-TestNovaPackageUploadTargetResolutionCases {
+    [CmdletBinding()]
+    param()
+
+    return @(
+        @{
+            Name = 'repository settings should override package headers and auth'
+            ProjectRootName = 'target-merge-precedence'
+            UseExplicitOverride = $false
+            ExpectedUrl = 'https://packages.example/raw/repository/'
+            ExpectedUploadPath = 'repo-path'
+            ExpectedTraceId = 'repo-trace'
+            ExpectPackageToken = $true
+        }
+        @{
+            Name = 'explicit Url and UploadPath should override configured locations'
+            ProjectRootName = 'target-explicit-overrides'
+            UseExplicitOverride = $true
+            ExpectedUrl = 'https://override.example/upload/'
+            ExpectedUploadPath = 'manual/path'
+            ExpectedTraceId = $null
+            ExpectPackageToken = $false
+        }
+    )
+}
+
+function Get-TestNovaPackageUploadHeaderResolutionCases {
+    [CmdletBinding()]
+    param()
+
+    return @(
+        Get-TestNovaPackageUploadHeaderResolutionNoTokenCase
+        Get-TestNovaPackageUploadHeaderResolutionCustomHeaderCase
+        Get-TestNovaPackageUploadHeaderResolutionAuthorizationCase
+        Get-TestNovaPackageUploadHeaderResolutionOverrideCase
+    )
+}
+
+function Get-TestNovaPackageUploadHeaderResolutionNoTokenCase {
+    [CmdletBinding()]
+    param()
+
+    return New-TestNovaPackageUploadNamedHeaderResolutionCase -Name 'no token is available' -Token $null -ExpectedHeaders ([ordered]@{
+        'X-Base' = 'base'
+        'X-Override' = 'override'
+    })
+}
+
+function Get-TestNovaPackageUploadHeaderResolutionCustomHeaderCase {
+    [CmdletBinding()]
+    param()
+
+    return New-TestNovaPackageUploadNamedHeaderResolutionCase -Name 'a custom auth header should be added with the raw token' -Token 'secret-token' -ExpectedHeaders ([ordered]@{
+        'X-Base' = 'base'
+        'X-Override' = 'override'
+        'X-Api-Key' = 'secret-token'
+    })
+}
+
+function New-TestNovaPackageUploadNamedHeaderResolutionCase {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [AllowNull()][string]$Token,
+        [Parameter(Mandatory)][System.Collections.IDictionary]$ExpectedHeaders
+    )
+
+    return @{
+        Name = $Name
+        UploadTarget = [pscustomobject]@{
+            Headers = [ordered]@{'X-Base' = 'base'}
+            Auth = [ordered]@{
+                HeaderName = 'X-Api-Key'
+            }
+        }
+        UploadOption = [pscustomobject]@{
+            Headers = [ordered]@{'X-Override' = 'override'}
+            Token = $Token
+            TokenEnvironmentVariable = $null
+            AuthenticationScheme = $null
+        }
+        ExpectedHeaders = [ordered]@{} + $ExpectedHeaders
+    }
+}
+
+function Get-TestNovaPackageUploadHeaderResolutionAuthorizationCase {
+    [CmdletBinding()]
+    param()
+
+    return @{
+        Name = 'Authorization should use the explicit authentication scheme'
+        UploadTarget = [pscustomobject]@{
+            Headers = [ordered]@{'X-Base' = 'base'}
+            Auth = [ordered]@{}
+        }
+        UploadOption = [pscustomobject]@{
+            Headers = [ordered]@{}
+            Token = 'secret-token'
+            TokenEnvironmentVariable = $null
+            AuthenticationScheme = 'Basic'
+        }
+        ExpectedHeaders = [ordered]@{
+            'X-Base' = 'base'
+            'Authorization' = 'Basic secret-token'
+        }
+    }
+}
+
+function Get-TestNovaPackageUploadHeaderResolutionOverrideCase {
+    [CmdletBinding()]
+    param()
+
+    return @{
+        Name = 'the auth header should override an existing merged header with the same name'
+        UploadTarget = [pscustomobject]@{
+            Headers = [ordered]@{'Authorization' = 'stale-value'}
+            Auth = [ordered]@{}
+        }
+        UploadOption = [pscustomobject]@{
+            Headers = [ordered]@{'Authorization' = 'also-stale'}
+            Token = 'fresh-token'
+            TokenEnvironmentVariable = $null
+            AuthenticationScheme = 'Bearer'
+        }
+        ExpectedHeaders = [ordered]@{
+            'Authorization' = 'Bearer fresh-token'
+        }
+    }
+}
+
+function Get-TestNovaPackageUploadArtifactResolutionCases {
+    [CmdletBinding()]
+    param()
+
+    return @(
+        @{
+            Name = 'multiple artifacts exist for the configured package types'
+            ProjectRootName = 'multi-artifact-upload'
+            Options = @{PackageTypes = @('Zip', 'NuGet')}
+            ExpectedPackagePathFilter = 'PackageProject.*'
+            ExpectedTypeList = @('NuGet', 'NuGet', 'Zip', 'Zip')
+        }
+        @{
+            Name = 'FileNamePattern targets zip artifacts'
+            ProjectRootName = 'explicit-zip-pattern-upload'
+            Options = @{PackageTypes = @('Zip', 'NuGet'); FileNamePattern = 'PackageProject.*.zip'}
+            ExpectedPackagePathFilter = '*.zip'
+            ExpectedTypeList = @('Zip', 'Zip')
+        }
+    )
+}
+
+function Get-TestNovaPackageUploadFailureCases {
+    [CmdletBinding()]
+    param()
+
+    return @(
+        @{
+            Name = 'the upload target URL is missing'
+            ProjectRootName = 'missing-upload-url'
+            ExpectedMessage = 'Upload target URL is missing*'
+            Invoke = {
+                param($PackagePath)
+
+                Deploy-NovaPackage -PackagePath $PackagePath
+            }
+        }
+        @{
+            Name = 'package selection is ambiguous'
+            ProjectRootName = 'ambiguous-package-selection'
+            ExpectedMessage = 'Package selection is ambiguous*'
+            Invoke = {
+                param($PackagePath)
+
+                Deploy-NovaPackage -PackagePath $PackagePath -PackageType NuGet -Url 'https://packages.example/raw/'
+            }
+        }
     )
 }
 

--- a/tests/NovaCommandModel.PackageUpload.Tests.ps1
+++ b/tests/NovaCommandModel.PackageUpload.Tests.ps1
@@ -186,26 +186,7 @@ Describe 'Nova command model - package upload behavior' {
         }
     }
 
-    It 'Resolve-NovaPackageUploadTarget resolves target precedence correctly when <Name>' -ForEach @(
-        @{
-            Name = 'repository settings should override package headers and auth'
-            ProjectRootName = 'target-merge-precedence'
-            UseExplicitOverride = $false
-            ExpectedUrl = 'https://packages.example/raw/repository/'
-            ExpectedUploadPath = 'repo-path'
-            ExpectedTraceId = 'repo-trace'
-            ExpectPackageToken = $true
-        }
-        @{
-            Name = 'explicit Url and UploadPath should override configured locations'
-            ProjectRootName = 'target-explicit-overrides'
-            UseExplicitOverride = $true
-            ExpectedUrl = 'https://override.example/upload/'
-            ExpectedUploadPath = 'manual/path'
-            ExpectedTraceId = $null
-            ExpectPackageToken = $false
-        }
-    ) {
+    It 'Resolve-NovaPackageUploadTarget resolves target precedence correctly when <Name>' -ForEach (Get-TestNovaPackageUploadTargetResolutionCases) {
         $testCase = $_
         $layout = Initialize-TestNovaPackageUploadLayout -ProjectRoot (Join-Path $TestDrive $testCase.ProjectRootName)
         $repositoryList = @(
@@ -266,6 +247,22 @@ Describe 'Nova command model - package upload behavior' {
 
             if ($TestCase.ExpectPackageToken) {
                 $result.Auth.Token | Should -Be 'package-token'
+            }
+        }
+    }
+
+    It 'Resolve-NovaPackageUploadHeaders handles auth resolution scenarios correctly' {
+        foreach ($testCase in @(Get-TestNovaPackageUploadHeaderResolutionCases)) {
+            InModuleScope $script:moduleName -Parameters @{TestCase = $testCase} {
+                param($TestCase)
+
+                $result = Resolve-NovaPackageUploadHeaders -UploadTarget $TestCase.UploadTarget -UploadOption $TestCase.UploadOption
+
+                foreach ($headerName in $TestCase.ExpectedHeaders.Keys) {
+                    $result[$headerName] | Should -Be $TestCase.ExpectedHeaders[$headerName] -Because $TestCase.Name
+                }
+
+                $result.Keys.Count | Should -Be $TestCase.ExpectedHeaders.Keys.Count -Because $TestCase.Name
             }
         }
     }
@@ -381,22 +378,7 @@ Describe 'Nova command model - package upload behavior' {
         }
     }
 
-    It 'Deploy-NovaPackage resolves matching artifacts when <Name>' -ForEach @(
-        @{
-            Name = 'multiple artifacts exist for the configured package types'
-            ProjectRootName = 'multi-artifact-upload'
-            Options = @{PackageTypes = @('Zip', 'NuGet')}
-            ExpectedPackagePathFilter = 'PackageProject.*'
-            ExpectedTypeList = @('NuGet', 'NuGet', 'Zip', 'Zip')
-        }
-        @{
-            Name = 'FileNamePattern targets zip artifacts'
-            ProjectRootName = 'explicit-zip-pattern-upload'
-            Options = @{PackageTypes = @('Zip', 'NuGet'); FileNamePattern = 'PackageProject.*.zip'}
-            ExpectedPackagePathFilter = '*.zip'
-            ExpectedTypeList = @('Zip', 'Zip')
-        }
-    ) {
+    It 'Deploy-NovaPackage resolves matching artifacts when <Name>' -ForEach (Get-TestNovaPackageUploadArtifactResolutionCases) {
         $testCase = $_
         $layout = Initialize-TestNovaPackageUploadLayout -ProjectRoot (Join-Path $TestDrive $testCase.ProjectRootName)
         $artifactPathList = @(New-TestNovaPackageArtifactSet -Directory $layout.PackageOutputDir -PackageType @('NuGet', 'Zip') -IncludeLatest)
@@ -453,28 +435,7 @@ Describe 'Nova command model - package upload behavior' {
         }
     }
 
-    It 'Deploy-NovaPackage fails with a clear message when <Name>' -ForEach @(
-        @{
-            Name = 'the upload target URL is missing'
-            ProjectRootName = 'missing-upload-url'
-            ExpectedMessage = 'Upload target URL is missing*'
-            Invoke = {
-                param($PackagePath)
-
-                Deploy-NovaPackage -PackagePath $PackagePath
-            }
-        }
-        @{
-            Name = 'package selection is ambiguous'
-            ProjectRootName = 'ambiguous-package-selection'
-            ExpectedMessage = 'Package selection is ambiguous*'
-            Invoke = {
-                param($PackagePath)
-
-                Deploy-NovaPackage -PackagePath $PackagePath -PackageType NuGet -Url 'https://packages.example/raw/'
-            }
-        }
-    ) {
+    It 'Deploy-NovaPackage fails with a clear message when <Name>' -ForEach (Get-TestNovaPackageUploadFailureCases) {
         $layout = Initialize-TestNovaPackageUploadLayout -ProjectRoot (Join-Path $TestDrive $_.ProjectRootName)
         $packagePath = New-TestNovaPackageArtifactFile -Directory $layout.PackageOutputDir -Name 'PackageProject.2.3.4.zip'
 

--- a/tests/NovaCommandModel.PackageUpload.Tests.ps1
+++ b/tests/NovaCommandModel.PackageUpload.Tests.ps1
@@ -55,6 +55,77 @@ BeforeAll {
 }
 
 Describe 'Nova command model - package upload behavior' {
+    It 'Get-NovaPackageUploadWorkflowContext resolves project info, normalized upload options, and upload artifacts' {
+        $layout = Initialize-TestNovaPackageUploadLayout -ProjectRoot (Join-Path $TestDrive 'workflow-context-upload')
+        $packagePath = New-TestNovaPackageArtifactFile -Directory $layout.PackageOutputDir -Name 'PackageProject.2.3.4.zip'
+
+        InModuleScope $script:moduleName -Parameters @{
+            ProjectInfo = (New-TestNovaPackageUploadProjectInfo -Layout $layout)
+            PackagePath = $packagePath
+        } {
+            param($ProjectInfo, $PackagePath)
+
+            $uploadOption = [pscustomobject]@{
+                PackagePath = @($PackagePath)
+                PackageType = @('Zip')
+                Url = 'https://packages.example/raw/'
+                Repository = ''
+                UploadPath = 'modules'
+                Headers = [ordered]@{}
+                Token = $null
+                TokenEnvironmentVariable = $null
+                AuthenticationScheme = $null
+            }
+            $uploadArtifactList = @(
+                [pscustomobject]@{
+                    Type = 'Zip'
+                    PackagePath = $PackagePath
+                    PackageFileName = 'PackageProject.2.3.4.zip'
+                    Repository = ''
+                    Headers = [ordered]@{}
+                    UploadUrl = 'https://packages.example/raw/modules/PackageProject.2.3.4.zip'
+                }
+            )
+
+            Mock Resolve-NovaPackageUploadInvocation {$uploadArtifactList}
+
+            $result = Get-NovaPackageUploadWorkflowContext -BoundParameters @{PackagePath = @($PackagePath); Url = 'https://packages.example/raw/'} -ProjectInfo $ProjectInfo -UploadOption $uploadOption
+
+            $result.ProjectInfo.ProjectRoot | Should -Be $ProjectInfo.ProjectRoot
+            $result.UploadOption.Url | Should -Be 'https://packages.example/raw/'
+            $result.UploadArtifactList.Count | Should -Be 1
+            $result.UploadArtifactList[0].UploadUrl | Should -Be 'https://packages.example/raw/modules/PackageProject.2.3.4.zip'
+            Assert-MockCalled Resolve-NovaPackageUploadInvocation -Times 1 -ParameterFilter {$UploadOption.Url -eq 'https://packages.example/raw/'}
+        }
+    }
+
+    It 'Invoke-NovaPackageUploadWorkflow uploads each approved artifact in order' {
+        InModuleScope $script:moduleName {
+            $script:steps = @()
+            $workflowContext = [pscustomobject]@{
+                UploadArtifactList = @(
+                    [pscustomobject]@{PackageFileName = 'PackageProject.2.3.4.nupkg'}
+                    [pscustomobject]@{PackageFileName = 'PackageProject.2.3.4.zip'}
+                )
+            }
+            $approvedUploadArtifactList = @(
+                [pscustomobject]@{PackageFileName = 'PackageProject.2.3.4.nupkg'}
+                [pscustomobject]@{PackageFileName = 'PackageProject.2.3.4.zip'}
+            )
+
+            Mock Invoke-NovaPackageArtifactUpload {
+                $script:steps += $UploadArtifact.PackageFileName
+                [pscustomobject]@{PackageFileName = $UploadArtifact.PackageFileName; StatusCode = 200}
+            }
+
+            $result = @(Invoke-NovaPackageUploadWorkflow -WorkflowContext $workflowContext -UploadArtifactList $approvedUploadArtifactList)
+
+            $script:steps | Should -Be @('PackageProject.2.3.4.nupkg', 'PackageProject.2.3.4.zip')
+            $result.PackageFileName | Should -Be @('PackageProject.2.3.4.nupkg', 'PackageProject.2.3.4.zip')
+            Assert-MockCalled Invoke-NovaPackageArtifactUpload -Times 2
+        }
+    }
+
     It 'Deploy-NovaPackage uploads the specified package file to the specified raw URL' {
         $layout = Initialize-TestNovaPackageUploadLayout -ProjectRoot (Join-Path $TestDrive 'explicit-upload')
         $packagePath = New-TestNovaPackageArtifactFile -Directory $layout.PackageOutputDir -Name 'PackageProject.2.3.4.zip'
@@ -77,6 +148,42 @@ Describe 'Nova command model - package upload behavior' {
                 $Uri -eq 'https://packages.example/raw/PackageProject.2.3.4.zip' -and
                         $Method -eq 'Put' -and
                         $InFile -eq $PackagePath
+            }
+        }
+    }
+
+    It 'Deploy-NovaPackage delegates orchestration to the private upload workflow helpers' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaPackageUploadWorkflowContext {
+                [pscustomobject]@{
+                    UploadArtifactList = @(
+                        [pscustomobject]@{
+                            Type = 'Zip'
+                            PackagePath = '/tmp/project/artifacts/packages/PackageProject.2.3.4.zip'
+                            PackageFileName = 'PackageProject.2.3.4.zip'
+                            UploadUrl = 'https://packages.example/raw/PackageProject.2.3.4.zip'
+                        }
+                    )
+                }
+            }
+            Mock Invoke-NovaPackageUploadWorkflow {
+                @(
+                    [pscustomobject]@{
+                        PackageFileName = 'PackageProject.2.3.4.zip'
+                        StatusCode = 200
+                    }
+                )
+            }
+
+            $result = @(Deploy-NovaPackage -Url 'https://packages.example/raw/' -Confirm:$false)
+
+            $result.PackageFileName | Should -Be @('PackageProject.2.3.4.zip')
+            $result.StatusCode | Should -Be @(200)
+            Assert-MockCalled Get-NovaPackageUploadWorkflowContext -Times 1 -ParameterFilter {$BoundParameters.Url -eq 'https://packages.example/raw/'}
+            Assert-MockCalled Invoke-NovaPackageUploadWorkflow -Times 1 -ParameterFilter {
+                $WorkflowContext.UploadArtifactList.Count -eq 1 -and
+                        $UploadArtifactList.Count -eq 1 -and
+                        $UploadArtifactList[0].UploadUrl -eq 'https://packages.example/raw/PackageProject.2.3.4.zip'
             }
         }
     }

--- a/tests/NovaCommandModel.PackageUpload.Tests.ps1
+++ b/tests/NovaCommandModel.PackageUpload.Tests.ps1
@@ -126,6 +126,66 @@ Describe 'Nova command model - package upload behavior' {
         }
     }
 
+    It 'Resolve-NovaPackageUploadInvocation orchestrates file, target, header, and artifact resolution' {
+        InModuleScope $script:moduleName {
+            $projectInfo = [pscustomobject]@{
+                ProjectName = 'PackageProject'
+            }
+            $uploadOption = [pscustomobject]@{
+                PackagePath = @('/tmp/project/artifacts/packages/PackageProject.2.3.4.zip')
+                PackageType = @('Zip')
+                Url = 'https://packages.example/raw/'
+                Repository = 'LocalRaw'
+                UploadPath = 'modules'
+                Headers = [ordered]@{}
+                Token = $null
+                TokenEnvironmentVariable = $null
+                AuthenticationScheme = $null
+            }
+            $uploadFileList = @(
+                [pscustomobject]@{
+                    Type = 'Zip'
+                    PackagePath = '/tmp/project/artifacts/packages/PackageProject.2.3.4.zip'
+                    PackageFileName = 'PackageProject.2.3.4.zip'
+                }
+            )
+            $uploadTarget = [pscustomobject]@{
+                Repository = 'LocalRaw'
+                Url = 'https://packages.example/raw/'
+                UploadPath = 'modules'
+            }
+            $uploadHeaders = [ordered]@{
+                'X-Trace-Id' = 'trace-123'
+            }
+
+            Mock Get-NovaPackageUploadFileList {$uploadFileList}
+            Mock Resolve-NovaPackageUploadTarget {$uploadTarget}
+            Mock Resolve-NovaPackageUploadHeaders {$uploadHeaders}
+            Mock Get-NovaPackageUploadArtifact {
+                [pscustomobject]@{
+                    Type = $PackageFileInfo.Type
+                    PackagePath = $PackageFileInfo.PackagePath
+                    PackageFileName = $PackageFileInfo.PackageFileName
+                    Repository = $UploadTarget.Repository
+                    Headers = $UploadHeaders
+                    UploadUrl = 'https://packages.example/raw/modules/PackageProject.2.3.4.zip'
+                }
+            }
+
+            $result = @(Resolve-NovaPackageUploadInvocation -ProjectInfo $projectInfo -UploadOption $uploadOption)
+
+            $result.Count | Should -Be 1
+            $result[0].Type | Should -Be 'Zip'
+            $result[0].Repository | Should -Be 'LocalRaw'
+            $result[0].Headers['X-Trace-Id'] | Should -Be 'trace-123'
+            $result[0].UploadUrl | Should -Be 'https://packages.example/raw/modules/PackageProject.2.3.4.zip'
+            Assert-MockCalled Get-NovaPackageUploadFileList -Times 1 -ParameterFilter {$ProjectInfo.ProjectName -eq 'PackageProject' -and $PackageType -eq @('Zip')}
+            Assert-MockCalled Resolve-NovaPackageUploadTarget -Times 1 -ParameterFilter {$ProjectInfo.ProjectName -eq 'PackageProject' -and $Repository -eq 'LocalRaw' -and $UploadPath -eq 'modules'}
+            Assert-MockCalled Resolve-NovaPackageUploadHeaders -Times 1 -ParameterFilter {$UploadTarget.Repository -eq 'LocalRaw' -and $UploadOption.Repository -eq 'LocalRaw'}
+            Assert-MockCalled Get-NovaPackageUploadArtifact -Times 1 -ParameterFilter {$PackageFileInfo.PackageFileName -eq 'PackageProject.2.3.4.zip' -and $UploadTarget.Repository -eq 'LocalRaw'}
+        }
+    }
+
     It 'Deploy-NovaPackage uploads the specified package file to the specified raw URL' {
         $layout = Initialize-TestNovaPackageUploadLayout -ProjectRoot (Join-Path $TestDrive 'explicit-upload')
         $packagePath = New-TestNovaPackageArtifactFile -Directory $layout.PackageOutputDir -Name 'PackageProject.2.3.4.zip'

--- a/tests/NovaCommandModel.PackageUpload.Tests.ps1
+++ b/tests/NovaCommandModel.PackageUpload.Tests.ps1
@@ -99,6 +99,38 @@ Describe 'Nova command model - package upload behavior' {
         }
     }
 
+    It 'Get-NovaPackageUploadWorkflowContext falls back to project-info and upload-option resolution when explicit inputs are omitted' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{ProjectRoot = '/tmp/project'; ProjectName = 'PackageProject'}
+            }
+            Mock New-NovaPackageUploadOption {
+                [pscustomobject]@{
+                    PackagePath = @('/tmp/project/artifacts/packages/PackageProject.2.3.4.zip')
+                    PackageType = @('Zip')
+                    Url = 'https://packages.example/raw/'
+                    Repository = ''
+                    UploadPath = 'modules'
+                    Headers = [ordered]@{}
+                    Token = $null
+                    TokenEnvironmentVariable = $null
+                    AuthenticationScheme = $null
+                }
+            }
+            Mock Resolve-NovaPackageUploadInvocation {
+                @([pscustomobject]@{PackageFileName = 'PackageProject.2.3.4.zip'; UploadUrl = 'https://packages.example/raw/modules/PackageProject.2.3.4.zip'})
+            }
+
+            $result = Get-NovaPackageUploadWorkflowContext -BoundParameters @{Url = 'https://packages.example/raw/'}
+
+            $result.ProjectInfo.ProjectName | Should -Be 'PackageProject'
+            $result.UploadOption.Url | Should -Be 'https://packages.example/raw/'
+            $result.UploadArtifactList.Count | Should -Be 1
+            Assert-MockCalled Get-NovaProjectInfo -Times 1
+            Assert-MockCalled New-NovaPackageUploadOption -Times 1 -ParameterFilter {$BoundParameters.Url -eq 'https://packages.example/raw/'}
+        }
+    }
+
     It 'Invoke-NovaPackageUploadWorkflow uploads each approved artifact in order' {
         InModuleScope $script:moduleName {
             $script:steps = @()
@@ -123,6 +155,20 @@ Describe 'Nova command model - package upload behavior' {
             $script:steps | Should -Be @('PackageProject.2.3.4.nupkg', 'PackageProject.2.3.4.zip')
             $result.PackageFileName | Should -Be @('PackageProject.2.3.4.nupkg', 'PackageProject.2.3.4.zip')
             Assert-MockCalled Invoke-NovaPackageArtifactUpload -Times 2
+        }
+    }
+
+    It 'Invoke-NovaPackageUploadWorkflow returns an empty result when no approved or resolved artifacts exist' {
+        InModuleScope $script:moduleName {
+            $workflowContext = [pscustomobject]@{
+                UploadArtifactList = @()
+            }
+            Mock Invoke-NovaPackageArtifactUpload {throw 'should not upload'}
+
+            $result = @(Invoke-NovaPackageUploadWorkflow -WorkflowContext $workflowContext -UploadArtifactList @())
+
+            $result.Count | Should -Be 0
+            Assert-MockCalled Invoke-NovaPackageArtifactUpload -Times 0
         }
     }
 

--- a/tests/NovaCommandModel.PackageUpload.Tests.ps1
+++ b/tests/NovaCommandModel.PackageUpload.Tests.ps1
@@ -186,6 +186,90 @@ Describe 'Nova command model - package upload behavior' {
         }
     }
 
+    It 'Resolve-NovaPackageUploadTarget resolves target precedence correctly when <Name>' -ForEach @(
+        @{
+            Name = 'repository settings should override package headers and auth'
+            ProjectRootName = 'target-merge-precedence'
+            UseExplicitOverride = $false
+            ExpectedUrl = 'https://packages.example/raw/repository/'
+            ExpectedUploadPath = 'repo-path'
+            ExpectedTraceId = 'repo-trace'
+            ExpectPackageToken = $true
+        }
+        @{
+            Name = 'explicit Url and UploadPath should override configured locations'
+            ProjectRootName = 'target-explicit-overrides'
+            UseExplicitOverride = $true
+            ExpectedUrl = 'https://override.example/upload/'
+            ExpectedUploadPath = 'manual/path'
+            ExpectedTraceId = $null
+            ExpectPackageToken = $false
+        }
+    ) {
+        $testCase = $_
+        $layout = Initialize-TestNovaPackageUploadLayout -ProjectRoot (Join-Path $TestDrive $testCase.ProjectRootName)
+        $repositoryList = @(
+            [ordered]@{
+                Name = 'LocalRaw'
+                Url = 'https://packages.example/raw/repository/'
+                UploadPath = 'repo-path'
+                Headers = [ordered]@{} + $( if ($null -ne $testCase.ExpectedTraceId) {
+                    [ordered]@{'X-Trace-Id' = 'repo-trace'}
+                } else {
+                    [ordered]@{}
+                } ) + [ordered]@{
+                    'X-Repo-Only' = 'repo-only'
+                }
+                Auth = [ordered]@{
+                    HeaderName = 'X-Repo-Token'
+                    TokenEnvironmentVariable = 'REPO_UPLOAD_TOKEN'
+                }
+            }
+        )
+
+        InModuleScope $script:moduleName -Parameters @{
+            ProjectInfo = (New-TestNovaPackageUploadProjectInfo -Layout $layout -Options @{
+                RepositoryUrl = 'https://packages.example/raw/package/'
+                UploadPath = 'package-path'
+                Headers = [ordered]@{
+                    'X-Package-Only' = 'package-only'
+                }
+                Auth = [ordered]@{
+                    HeaderName = 'X-Package-Token'
+                    TokenEnvironmentVariable = 'PACKAGE_UPLOAD_TOKEN'
+                    Token = 'package-token'
+                }
+                Repositories = $repositoryList
+            })
+            TestCase = $testCase
+        } {
+            param($ProjectInfo, $TestCase)
+
+            $result = if ($TestCase.UseExplicitOverride) {
+                Resolve-NovaPackageUploadTarget -ProjectInfo $ProjectInfo -Repository 'LocalRaw' -Url 'https://override.example/upload/' -UploadPath 'manual/path'
+            }
+            else {
+                Resolve-NovaPackageUploadTarget -ProjectInfo $ProjectInfo -Repository 'localraw'
+            }
+
+            $result.Repository | Should -Be 'LocalRaw'
+            $result.Url | Should -Be $TestCase.ExpectedUrl
+            $result.UploadPath | Should -Be $TestCase.ExpectedUploadPath
+            $result.Headers['X-Package-Only'] | Should -Be 'package-only'
+            $result.Headers['X-Repo-Only'] | Should -Be 'repo-only'
+            $result.Auth.HeaderName | Should -Be 'X-Repo-Token'
+            $result.Auth.TokenEnvironmentVariable | Should -Be 'REPO_UPLOAD_TOKEN'
+
+            if ($null -ne $TestCase.ExpectedTraceId) {
+                $result.Headers['X-Trace-Id'] | Should -Be $TestCase.ExpectedTraceId
+            }
+
+            if ($TestCase.ExpectPackageToken) {
+                $result.Auth.Token | Should -Be 'package-token'
+            }
+        }
+    }
+
     It 'Deploy-NovaPackage uploads the specified package file to the specified raw URL' {
         $layout = Initialize-TestNovaPackageUploadLayout -ProjectRoot (Join-Path $TestDrive 'explicit-upload')
         $packagePath = New-TestNovaPackageArtifactFile -Directory $layout.PackageOutputDir -Name 'PackageProject.2.3.4.zip'

--- a/tests/NovaCommandModel.ReleasePublish.Tests.ps1
+++ b/tests/NovaCommandModel.ReleasePublish.Tests.ps1
@@ -315,6 +315,26 @@ Describe 'Nova command model - release and publish behavior' {
         }
     }
 
+    It 'Get-NovaPackageWorkflowContext uses the single-package operation wording when exactly one package is requested' {
+        InModuleScope $script:moduleName {
+            $projectInfo = [pscustomobject]@{
+                ProjectName = 'NovaModuleTools'
+            }
+            $packageMetadataList = @(
+                [pscustomobject]@{Type = 'NuGet'; PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'}
+            )
+
+            Mock Get-NovaPackageMetadataList {$packageMetadataList}
+            Mock Assert-NovaPackageMetadata {}
+
+            $result = Get-NovaPackageWorkflowContext -ProjectInfo $projectInfo
+
+            $result.Operation | Should -Be 'Create NuGet package from built module output'
+            $result.Target | Should -Be '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'
+            Assert-MockCalled Assert-NovaPackageMetadata -Times 1
+        }
+    }
+
     It 'Invoke-NovaPackageWorkflow runs build, test, and package creation in order for all requested package types' {
         InModuleScope $script:moduleName {
             $script:steps = @()
@@ -392,6 +412,39 @@ Describe 'Nova command model - release and publish behavior' {
             $script:steps -join ',' | Should -Be 'pack'
             $result.Type | Should -Be @('NuGet', 'Zip')
             Assert-MockCalled Import-Module -Times 1 -ParameterFilter {$Name -eq $ExecutionContext.SessionState.Module.Path -and $PassThru}
+        }
+    }
+
+    It 'Invoke-NovaPackageArtifactCreation uses the loaded package helper directly when it is already available' {
+        InModuleScope $script:moduleName {
+            $projectInfo = [pscustomobject]@{
+                ProjectName = 'NovaModuleTools'
+            }
+            $packageMetadataList = @(
+                [pscustomobject]@{Type = 'NuGet'; PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'}
+            )
+
+            Mock Get-Command {
+                [pscustomobject]@{Name = 'New-NovaPackageArtifacts'}
+            } -ParameterFilter {$Name -eq 'New-NovaPackageArtifacts' -and $CommandType -eq 'Function'}
+            Mock New-NovaPackageArtifacts {
+                @([pscustomobject]@{Type = 'NuGet'; PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'})
+            }
+            Mock Import-Module {throw 'should not import'}
+
+            $workflowContext = [pscustomobject]@{
+                ProjectInfo = $projectInfo
+                PackageMetadataList = $packageMetadataList
+                ModulePath = '/tmp/NovaModuleTools.psm1'
+            }
+
+            $result = @(Invoke-NovaPackageArtifactCreation -WorkflowContext $workflowContext)
+
+            $result.Type | Should -Be @('NuGet')
+            Assert-MockCalled New-NovaPackageArtifacts -Times 1 -ParameterFilter {
+                $ProjectInfo.ProjectName -eq 'NovaModuleTools' -and $PackageMetadataList.Count -eq 1
+            }
+            Assert-MockCalled Import-Module -Times 0
         }
     }
 

--- a/tests/NovaCommandModel.ReleasePublish.Tests.ps1
+++ b/tests/NovaCommandModel.ReleasePublish.Tests.ps1
@@ -42,28 +42,25 @@ BeforeAll {
 }
 
 Describe 'Nova command model - release and publish behavior' {
-    It 'Invoke-NovaRelease runs build test bump build publish in order' {
+    It 'Invoke-NovaReleaseWorkflow runs build test bump build publish in order' {
         InModuleScope $script:moduleName {
             $script:steps = @()
 
-            Mock Get-NovaProjectInfo {
-                [pscustomobject]@{
-                    ProjectName = 'NovaModuleTools'
-                    OutputModuleDir = '/tmp/dist/NovaModuleTools'
-                }
-            }
-            Mock Get-LocalModulePath {'/tmp/modules'}
             Mock Invoke-NovaBuild {$script:steps += 'build'}
             Mock Test-NovaBuild {$script:steps += 'test'}
             Mock Update-NovaModuleVersion {
                 $script:steps += 'bump'
                 return [pscustomobject]@{NewVersion = '1.0.1'}
             }
-            Mock Test-Path {$true}
-            Mock Remove-Item {}
-            Mock Copy-Item {$script:steps += 'publish'}
+            $workflowContext = [pscustomobject]@{
+                WorkflowParams = @{}
+                PublishInvocation = [pscustomobject]@{
+                    Action = {$script:steps += 'publish'}
+                }
+                PublishParams = @{}
+            }
 
-            Invoke-NovaRelease -PublishOption @{Local = $true} -Path (Get-Location).Path | Out-Null
+            Invoke-NovaReleaseWorkflow -WorkflowContext $workflowContext | Out-Null
 
             $script:steps -join ',' | Should -Be 'build,test,bump,build,publish'
         }
@@ -87,52 +84,38 @@ Describe 'Nova command model - release and publish behavior' {
         }
     }
 
-    It 'Invoke-NovaRelease -WhatIf forwards preview mode through the nested workflow' {
+    It 'Invoke-NovaReleaseWorkflow forwards WhatIf to build test bump build and publish helpers' {
         InModuleScope $script:moduleName {
             $script:steps = @()
             $publishAction = {
-                param($ProjectInfo, $ModuleDirectoryPath)
+                param($WhatIf)
 
-                Publish-NovaBuiltModuleToDirectory @PSBoundParameters
+                $script:steps += "publish:$WhatIf"
             }
 
-            Mock Get-NovaProjectInfo {
-                [pscustomobject]@{
-                    ProjectName = 'NovaModuleTools'
-                    OutputModuleDir = '/tmp/dist/NovaModuleTools'
-                }
-            }
-            Mock Get-Command {
-                [pscustomobject]@{ScriptBlock = $publishAction}
-            } -ParameterFilter {$Name -eq 'Publish-NovaBuiltModuleToDirectory' -and $CommandType -eq 'Function'}
-            Mock Get-LocalModulePath {'/tmp/modules'}
             Mock Invoke-NovaBuild {$script:steps += "build:$WhatIfPreference"}
             Mock Test-NovaBuild {$script:steps += "test:$WhatIfPreference"}
             Mock Update-NovaModuleVersion {
                 $script:steps += "bump:$WhatIfPreference"
                 [pscustomobject]@{PreviousVersion = '1.0.0'; NewVersion = '1.0.0'; Label = 'Patch'; CommitCount = 0}
             }
-            Mock Publish-NovaBuiltModuleToDirectory {$script:steps += "publish:$WhatIfPreference"}
+            $workflowContext = [pscustomobject]@{
+                WorkflowParams = @{WhatIf = $true}
+                PublishInvocation = [pscustomobject]@{
+                    Action = $publishAction
+                }
+                PublishParams = @{WhatIf = $true}
+            }
 
-            $result = Invoke-NovaRelease -PublishOption @{Local = $true} -Path (Get-Location).Path -WhatIf
+            $result = Invoke-NovaReleaseWorkflow -WorkflowContext $workflowContext
 
             $script:steps -join ',' | Should -Be 'build:True,test:True,bump:True,build:True,publish:True'
             $result.NewVersion | Should -Be '1.0.0'
         }
     }
 
-    It 'Invoke-NovaRelease reuses shared publish parameter resolution for local release execution' {
+    It 'Get-NovaPublishWorkflowContext composes shared release workflow context for local execution' {
         InModuleScope $script:moduleName {
-            $script:publishBoundParameters = $null
-
-            Mock Get-NovaProjectInfo {
-                [pscustomobject]@{
-                    ProjectName = 'NovaModuleTools'
-                    OutputModuleDir = '/tmp/dist/NovaModuleTools'
-                }
-            }
-            Mock Write-NovaLocalWorkflowMode {}
-            Mock Write-NovaResolvedLocalPublishTarget {}
             Mock Resolve-NovaPublishInvocation {
                 [pscustomobject]@{
                     Target = '/tmp/modules'
@@ -155,67 +138,81 @@ Describe 'Nova command model - release and publish behavior' {
                 @{
                     ProjectInfo = [pscustomobject]@{ProjectName = 'NovaModuleTools'}
                     ModuleDirectoryPath = '/tmp/modules'
+                    WhatIf = $true
                 }
             }
-            Mock Invoke-NovaBuild {}
-            Mock Test-NovaBuild {}
-            Mock Update-NovaModuleVersion {
-                [pscustomobject]@{NewVersion = '1.0.1'}
+            $projectInfo = [pscustomobject]@{
+                ProjectName = 'NovaModuleTools'
+                OutputModuleDir = '/tmp/dist/NovaModuleTools'
             }
-            Mock Import-NovaPublishedLocalModule {throw 'release should not import the published module'}
 
-            {Invoke-NovaRelease -PublishOption @{Local = $true} -Path (Get-Location).Path} | Should -Not -Throw
+            $result = Get-NovaPublishWorkflowContext -ProjectInfo $projectInfo -PublishOption @{Local = $true} -WorkflowParams @{WhatIf = $true} -WorkflowSettings @{
+                WorkflowName = 'release'
+                Release = $true
+            }
 
             Assert-MockCalled Get-NovaResolvedPublishParameterMap -Times 1
-            Assert-MockCalled Write-NovaResolvedLocalPublishTarget -Times 1 -ParameterFilter {$PublishInvocation.IsLocal}
-            $script:publishBoundParameters.ProjectInfo.ProjectName | Should -Be 'NovaModuleTools'
-            $script:publishBoundParameters.ModuleDirectoryPath | Should -Be '/tmp/modules'
-            @($script:publishBoundParameters.Keys | Sort-Object) | Should -Be @('ModuleDirectoryPath', 'ProjectInfo')
+            $result.PublishParams.ProjectInfo.ProjectName | Should -Be 'NovaModuleTools'
+            $result.PublishParams.ModuleDirectoryPath | Should -Be '/tmp/modules'
+            $result.PublishParams.WhatIf | Should -BeTrue
+            $result.PublishInvocation.IsLocal | Should -BeTrue
+            $result.Operation | Should -Be 'Run Nova release workflow and publish to local directory'
+            $result.LocalPublishActivation | Should -BeNullOrEmpty
         }
     }
 
-    It 'Publish-NovaModule resolves the local target and published manifest before testing, then imports the published module from that local path' {
+    It 'Invoke-NovaRelease delegates orchestration to the private release workflow helper' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{ProjectName = 'NovaModuleTools'}
+            }
+            Mock Get-NovaPublishWorkflowContext {
+                [pscustomobject]@{
+                    WorkflowName = 'release'
+                    LocalRequested = $true
+                    PublishInvocation = [pscustomobject]@{IsLocal = $true}
+                    Target = '/tmp/modules'
+                    Operation = 'Run Nova release workflow and publish to local directory'
+                }
+            }
+            Mock Write-NovaPublishWorkflowContext {}
+            Mock Invoke-NovaReleaseWorkflow {
+                [pscustomobject]@{NewVersion = '1.0.1'}
+            }
+
+            $result = Invoke-NovaRelease -PublishOption @{Local = $true} -Path (Get-Location).Path -Confirm:$false
+
+            $result.NewVersion | Should -Be '1.0.1'
+            Assert-MockCalled Get-NovaPublishWorkflowContext -Times 1 -ParameterFilter {$WorkflowSettings.WorkflowName -eq 'release' -and $WorkflowSettings.Release}
+            Assert-MockCalled Write-NovaPublishWorkflowContext -Times 1
+            Assert-MockCalled Invoke-NovaReleaseWorkflow -Times 1
+        }
+    }
+
+    It 'Invoke-NovaPublishWorkflow imports the published local module after a successful local publish' {
         InModuleScope $script:moduleName {
             $script:steps = @()
             $localManifestPath = '/tmp/modules/NovaModuleTools/NovaModuleTools.psd1'
-            $importAction = {
-                param($ProjectName, $ManifestPath)
-
-                Import-NovaPublishedLocalModule @PSBoundParameters
-            }
-
-            Mock Get-NovaProjectInfo {
-                [pscustomobject]@{
-                    ProjectName = 'NovaModuleTools'
-                    OutputModuleDir = '/tmp/dist/NovaModuleTools'
+            Mock Invoke-NovaBuild {$script:steps += 'build'}
+            Mock Test-NovaBuild {$script:steps += 'test'}
+            $workflowContext = [pscustomobject]@{
+                WorkflowParams = @{}
+                PublishInvocation = [pscustomobject]@{
+                    Parameters = @{
+                        ProjectInfo = [pscustomobject]@{ProjectName = 'NovaModuleTools'}
+                    }
+                    Action = {$script:steps += 'publish'}
+                }
+                PublishParams = @{}
+                LocalPublishActivation = [pscustomobject]@{
+                    ManifestPath = $localManifestPath
+                    ImportAction = {param($ProjectName, $ManifestPath) $script:steps += 'import'}
                 }
             }
-            Mock Get-LocalModulePath {
-                $script:steps += 'resolve'
-                '/tmp/modules'
-            }
-            Mock Get-Command {
-                [pscustomobject]@{ScriptBlock = $importAction}
-            } -ParameterFilter {$Name -eq 'Import-NovaPublishedLocalModule' -and $CommandType -eq 'Function'}
-            Mock Get-NovaPublishedLocalManifestPath {
-                $script:steps += 'manifest'
-                $localManifestPath
-            }
-            Mock Invoke-NovaBuild {$script:steps += 'build'}
-            Mock Test-NovaBuild {
-                $script:steps += 'test'
-                Remove-Item function:Get-LocalModulePath -ErrorAction SilentlyContinue
-            }
-            Mock Test-Path {$true}
-            Mock Remove-Item {}
-            Mock Copy-Item {$script:steps += 'copy'}
-            Mock Import-NovaPublishedLocalModule {$script:steps += 'import'}
 
-            {Publish-NovaModule -Local} | Should -Not -Throw
+            {Invoke-NovaPublishWorkflow -WorkflowContext $workflowContext -ShouldRun} | Should -Not -Throw
 
-            $script:steps -join ',' | Should -Be 'resolve,manifest,build,test,copy,import'
-            Assert-MockCalled Copy-Item -Times 1 -ParameterFilter {$Destination -eq '/tmp/modules'}
-            Assert-MockCalled Import-NovaPublishedLocalModule -Times 1 -ParameterFilter {$ProjectName -eq 'NovaModuleTools' -and $ManifestPath -eq $localManifestPath}
+            $script:steps -join ',' | Should -Be 'build,test,publish,import'
         }
     }
 
@@ -237,64 +234,58 @@ Describe 'Nova command model - release and publish behavior' {
         }
     }
 
-    It 'Publish-NovaModule -WhatIf forwards preview mode to build, test, and publish helpers' {
+    It 'Invoke-NovaPublishWorkflow forwards WhatIf to build test and publish helpers without importing' {
         InModuleScope $script:moduleName {
             $script:steps = @()
             $publishAction = {
-                param($ProjectInfo, $ModuleDirectoryPath)
+                param($WhatIf)
 
-                Publish-NovaBuiltModuleToDirectory @PSBoundParameters
+                $script:steps += "publish:$WhatIf"
             }
 
-            Mock Get-NovaProjectInfo {
-                [pscustomobject]@{
-                    ProjectName = 'NovaModuleTools'
-                    OutputModuleDir = '/tmp/dist/NovaModuleTools'
-                }
-            }
-            Mock Get-Command {
-                [pscustomobject]@{ScriptBlock = $publishAction}
-            } -ParameterFilter {$Name -eq 'Publish-NovaBuiltModuleToDirectory' -and $CommandType -eq 'Function'}
-            Mock Get-LocalModulePath {'/tmp/modules'}
             Mock Invoke-NovaBuild {$script:steps += "build:$WhatIfPreference"}
             Mock Test-NovaBuild {$script:steps += "test:$WhatIfPreference"}
-            Mock Publish-NovaBuiltModuleToDirectory {$script:steps += "publish:$WhatIfPreference"}
-            Mock Import-NovaPublishedLocalModule {$script:steps += 'import'}
+            $workflowContext = [pscustomobject]@{
+                WorkflowParams = @{WhatIf = $true}
+                PublishInvocation = [pscustomobject]@{
+                    Action = $publishAction
+                }
+                PublishParams = @{WhatIf = $true}
+                LocalPublishActivation = [pscustomobject]@{
+                    ManifestPath = '/tmp/modules/NovaModuleTools/NovaModuleTools.psd1'
+                    ImportAction = {$script:steps += 'import'}
+                }
+            }
 
-            $result = Publish-NovaModule -Local -WhatIf
+            $result = Invoke-NovaPublishWorkflow -WorkflowContext $workflowContext
 
             $result | Should -BeNullOrEmpty
             $script:steps -join ',' | Should -Be 'build:True,test:True,publish:True'
-            Assert-MockCalled Import-NovaPublishedLocalModule -Times 0
         }
     }
 
-    It 'Publish-NovaModule repository mode does not import the published module after publish' {
+    It 'Publish-NovaModule delegates orchestration to the private publish workflow helper' {
         InModuleScope $script:moduleName {
-            $publishAction = {
-                param($ProjectInfo, $Repository, $ApiKey)
-
-                Publish-NovaBuiltModuleToRepository @PSBoundParameters
-            }
-
             Mock Get-NovaProjectInfo {
+                [pscustomobject]@{ProjectName = 'NovaModuleTools'}
+            }
+            Mock Get-NovaPublishWorkflowContext {
                 [pscustomobject]@{
-                    ProjectName = 'NovaModuleTools'
-                    OutputModuleDir = '/tmp/dist/NovaModuleTools'
+                    WorkflowName = 'publish'
+                    LocalRequested = $false
+                    PublishInvocation = [pscustomobject]@{IsLocal = $false}
+                    Target = 'PSGallery'
+                    Operation = 'Build, test, and publish Nova module to repository'
                 }
             }
-            Mock Get-Command {
-                [pscustomobject]@{ScriptBlock = $publishAction}
-            } -ParameterFilter {$Name -eq 'Publish-NovaBuiltModuleToRepository' -and $CommandType -eq 'Function'}
-            Mock Invoke-NovaBuild {}
-            Mock Test-NovaBuild {}
-            Mock Publish-NovaBuiltModuleToRepository {}
-            Mock Import-NovaPublishedLocalModule {}
+            Mock Write-NovaPublishWorkflowContext {}
+            Mock Invoke-NovaPublishWorkflow {}
 
-            {Publish-NovaModule -Repository PSGallery -ApiKey key123} | Should -Not -Throw
+            {Publish-NovaModule -Repository PSGallery -ApiKey key123 -Confirm:$false} | Should -Not -Throw
 
-            Assert-MockCalled Publish-NovaBuiltModuleToRepository -Times 1 -ParameterFilter {$Repository -eq 'PSGallery' -and $ApiKey -eq 'key123'}
-            Assert-MockCalled Import-NovaPublishedLocalModule -Times 0
+            Assert-MockCalled Get-NovaPublishWorkflowContext -Times 1 -ParameterFilter {$WorkflowSettings.WorkflowName -eq 'publish' -and $WorkflowSettings.IncludeLocalPublishActivation}
+            Assert-MockCalled Write-NovaPublishWorkflowContext -Times 1
+            Assert-MockCalled Invoke-NovaPublishWorkflow -Times 1
         }
     }
 
@@ -793,8 +784,8 @@ Describe 'Nova command model - release and publish behavior' {
         $publishFunction | Should -Not -BeNullOrEmpty
         $publishSource = $publishFunction.Extent.Text
 
-        $publishSource.IndexOf('Resolve-NovaPublishInvocation') | Should -BeGreaterThan -1
-        $publishSource.IndexOf('Invoke-NovaBuild') | Should -BeGreaterThan -1
-        $publishSource.IndexOf('Resolve-NovaPublishInvocation') | Should -BeLessThan $publishSource.IndexOf('Invoke-NovaBuild')
+        $publishSource.IndexOf('Get-NovaPublishWorkflowContext') | Should -BeGreaterThan -1
+        $publishSource.IndexOf('Invoke-NovaPublishWorkflow') | Should -BeGreaterThan -1
+        $publishSource.IndexOf('Get-NovaPublishWorkflowContext') | Should -BeLessThan $publishSource.IndexOf('Invoke-NovaPublishWorkflow')
     }
 }

--- a/tests/NovaCommandModel.ReleasePublish.Tests.ps1
+++ b/tests/NovaCommandModel.ReleasePublish.Tests.ps1
@@ -289,40 +289,48 @@ Describe 'Nova command model - release and publish behavior' {
         }
     }
 
-    It 'New-NovaModulePackage runs build, test, and package creation in order for all requested package types' {
+    It 'Get-NovaPackageWorkflowContext resolves package metadata, target, and operation for all requested package types' {
+        InModuleScope $script:moduleName {
+            $projectInfo = [pscustomobject]@{
+                ProjectName = 'NovaModuleTools'
+            }
+            $packageMetadataList = @(
+                [pscustomobject]@{Type = 'NuGet'; PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'}
+                [pscustomobject]@{Type = 'Zip'; PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.zip'}
+            )
+
+            Mock Get-NovaPackageMetadataList {$packageMetadataList}
+            Mock Assert-NovaPackageMetadata {}
+
+            $result = Get-NovaPackageWorkflowContext -ProjectInfo $projectInfo -WorkflowParams @{WhatIf = $true} -ModulePath '/tmp/NovaModuleTools.psm1'
+
+            $result.ProjectInfo.ProjectName | Should -Be 'NovaModuleTools'
+            $result.WorkflowParams.WhatIf | Should -BeTrue
+            $result.ModulePath | Should -Be '/tmp/NovaModuleTools.psm1'
+            $result.Target | Should -Be '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg, /tmp/project/artifacts/packages/NovaModuleTools.1.2.3.zip'
+            $result.Operation | Should -Be 'Create package artifacts from built module output'
+            $result.PackageMetadataList.Type | Should -Be @('NuGet', 'Zip')
+            Assert-MockCalled Get-NovaPackageMetadataList -Times 1 -ParameterFilter {$ProjectInfo.ProjectName -eq 'NovaModuleTools'}
+            Assert-MockCalled Assert-NovaPackageMetadata -Times 2
+        }
+    }
+
+    It 'Invoke-NovaPackageWorkflow runs build, test, and package creation in order for all requested package types' {
         InModuleScope $script:moduleName {
             $script:steps = @()
-
-            Mock Get-NovaProjectInfo {
-                [pscustomobject]@{
-                    ProjectName = 'NovaModuleTools'
-                    Version = '1.2.3'
-                    ProjectRoot = '/tmp/project'
-                    OutputModuleDir = '/tmp/dist/NovaModuleTools'
-                    Description = 'Package test'
-                    Manifest = [ordered]@{
-                        Author = 'Test Author'
-                        Tags = @('Nova', 'PowerShell')
-                        ProjectUri = 'https://example.test/project'
-                        ReleaseNotes = 'https://example.test/release-notes'
-                        LicenseUri = 'https://example.test/license'
-                    }
-                    Package = [ordered]@{
-                        Id = 'NovaModuleTools'
-                        Types = @('NuGet', 'Zip')
-                        OutputDirectory = [ordered]@{
-                            Path = '/tmp/project/artifacts/packages'
-                            Clean = $true
-                        }
-                        PackageFileName = 'NovaModuleTools.1.2.3.nupkg'
-                        Authors = 'Test Author'
-                        Description = 'Package test'
-                    }
-                }
+            $workflowContext = [pscustomobject]@{
+                ProjectInfo = [pscustomobject]@{ProjectName = 'NovaModuleTools'}
+                WorkflowParams = @{}
+                PackageMetadataList = @(
+                    [pscustomobject]@{Type = 'NuGet'; PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'}
+                    [pscustomobject]@{Type = 'Zip'; PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.zip'}
+                )
+                ModulePath = '/tmp/NovaModuleTools.psm1'
             }
+
             Mock Invoke-NovaBuild {$script:steps += 'build'}
             Mock Test-NovaBuild {$script:steps += 'test'}
-            Mock New-NovaPackageArtifacts {
+            Mock Invoke-NovaPackageArtifactCreation {
                 $script:steps += 'pack'
                 @(
                     [pscustomobject]@{Type = 'NuGet'; PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'}
@@ -330,7 +338,7 @@ Describe 'Nova command model - release and publish behavior' {
                 )
             }
 
-            $result = @(New-NovaModulePackage)
+            $result = @(Invoke-NovaPackageWorkflow -WorkflowContext $workflowContext -ShouldRun)
 
             $script:steps -join ',' | Should -Be 'build,test,pack'
             $result.Type | Should -Be @('NuGet', 'Zip')
@@ -338,42 +346,27 @@ Describe 'Nova command model - release and publish behavior' {
                 '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg',
                 '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.zip'
             )
+            Assert-MockCalled Invoke-NovaBuild -Times 1
+            Assert-MockCalled Test-NovaBuild -Times 1
+            Assert-MockCalled Invoke-NovaPackageArtifactCreation -Times 1 -ParameterFilter {
+                $WorkflowContext.ProjectInfo.ProjectName -eq 'NovaModuleTools' -and
+                        $WorkflowContext.PackageMetadataList.Count -eq 2 -and
+                        $WorkflowContext.ModulePath -eq '/tmp/NovaModuleTools.psm1'
+            }
         }
     }
 
-    It 'New-NovaModulePackage reimports the current module when package helpers were unloaded during tests' {
+    It 'Invoke-NovaPackageArtifactCreation reimports the current module when package helpers were unloaded during tests' {
         InModuleScope $script:moduleName {
             $script:steps = @()
-
-            Mock Get-NovaProjectInfo {
-                [pscustomobject]@{
-                    ProjectName = 'NovaModuleTools'
-                    Version = '1.2.3'
-                    ProjectRoot = '/tmp/project'
-                    OutputModuleDir = '/tmp/dist/NovaModuleTools'
-                    Description = 'Package test'
-                    Manifest = [ordered]@{
-                        Author = 'Test Author'
-                        Tags = @('Nova', 'PowerShell')
-                        ProjectUri = 'https://example.test/project'
-                        ReleaseNotes = 'https://example.test/release-notes'
-                        LicenseUri = 'https://example.test/license'
-                    }
-                    Package = [ordered]@{
-                        Id = 'NovaModuleTools'
-                        Types = @('NuGet', 'Zip')
-                        OutputDirectory = [ordered]@{
-                            Path = '/tmp/project/artifacts/packages'
-                            Clean = $true
-                        }
-                        PackageFileName = 'NovaModuleTools.1.2.3.nupkg'
-                        Authors = 'Test Author'
-                        Description = 'Package test'
-                    }
-                }
+            $projectInfo = [pscustomobject]@{
+                ProjectName = 'NovaModuleTools'
             }
-            Mock Invoke-NovaBuild {$script:steps += 'build'}
-            Mock Test-NovaBuild {$script:steps += 'test'}
+            $packageMetadataList = @(
+                [pscustomobject]@{Type = 'NuGet'; PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'}
+                [pscustomobject]@{Type = 'Zip'; PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.zip'}
+            )
+
             Mock Get-Command {
                 $null
             } -ParameterFilter {$Name -eq 'New-NovaPackageArtifacts' -and $CommandType -eq 'Function'}
@@ -388,53 +381,74 @@ Describe 'Nova command model - release and publish behavior' {
                 )
             }
 
-            $result = @(New-NovaModulePackage)
+            $workflowContext = [pscustomobject]@{
+                ProjectInfo = $projectInfo
+                PackageMetadataList = $packageMetadataList
+                ModulePath = $ExecutionContext.SessionState.Module.Path
+            }
 
-            $script:steps -join ',' | Should -Be 'build,test,pack'
+            $result = @(Invoke-NovaPackageArtifactCreation -WorkflowContext $workflowContext)
+
+            $script:steps -join ',' | Should -Be 'pack'
             $result.Type | Should -Be @('NuGet', 'Zip')
             Assert-MockCalled Import-Module -Times 1 -ParameterFilter {$Name -eq $ExecutionContext.SessionState.Module.Path -and $PassThru}
         }
     }
 
-    It 'New-NovaModulePackage -WhatIf forwards preview mode through build and test without creating a package' {
+    It 'New-NovaModulePackage delegates orchestration to the private package workflow helpers' {
         InModuleScope $script:moduleName {
-            $script:steps = @()
-
-            Mock Get-NovaProjectInfo {
+            Mock Get-NovaPackageWorkflowContext {
                 [pscustomobject]@{
-                    ProjectName = 'NovaModuleTools'
-                    Version = '1.2.3'
-                    ProjectRoot = '/tmp/project'
-                    OutputModuleDir = '/tmp/dist/NovaModuleTools'
-                    Description = 'Package test'
-                    Manifest = [ordered]@{
-                        Author = 'Test Author'
-                        Tags = @()
-                        ProjectUri = ''
-                        ReleaseNotes = ''
-                        LicenseUri = ''
-                    }
-                    Package = [ordered]@{
-                        Id = 'NovaModuleTools'
-                        OutputDirectory = [ordered]@{
-                            Path = '/tmp/project/artifacts/packages'
-                            Clean = $true
-                        }
-                        PackageFileName = 'NovaModuleTools.1.2.3.nupkg'
-                        Authors = 'Test Author'
-                        Description = 'Package test'
-                    }
+                    ProjectInfo = [pscustomobject]@{ProjectName = 'NovaModuleTools'}
+                    WorkflowParams = @{}
+                    PackageMetadataList = @(
+                        [pscustomobject]@{Type = 'NuGet'; PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'}
+                    )
+                    ModulePath = '/tmp/NovaModuleTools.psm1'
+                    Target = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'
+                    Operation = 'Create NuGet package from built module output'
                 }
             }
+            Mock Invoke-NovaPackageWorkflow {
+                @(
+                    [pscustomobject]@{Type = 'NuGet'; PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'}
+                )
+            }
+
+            $result = @(New-NovaModulePackage -Confirm:$false)
+
+            $result.Type | Should -Be @('NuGet')
+            $result.PackagePath | Should -Be @('/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg')
+            Assert-MockCalled Get-NovaPackageWorkflowContext -Times 1
+            Assert-MockCalled Invoke-NovaPackageWorkflow -Times 1 -ParameterFilter {
+                $ShouldRun -and
+                        $WorkflowContext.Target -eq '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg' -and
+                        $WorkflowContext.Operation -eq 'Create NuGet package from built module output'
+            }
+        }
+    }
+
+    It 'Invoke-NovaPackageWorkflow -WhatIf forwards preview mode through build and test without creating a package' {
+        InModuleScope $script:moduleName {
+            $script:steps = @()
+            $workflowContext = [pscustomobject]@{
+                ProjectInfo = [pscustomobject]@{ProjectName = 'NovaModuleTools'}
+                WorkflowParams = @{WhatIf = $true}
+                PackageMetadataList = @(
+                    [pscustomobject]@{Type = 'NuGet'; PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'}
+                )
+                ModulePath = '/tmp/NovaModuleTools.psm1'
+            }
+
             Mock Invoke-NovaBuild {$script:steps += "build:$WhatIfPreference"}
             Mock Test-NovaBuild {$script:steps += "test:$WhatIfPreference"}
-            Mock New-NovaPackageArtifacts {$script:steps += 'pack'}
+            Mock Invoke-NovaPackageArtifactCreation {throw 'should not package'}
 
-            $result = New-NovaModulePackage -WhatIf
+            $result = Invoke-NovaPackageWorkflow -WorkflowContext $workflowContext
 
             $result | Should -BeNullOrEmpty
             $script:steps -join ',' | Should -Be 'build:True,test:True'
-            Assert-MockCalled New-NovaPackageArtifacts -Times 0
+            Assert-MockCalled Invoke-NovaPackageArtifactCreation -Times 0
         }
     }
 

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -428,22 +428,57 @@ Describe 'Nova command model - project, help, and build behavior' {
         }
     }
 
-    It 'Invoke-NovaBuild runs module build pipeline' {
+    It 'Invoke-NovaBuildWorkflow runs the build pipeline in order and forwards project info to build helpers' {
         InModuleScope $script:moduleName {
-            Mock Reset-ProjectDist {}
-            Mock Build-Module {}
-            Mock Get-NovaProjectInfo {[pscustomobject]@{FailOnDuplicateFunctionNames = $false; OutputModuleDir = '/tmp/dist/NovaModuleTools'}}
-            Mock Build-Manifest {}
-            Mock Build-Help {}
-            Mock Copy-ProjectResource {}
-            Mock New-NovaPackageArtifact {}
-            Mock Invoke-NovaBuildUpdateNotification {}
+            $script:steps = @()
+            $projectInfo = [pscustomobject]@{
+                ProjectName = 'NovaModuleTools'
+                OutputModuleDir = '/tmp/dist/NovaModuleTools'
+                FailOnDuplicateFunctionNames = $true
+            }
+            $workflowContext = [pscustomobject]@{
+                ProjectInfo = $projectInfo
+            }
 
-            Invoke-NovaBuild
+            Mock Reset-ProjectDist {$script:steps += 'reset'}
+            Mock Build-Module {$script:steps += 'module'}
+            Mock Assert-BuiltModuleHasNoDuplicateFunctionName {$script:steps += 'duplicates'}
+            Mock Build-Manifest {$script:steps += 'manifest'}
+            Mock Build-Help {$script:steps += 'help'}
+            Mock Copy-ProjectResource {$script:steps += 'resources'}
+            Mock Invoke-NovaBuildUpdateNotification {$script:steps += 'notification'}
 
-            Assert-MockCalled Build-Module -Times 1
-            Assert-MockCalled New-NovaPackageArtifact -Times 0
+            Invoke-NovaBuildWorkflow -WorkflowContext $workflowContext
+
+            $script:steps -join ',' | Should -Be 'reset,module,duplicates,manifest,help,resources,notification'
+            Assert-MockCalled Reset-ProjectDist -Times 1 -ParameterFilter {$ProjectInfo.ProjectName -eq 'NovaModuleTools' -and -not $Confirm}
+            Assert-MockCalled Build-Module -Times 1 -ParameterFilter {$ProjectInfo.ProjectName -eq 'NovaModuleTools'}
+            Assert-MockCalled Assert-BuiltModuleHasNoDuplicateFunctionName -Times 1 -ParameterFilter {$ProjectInfo.ProjectName -eq 'NovaModuleTools'}
+            Assert-MockCalled Build-Manifest -Times 1 -ParameterFilter {$ProjectInfo.ProjectName -eq 'NovaModuleTools'}
+            Assert-MockCalled Build-Help -Times 1 -ParameterFilter {$ProjectInfo.ProjectName -eq 'NovaModuleTools'}
+            Assert-MockCalled Copy-ProjectResource -Times 1 -ParameterFilter {$ProjectInfo.ProjectName -eq 'NovaModuleTools'}
             Assert-MockCalled Invoke-NovaBuildUpdateNotification -Times 1
+        }
+    }
+
+    It 'Invoke-NovaBuild delegates orchestration to the private build workflow helper' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaBuildWorkflowContext {
+                [pscustomobject]@{
+                    Target = '/tmp/dist/NovaModuleTools'
+                    Operation = 'Build Nova module output'
+                    ProjectInfo = [pscustomobject]@{ProjectName = 'NovaModuleTools'}
+                }
+            }
+            Mock Invoke-NovaBuildWorkflow {}
+
+            Invoke-NovaBuild -Confirm:$false
+
+            Assert-MockCalled Get-NovaBuildWorkflowContext -Times 1
+            Assert-MockCalled Invoke-NovaBuildWorkflow -Times 1 -ParameterFilter {
+                $WorkflowContext.Target -eq '/tmp/dist/NovaModuleTools' -and
+                        $WorkflowContext.Operation -eq 'Build Nova module output'
+            }
         }
     }
 

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -605,6 +605,30 @@ title: Invoke-NovaBuild
         }
     }
 
+    It 'Test-NovaBuild delegates orchestration to the private test workflow helper' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaTestWorkflowContext {
+                [pscustomobject]@{
+                    Target = '/tmp/nova-project/artifacts/TestResults.xml'
+                    Operation = 'Run Pester tests and write test results'
+                    PesterConfig = [pscustomobject]@{}
+                }
+            }
+            Mock Invoke-NovaTestWorkflow {}
+
+            Test-NovaBuild -Confirm:$false
+
+            Assert-MockCalled Get-NovaTestWorkflowContext -Times 1 -ParameterFilter {
+                $BoundParameters.ContainsKey('Confirm') -and
+                        $BoundParameters.Confirm -eq $false
+            }
+            Assert-MockCalled Invoke-NovaTestWorkflow -Times 1 -ParameterFilter {
+                $WorkflowContext.Target -eq '/tmp/nova-project/artifacts/TestResults.xml' -and
+                        $WorkflowContext.Operation -eq 'Run Pester tests and write test results'
+            }
+        }
+    }
+
     It 'Test-NovaBuild rejects the removed Plaintext output render mode' {
         InModuleScope $script:moduleName {
             {Test-NovaBuild -OutputRenderMode Plaintext} | Should -Throw '*Cannot validate argument on parameter*OutputRenderMode*'

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -54,11 +54,56 @@ BeforeAll {
 }
 
 Describe 'Nova command model - project, help, and build behavior' {
+    It 'Get-NovaProjectInfoContext resolves the project root, project.json path, and JSON data' {
+        InModuleScope $script:moduleName {
+            $projectRoot = Join-Path $TestDrive 'project-info-context'
+            New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+            Set-Content -LiteralPath (Join-Path $projectRoot 'project.json') -Value '{"ProjectName":"ContextProject","Version":"1.2.3"}' -Encoding utf8
+            Mock Read-ProjectJsonData {
+                [ordered]@{
+                    ProjectName = 'ContextProject'
+                    Version = '1.2.3'
+                }
+            }
+
+            $result = Get-NovaProjectInfoContext -Path $projectRoot
+
+            $result.ProjectRoot | Should -Be (Resolve-Path -LiteralPath $projectRoot).Path
+            $result.ProjectJson | Should -Be ([System.IO.Path]::Join((Resolve-Path -LiteralPath $projectRoot).Path, 'project.json'))
+            $result.JsonData.ProjectName | Should -Be 'ContextProject'
+            Assert-MockCalled Read-ProjectJsonData -Times 1 -ParameterFilter {$ProjectJsonPath -eq ([System.IO.Path]::Join((Resolve-Path -LiteralPath $projectRoot).Path, 'project.json'))}
+        }
+    }
+
     It 'Get-NovaProjectInfo -Version returns only version' {
         InModuleScope $script:moduleName {
             Mock Get-Content {'{"ProjectName":"X","Version":"9.9.9"}'}
 
             Get-NovaProjectInfo -Version | Should -Be '9.9.9'
+        }
+    }
+
+    It 'Get-NovaProjectInfo delegates context resolution and result shaping to private helpers' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaProjectInfoContext {
+                [pscustomobject]@{
+                    ProjectRoot = '/tmp/project'
+                    ProjectJson = '/tmp/project/project.json'
+                    JsonData = [ordered]@{ProjectName = 'DelegationProject'; Version = '1.0.0'}
+                }
+            }
+            Mock Get-NovaProjectInfoResult {
+                [pscustomobject]@{
+                    ProjectName = 'DelegationProject'
+                    ProjectRoot = '/tmp/project'
+                }
+            }
+
+            $result = Get-NovaProjectInfo -Path '/tmp/project'
+
+            $result.ProjectName | Should -Be 'DelegationProject'
+            Assert-MockCalled Get-NovaProjectInfoContext -Times 1 -ParameterFilter {$Path -eq '/tmp/project'}
+            Assert-MockCalled Get-NovaProjectInfoResult -Times 1 -ParameterFilter {$WorkflowContext.ProjectRoot -eq '/tmp/project' -and -not $Version}
         }
     }
 

--- a/tests/RemainingCommandCoverage.TestSupport.ps1
+++ b/tests/RemainingCommandCoverage.TestSupport.ps1
@@ -1,0 +1,82 @@
+function Get-TestNovaPesterConfig {
+    [CmdletBinding()]
+    param()
+
+    return [pscustomobject]@{
+    Run = [pscustomobject]@{
+    Path = $null
+    PassThru = $false
+    Exit = $false
+    Throw = $false
+    }
+    Filter = [pscustomobject]@{
+    Tag = @()
+    ExcludeTag = @()
+    }
+    Output = [pscustomobject]@{
+    Verbosity = 'Detailed'
+    RenderMode = 'Auto'
+    }
+    TestResult = [pscustomobject]@{
+    OutputPath = $null
+    }
+    }
+}
+
+function Get-TestNovaTestWorkflowContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$Config,
+        [Parameter(Mandatory)][string]$ProjectRoot,
+        [Parameter(Mandatory)][scriptblock]$ArtifactWriter,
+        [Parameter(Mandatory)][scriptblock]$ReportWriter
+    )
+
+    return [pscustomobject]@{
+        TestResultDirectory = [System.IO.Path]::Join($ProjectRoot, 'artifacts')
+        TestResultPath = [System.IO.Path]::Join($ProjectRoot, 'artifacts', 'TestResults.xml')
+        PesterConfig = $Config
+        TestResultArtifactWriter = [pscustomobject]@{ScriptBlock = $ArtifactWriter}
+        TestResultReportWriter = [pscustomobject]@{ScriptBlock = $ReportWriter}
+    }
+}
+
+function Get-TestNovaPesterWorkflowReportContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$Config,
+        [Parameter(Mandatory)][string]$ProjectRoot
+    )
+
+    $expectedOutputPath = [System.IO.Path]::Join($ProjectRoot, 'artifacts', 'TestResults.xml')
+    $artifactWriter = Get-TestNovaPesterArtifactWriter
+    $reportWriter = Get-TestNovaPesterReportWriter -ExpectedOutputPath $expectedOutputPath
+
+    return Get-TestNovaTestWorkflowContext -Config $Config -ProjectRoot $ProjectRoot -ArtifactWriter $artifactWriter -ReportWriter $reportWriter
+}
+
+function Get-TestNovaPesterArtifactWriter {
+    [CmdletBinding()]
+    param()
+
+    return {
+        param($TestResult, $OutputPath, $ReportWriter)
+
+        & $ReportWriter -TestResult $TestResult -OutputPath $OutputPath
+    }
+}
+
+function Get-TestNovaPesterReportWriter {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ExpectedOutputPath
+    )
+
+    return {
+        param($TestResult, $OutputPath)
+
+        $global:reportWasWritten = $null -ne $TestResult -and $OutputPath -eq $ExpectedOutputPath
+    }.GetNewClosure()
+}
+
+

--- a/tests/RemainingCommandCoverage.Tests.ps1
+++ b/tests/RemainingCommandCoverage.Tests.ps1
@@ -3,9 +3,23 @@ BeforeAll {
     $script:repoRoot = Split-Path -Parent $here
     $script:moduleName = (Get-Content -LiteralPath (Join-Path $script:repoRoot 'project.json') -Raw | ConvertFrom-Json).ProjectName
     $script:distModuleDir = Join-Path $script:repoRoot "dist/$script:moduleName"
+    $remainingCommandCoverageTestSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'RemainingCommandCoverage.TestSupport.ps1')).Path
+    $remainingCommandCoverageTestSupportFunctionNameList = @(
+        'Get-TestNovaPesterConfig'
+        'Get-TestNovaTestWorkflowContext'
+        'Get-TestNovaPesterWorkflowReportContext'
+        'Get-TestNovaPesterArtifactWriter'
+        'Get-TestNovaPesterReportWriter'
+    )
 
     if (-not (Test-Path -LiteralPath $script:distModuleDir)) {
         throw "Expected built $script:moduleName module at: $script:distModuleDir. Run Invoke-NovaBuild in the repo root first."
+    }
+
+    . $remainingCommandCoverageTestSupportPath
+    foreach ($functionName in $remainingCommandCoverageTestSupportFunctionNameList) {
+        $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
+        Set-Item -Path "function:global:$functionName" -Value $scriptBlock
     }
 
     Remove-Module $script:moduleName -ErrorAction SilentlyContinue
@@ -95,31 +109,15 @@ Describe 'Coverage for remaining command and filesystem branches' {
         }
     }
 
-    It 'Test-NovaBuild creates the artifacts directory when it is missing' {
-        $cfg = [pscustomobject]@{
-            Run = [pscustomobject]@{
-                Path = $null
-                PassThru = $false
-                Exit = $false
-                Throw = $false
-            }
-            Filter = [pscustomobject]@{
-                Tag = @()
-                ExcludeTag = @()
-            }
-            Output = [pscustomobject]@{
-                Verbosity = 'Detailed'
-                RenderMode = 'Auto'
-            }
-            TestResult = [pscustomobject]@{
-                OutputPath = $null
-            }
-        }
+    It 'Get-NovaTestWorkflowContext prepares the Pester workflow state and resolves the report writers' {
+        $cfg = Get-TestNovaPesterConfig
 
         InModuleScope $script:moduleName -Parameters @{Config = $cfg} {
             param($Config)
 
             $projectRoot = '/tmp/nova-project'
+            $artifactWriter = [pscustomobject]@{ScriptBlock = {}}
+            $reportWriter = [pscustomobject]@{ScriptBlock = {}}
 
             Mock Test-ProjectSchema {}
             Mock Get-NovaProjectInfo {
@@ -131,113 +129,71 @@ Describe 'Coverage for remaining command and filesystem branches' {
                 }
             }
             Mock New-PesterConfiguration {$Config}
-            Mock Test-Path {$false}
-            Mock New-Item {}
-            Mock Invoke-Pester {[pscustomobject]@{Result = 'Passed'}}
+            Mock Get-Command {$artifactWriter} -ParameterFilter {$Name -eq 'Write-NovaPesterTestResultArtifact' -and $CommandType -eq 'Function'}
+            Mock Get-Command {$reportWriter} -ParameterFilter {$Name -eq 'Write-NovaPesterTestResultReport' -and $CommandType -eq 'Function'}
 
-            Test-NovaBuild
+            $result = Get-NovaTestWorkflowContext -TestOption @{} -BoundParameters @{}
 
+            $result.Target | Should -Be ([System.IO.Path]::Join($projectRoot, 'artifacts', 'TestResults.xml'))
+            $result.Operation | Should -Be 'Run Pester tests and write test results'
             $Config.Run.Path | Should -Be ([System.IO.Path]::Join('tests', '*.Tests.ps1'))
             $Config.Output.RenderMode | Should -Be 'Auto'
+            $result.TestResultArtifactWriter | Should -Be $artifactWriter
+            $result.TestResultReportWriter | Should -Be $reportWriter
+        }
+    }
+
+    It 'Invoke-NovaTestWorkflow creates the artifacts directory when it is missing' {
+        $cfg = Get-TestNovaPesterConfig
+
+        InModuleScope $script:moduleName -Parameters @{Config = $cfg} {
+            param($Config)
+
+            $workflowContext = Get-TestNovaTestWorkflowContext -Config $Config -ProjectRoot '/tmp/nova-project' -ArtifactWriter {} -ReportWriter {}
+
+            Mock Test-Path {$false}
+            Mock New-Item {}
+            Mock Invoke-NovaPester {[pscustomobject]@{Result = 'Passed'}}
+
+            Invoke-NovaTestWorkflow -WorkflowContext $workflowContext
+
             Assert-MockCalled New-Item -Times 1 -ParameterFilter {
-                $ItemType -eq 'Directory' -and $Path -eq ([System.IO.Path]::Join($projectRoot, 'artifacts')) -and $Force
+                $ItemType -eq 'Directory' -and $Path -eq '/tmp/nova-project/artifacts' -and $Force
             }
+            $Config.TestResult.OutputPath | Should -Be '/tmp/nova-project/artifacts/TestResults.xml'
         }
     }
 
-    It 'Test-NovaBuild throws when Pester reports a failing result' {
-        $cfg = [pscustomobject]@{
-            Run = [pscustomobject]@{
-                Path = $null
-                PassThru = $false
-                Exit = $false
-                Throw = $false
-            }
-            Filter = [pscustomobject]@{
-                Tag = @()
-                ExcludeTag = @()
-            }
-            Output = [pscustomobject]@{
-                Verbosity = 'Detailed'
-                RenderMode = 'Auto'
-            }
-            TestResult = [pscustomobject]@{
-                OutputPath = $null
-            }
-        }
+    It 'Invoke-NovaTestWorkflow throws when Pester reports a failing result' {
+        $cfg = Get-TestNovaPesterConfig
 
         InModuleScope $script:moduleName -Parameters @{Config = $cfg} {
             param($Config)
 
-            Mock Test-ProjectSchema {}
-            Mock Get-NovaProjectInfo {
-                [pscustomobject]@{
-                    Pester = @{}
-                    BuildRecursiveFolders = $true
-                    TestsDir = 'tests'
-                    ProjectRoot = '/tmp/nova-project'
-                }
-            }
-            Mock New-PesterConfiguration {$Config}
-            Mock Test-Path {$true}
-            Mock Invoke-Pester {[pscustomobject]@{Result = 'Failed'}}
+            $workflowContext = Get-TestNovaTestWorkflowContext -Config $Config -ProjectRoot '/tmp/nova-project' -ArtifactWriter {} -ReportWriter {}
 
-            {Test-NovaBuild} | Should -Throw 'Tests failed'
+            Mock Test-Path {$true}
+            Mock Invoke-NovaPester {[pscustomobject]@{Result = 'Failed'}}
+
+            {Invoke-NovaTestWorkflow -WorkflowContext $workflowContext} | Should -Throw 'Tests failed'
         }
     }
 
-    It 'Test-NovaBuild resolves and invokes the private test result report writer when Pester returns tests' {
-        $cfg = [pscustomobject]@{
-            Run = [pscustomobject]@{
-                Path = $null
-                PassThru = $false
-                Exit = $false
-                Throw = $false
-            }
-            Filter = [pscustomobject]@{
-                Tag = @()
-                ExcludeTag = @()
-            }
-            Output = [pscustomobject]@{
-                Verbosity = 'Detailed'
-                RenderMode = 'Auto'
-            }
-            TestResult = [pscustomobject]@{
-                OutputPath = $null
-            }
-        }
+    It 'Invoke-NovaTestWorkflow resolves and invokes the private test result report writer when Pester returns tests' {
+        $cfg = Get-TestNovaPesterConfig
 
         InModuleScope $script:moduleName -Parameters @{Config = $cfg} {
             param($Config)
 
-            $script:reportWasWritten = $false
-            $projectRoot = '/tmp/nova-project'
-            $reportWriter = {
-                param($TestResult, $OutputPath, $ReportWriter)
+            $global:reportWasWritten = $false
+            $workflowContext = Get-TestNovaPesterWorkflowReportContext -Config $Config -ProjectRoot '/tmp/nova-project'
 
-                $script:reportWasWritten = $null -ne $TestResult -and $OutputPath -eq [System.IO.Path]::Join($projectRoot, 'artifacts', 'TestResults.xml')
-            }
-
-            Mock Test-ProjectSchema {}
-            Mock Get-NovaProjectInfo {
-                [pscustomobject]@{
-                    Pester = @{}
-                    BuildRecursiveFolders = $true
-                    TestsDir = 'tests'
-                    ProjectRoot = $projectRoot
-                }
-            }
-            Mock New-PesterConfiguration {$Config}
             Mock Test-Path {$true}
-            Mock Get-Command {
-                [pscustomobject]@{ScriptBlock = $reportWriter}
-            } -ParameterFilter {$Name -eq 'Write-NovaPesterTestResultArtifact' -and $CommandType -eq 'Function'}
-            Mock Invoke-Pester {[pscustomobject]@{Result = 'Passed'; Tests = @([pscustomobject]@{Result = 'Passed'})}}
+            Mock Invoke-NovaPester {[pscustomobject]@{Result = 'Passed'; Tests = @([pscustomobject]@{Result = 'Passed'})}}
 
-            Test-NovaBuild
+            Invoke-NovaTestWorkflow -WorkflowContext $workflowContext
 
-            $script:reportWasWritten | Should -BeTrue
-            Assert-MockCalled Get-Command -Times 1 -ParameterFilter {$Name -eq 'Write-NovaPesterTestResultArtifact' -and $CommandType -eq 'Function'}
+            $global:reportWasWritten | Should -BeTrue
         }
     }
 

--- a/tests/RemainingCommandCoverage.Tests.ps1
+++ b/tests/RemainingCommandCoverage.Tests.ps1
@@ -210,6 +210,89 @@ Describe 'Coverage for remaining command and filesystem branches' {
         }
     }
 
+    It 'Get-NovaCliInstallWorkflowContext resolves launcher install paths and action text' {
+        InModuleScope $script:moduleName {
+            try {
+                Set-Variable -Name IsWindows -Value $false -Force
+                Mock Get-NovaCliInstallDirectory {'/tmp/bin'}
+                Mock Get-NovaCliLauncherPath {'/tmp/source/nova'}
+                Mock Test-Path {$false}
+
+                $result = Get-NovaCliInstallWorkflowContext -DestinationDirectory '/tmp/bin' -Force
+
+                $result.SourcePath | Should -Be '/tmp/source/nova'
+                $result.TargetPath | Should -Be '/tmp/bin/nova'
+                $result.TargetDirectory | Should -Be '/tmp/bin'
+                $result.Force | Should -BeTrue
+                $result.Action | Should -Be 'Install nova CLI launcher'
+            }
+            finally {
+                Remove-Variable -Name IsWindows -Force -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    It 'Invoke-NovaCliInstallWorkflow copies the launcher and shapes the install result' {
+        InModuleScope $script:moduleName {
+            $workflowContext = [pscustomobject]@{
+                SourcePath = '/tmp/source/nova'
+                TargetPath = '/tmp/bin/nova'
+                TargetDirectory = '/tmp/bin'
+                Force = $true
+                Action = 'Install nova CLI launcher'
+            }
+            Mock Copy-NovaCliLauncher {'/tmp/bin/nova'}
+            Mock Test-NovaCliDirectoryOnPath {$true}
+            Mock Write-NovaModuleReleaseNotesLink {}
+
+            $result = Invoke-NovaCliInstallWorkflow -WorkflowContext $workflowContext
+
+            $result.CommandName | Should -Be 'nova'
+            $result.InstalledPath | Should -Be '/tmp/bin/nova'
+            $result.DestinationDirectory | Should -Be '/tmp/bin'
+            $result.DirectoryOnPath | Should -BeTrue
+            Assert-MockCalled Copy-NovaCliLauncher -Times 1 -ParameterFilter {
+                $SourcePath -eq '/tmp/source/nova' -and
+                        $TargetPath -eq '/tmp/bin/nova' -and
+                        $Force
+            }
+            Assert-MockCalled Write-NovaModuleReleaseNotesLink -Times 1
+        }
+    }
+
+    It 'Install-NovaCli delegates context resolution and install execution to private helpers' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaCliInstallWorkflowContext {
+                [pscustomobject]@{
+                    SourcePath = '/tmp/source/nova'
+                    TargetPath = '/tmp/bin/nova'
+                    TargetDirectory = '/tmp/bin'
+                    Force = $true
+                    Action = 'Install nova CLI launcher'
+                }
+            }
+            Mock Invoke-NovaCliInstallWorkflow {
+                [pscustomobject]@{
+                    CommandName = 'nova'
+                    InstalledPath = '/tmp/bin/nova'
+                    DestinationDirectory = '/tmp/bin'
+                    DirectoryOnPath = $true
+                }
+            }
+
+            $result = Install-NovaCli -DestinationDirectory '/tmp/bin' -Force -Confirm:$false
+
+            $result.InstalledPath | Should -Be '/tmp/bin/nova'
+            Assert-MockCalled Get-NovaCliInstallWorkflowContext -Times 1 -ParameterFilter {
+                $DestinationDirectory -eq '/tmp/bin' -and $Force
+            }
+            Assert-MockCalled Invoke-NovaCliInstallWorkflow -Times 1 -ParameterFilter {
+                $WorkflowContext.TargetPath -eq '/tmp/bin/nova' -and
+                        $WorkflowContext.Action -eq 'Install nova CLI launcher'
+            }
+        }
+    }
+
     It 'Install-NovaCli throws when the target file exists and Force is not used' {
         InModuleScope $script:moduleName {
             try {

--- a/tests/UpdateNotification.Tests.ps1
+++ b/tests/UpdateNotification.Tests.ps1
@@ -92,6 +92,12 @@ Describe 'Update notification behavior' {
         }
     }
 
+    It 'Get-NovaUpdateNotificationPreferenceChangeContext throws when neither enable nor disable was requested' {
+        InModuleScope $script:moduleName {
+            {Get-NovaUpdateNotificationPreferenceChangeContext} | Should -Throw 'Specify either -EnablePrereleaseNotifications or -DisablePrereleaseNotifications.'
+        }
+    }
+
     It 'Invoke-NovaUpdateNotificationPreferenceChange writes the new preference and returns the shared status' {
         InModuleScope $script:moduleName {
             $workflowContext = [pscustomobject]@{
@@ -192,32 +198,59 @@ Describe 'Update notification behavior' {
         }
     }
 
-    It 'Invoke-NovaModuleSelfUpdateWorkflow runs the self-update and marks the plan as updated' {
-        InModuleScope $script:moduleName {
-            $workflowContext = [pscustomobject]@{
-                Plan = [pscustomobject]@{
-                    ModuleName = 'NovaModuleTools'
-                    CurrentVersion = '1.0.0'
-                    TargetVersion = '1.1.0'
-                    PrereleaseNotificationsEnabled = $true
-                    UpdateAvailable = $true
-                    Updated = $false
-                    Cancelled = $false
-                    IsPrereleaseTarget = $false
-                    UsedAllowPrerelease = $false
+    It 'Invoke-NovaModuleSelfUpdateWorkflow handles both update and no-update paths correctly' {
+        foreach ($testCase in @(
+            @{
+                Name = 'update available'
+                TargetVersion = '1.1.0'
+                UpdateAvailable = $true
+                ExpectedUpdated = $true
+                ExpectedUpdateCalls = 1
+                ExpectedReleaseNotesCalls = 1
+            }
+            @{
+                Name = 'no update available'
+                TargetVersion = $null
+                UpdateAvailable = $false
+                ExpectedUpdated = $false
+                ExpectedUpdateCalls = 0
+                ExpectedReleaseNotesCalls = 0
+            }
+        )) {
+            InModuleScope $script:moduleName -Parameters @{TestCase = $testCase} {
+                param($TestCase)
+
+                $workflowContext = [pscustomobject]@{
+                    Plan = [pscustomobject]@{
+                        ModuleName = 'NovaModuleTools'
+                        CurrentVersion = '1.0.0'
+                        TargetVersion = $TestCase.TargetVersion
+                        PrereleaseNotificationsEnabled = $true
+                        UpdateAvailable = $TestCase.UpdateAvailable
+                        Updated = $false
+                        Cancelled = $false
+                        IsPrereleaseTarget = $false
+                        UsedAllowPrerelease = $false
+                    }
+                    Action = 'Update NovaModuleTools to version 1.1.0'
                 }
-                Action = 'Update NovaModuleTools to version 1.1.0'
-            }
-            Mock Invoke-NovaModuleSelfUpdate {}
-            Mock Write-NovaModuleReleaseNotesLink {}
+                if ($TestCase.ExpectedUpdateCalls -eq 0) {
+                    Mock Invoke-NovaModuleSelfUpdate {throw 'should not update'}
+                    Mock Write-NovaModuleReleaseNotesLink {throw 'should not write'}
+                }
+                else {
+                    Mock Invoke-NovaModuleSelfUpdate {}
+                    Mock Write-NovaModuleReleaseNotesLink {}
+                }
 
-            $result = Invoke-NovaModuleSelfUpdateWorkflow -WorkflowContext $workflowContext
+                $result = Invoke-NovaModuleSelfUpdateWorkflow -WorkflowContext $workflowContext
 
-            $result.Updated | Should -BeTrue
-            Assert-MockCalled Invoke-NovaModuleSelfUpdate -Times 1 -ParameterFilter {
-                $ModuleName -eq 'NovaModuleTools' -and -not $AllowPrerelease
+                $result.Updated | Should -Be $TestCase.ExpectedUpdated -Because $TestCase.Name
+                if ($TestCase.ExpectedUpdateCalls -gt 0) {
+                    Assert-MockCalled Invoke-NovaModuleSelfUpdate -Times $TestCase.ExpectedUpdateCalls
+                    Assert-MockCalled Write-NovaModuleReleaseNotesLink -Times $TestCase.ExpectedReleaseNotesCalls
+                }
             }
-            Assert-MockCalled Write-NovaModuleReleaseNotesLink -Times 1
         }
     }
 

--- a/tests/UpdateNotification.Tests.ps1
+++ b/tests/UpdateNotification.Tests.ps1
@@ -198,6 +198,22 @@ Describe 'Update notification behavior' {
         }
     }
 
+    It 'Get-NovaModuleSelfUpdateWorkflowContext throws when update lookup cannot resolve a candidate' {
+        InModuleScope $script:moduleName {
+            Mock Read-NovaUpdateNotificationPreference {[pscustomobject]@{PrereleaseNotificationsEnabled = $true}}
+            Mock Get-NovaInstalledModuleVersionInfo {[pscustomobject]@{ModuleName = 'NovaModuleTools'}}
+            Mock Invoke-NovaModuleUpdateLookup {$null}
+
+            {
+                Get-NovaModuleSelfUpdateWorkflowContext
+            } | Should -Throw 'Unable to determine a NovaModuleTools update candidate. Try again when the PowerShell Gallery is reachable.'
+
+            Assert-MockCalled Invoke-NovaModuleUpdateLookup -Times 1 -ParameterFilter {
+                $AllowPrereleaseNotifications -and $TimeoutMilliseconds -eq 10000
+            }
+        }
+    }
+
     It 'Invoke-NovaModuleSelfUpdateWorkflow handles both update and no-update paths correctly' {
         foreach ($testCase in @(
             @{

--- a/tests/UpdateNotification.Tests.ps1
+++ b/tests/UpdateNotification.Tests.ps1
@@ -150,6 +150,111 @@ Describe 'Update notification behavior' {
         }
     }
 
+    It 'Get-NovaModuleSelfUpdateWorkflowContext resolves the update plan and action text' {
+        InModuleScope $script:moduleName {
+            $preference = [pscustomobject]@{PrereleaseNotificationsEnabled = $true}
+            $installedModule = [pscustomobject]@{
+                ModuleName = 'NovaModuleTools'
+                Version = '1.0.0'
+                SemanticVersion = [semver]'1.0.0'
+                IsPrerelease = $false
+            }
+            $lookupResult = [pscustomobject]@{
+                Stable = $null
+                Prerelease = [pscustomobject]@{Version = '1.1.0-preview'}
+            }
+            Mock Get-NovaModuleSelfUpdatePlan {
+                [pscustomobject]@{
+                    ModuleName = 'NovaModuleTools'
+                    CurrentVersion = '1.0.0'
+                    TargetVersion = '1.1.0-preview'
+                    PrereleaseNotificationsEnabled = $true
+                    UpdateAvailable = $true
+                    Updated = $false
+                    Cancelled = $false
+                    IsPrereleaseTarget = $true
+                    UsedAllowPrerelease = $true
+                }
+            }
+
+            $result = Get-NovaModuleSelfUpdateWorkflowContext -Preference $preference -InstalledModule $installedModule -LookupResult $lookupResult
+
+            $result.Preference.PrereleaseNotificationsEnabled | Should -BeTrue
+            $result.InstalledModule.ModuleName | Should -Be 'NovaModuleTools'
+            $result.LookupResult.Prerelease.Version | Should -Be '1.1.0-preview'
+            $result.Plan.TargetVersion | Should -Be '1.1.0-preview'
+            $result.Action | Should -Be 'Update NovaModuleTools to prerelease version 1.1.0-preview'
+            Assert-MockCalled Get-NovaModuleSelfUpdatePlan -Times 1 -ParameterFilter {
+                $InstalledModule.ModuleName -eq 'NovaModuleTools' -and
+                        $LookupResult.Prerelease.Version -eq '1.1.0-preview' -and
+                        $PrereleaseNotificationsEnabled
+            }
+        }
+    }
+
+    It 'Invoke-NovaModuleSelfUpdateWorkflow runs the self-update and marks the plan as updated' {
+        InModuleScope $script:moduleName {
+            $workflowContext = [pscustomobject]@{
+                Plan = [pscustomobject]@{
+                    ModuleName = 'NovaModuleTools'
+                    CurrentVersion = '1.0.0'
+                    TargetVersion = '1.1.0'
+                    PrereleaseNotificationsEnabled = $true
+                    UpdateAvailable = $true
+                    Updated = $false
+                    Cancelled = $false
+                    IsPrereleaseTarget = $false
+                    UsedAllowPrerelease = $false
+                }
+                Action = 'Update NovaModuleTools to version 1.1.0'
+            }
+            Mock Invoke-NovaModuleSelfUpdate {}
+            Mock Write-NovaModuleReleaseNotesLink {}
+
+            $result = Invoke-NovaModuleSelfUpdateWorkflow -WorkflowContext $workflowContext
+
+            $result.Updated | Should -BeTrue
+            Assert-MockCalled Invoke-NovaModuleSelfUpdate -Times 1 -ParameterFilter {
+                $ModuleName -eq 'NovaModuleTools' -and -not $AllowPrerelease
+            }
+            Assert-MockCalled Write-NovaModuleReleaseNotesLink -Times 1
+        }
+    }
+
+    It 'Update-NovaModuleTool delegates workflow context resolution and execution to private helpers' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaModuleSelfUpdateWorkflowContext {
+                [pscustomobject]@{
+                    Plan = [pscustomobject]@{
+                        ModuleName = 'NovaModuleTools'
+                        CurrentVersion = '1.0.0'
+                        TargetVersion = '1.1.0'
+                        PrereleaseNotificationsEnabled = $true
+                        UpdateAvailable = $true
+                        Updated = $false
+                        Cancelled = $false
+                        IsPrereleaseTarget = $false
+                        UsedAllowPrerelease = $false
+                    }
+                    Action = 'Update NovaModuleTools to version 1.1.0'
+                }
+            }
+            Mock Invoke-NovaModuleSelfUpdateWorkflow {
+                $WorkflowContext.Plan.Updated = $true
+                return $WorkflowContext.Plan
+            }
+
+            $result = Update-NovaModuleTool -Confirm:$false
+
+            $result.Updated | Should -BeTrue
+            Assert-MockCalled Get-NovaModuleSelfUpdateWorkflowContext -Times 1
+            Assert-MockCalled Invoke-NovaModuleSelfUpdateWorkflow -Times 1 -ParameterFilter {
+                $WorkflowContext.Action -eq 'Update NovaModuleTools to version 1.1.0' -and
+                        $WorkflowContext.Plan.ModuleName -eq 'NovaModuleTools'
+            }
+        }
+    }
+
     It 'Get-NovaUpdateNotificationPreference defaults prerelease notifications to enabled when no settings file exists' {
         $configRoot = Join-Path $TestDrive 'config-default'
         $originalConfigHome = $env:XDG_CONFIG_HOME

--- a/tests/UpdateNotification.Tests.ps1
+++ b/tests/UpdateNotification.Tests.ps1
@@ -39,6 +39,40 @@ BeforeAll {
 }
 
 Describe 'Update notification behavior' {
+    It 'Get-NovaUpdateNotificationPreferenceStatus shapes the stored preference and settings path' {
+        InModuleScope $script:moduleName {
+            Mock Read-NovaUpdateNotificationPreference {
+                [pscustomobject]@{PrereleaseNotificationsEnabled = $false}
+            }
+            Mock Get-NovaUpdateSettingsFilePath {'/tmp/nova/settings.json'}
+
+            $result = Get-NovaUpdateNotificationPreferenceStatus
+
+            $result.PrereleaseNotificationsEnabled | Should -BeFalse
+            $result.StableReleaseNotificationsEnabled | Should -BeTrue
+            $result.SettingsPath | Should -Be '/tmp/nova/settings.json'
+            Assert-MockCalled Read-NovaUpdateNotificationPreference -Times 1
+            Assert-MockCalled Get-NovaUpdateSettingsFilePath -Times 1
+        }
+    }
+
+    It 'Get-NovaUpdateNotificationPreference delegates to the private status helper' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaUpdateNotificationPreferenceStatus {
+                [pscustomobject]@{
+                    PrereleaseNotificationsEnabled = $true
+                    StableReleaseNotificationsEnabled = $true
+                    SettingsPath = '/tmp/delegated-settings.json'
+                }
+            }
+
+            $result = Get-NovaUpdateNotificationPreference
+
+            $result.SettingsPath | Should -Be '/tmp/delegated-settings.json'
+            Assert-MockCalled Get-NovaUpdateNotificationPreferenceStatus -Times 1
+        }
+    }
+
     It 'Get-NovaUpdateNotificationPreference defaults prerelease notifications to enabled when no settings file exists' {
         $configRoot = Join-Path $TestDrive 'config-default'
         $originalConfigHome = $env:XDG_CONFIG_HOME

--- a/tests/UpdateNotification.Tests.ps1
+++ b/tests/UpdateNotification.Tests.ps1
@@ -73,6 +73,83 @@ Describe 'Update notification behavior' {
         }
     }
 
+    It 'Get-NovaUpdateNotificationPreferenceChangeContext resolves enable and disable actions' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaUpdateSettingsFilePath {'/tmp/nova/settings.json'}
+
+            foreach ($testCase in @(
+                @{Enable = $true; Disable = $false; ExpectedEnabled = $true; ExpectedAction = 'Enable prerelease update notifications'}
+                @{Enable = $false; Disable = $true; ExpectedEnabled = $false; ExpectedAction = 'Disable prerelease update notifications'}
+            )) {
+                $result = Get-NovaUpdateNotificationPreferenceChangeContext -EnablePrereleaseNotifications:$testCase.Enable -DisablePrereleaseNotifications:$testCase.Disable
+
+                $result.PrereleaseNotificationsEnabled | Should -Be $testCase.ExpectedEnabled
+                $result.Target | Should -Be '/tmp/nova/settings.json'
+                $result.Action | Should -Be $testCase.ExpectedAction
+            }
+
+            Assert-MockCalled Get-NovaUpdateSettingsFilePath -Times 2
+        }
+    }
+
+    It 'Invoke-NovaUpdateNotificationPreferenceChange writes the new preference and returns the shared status' {
+        InModuleScope $script:moduleName {
+            $workflowContext = [pscustomobject]@{
+                PrereleaseNotificationsEnabled = $false
+                Target = '/tmp/nova/settings.json'
+                Action = 'Disable prerelease update notifications'
+            }
+            Mock Write-NovaUpdateNotificationPreference {}
+            Mock Get-NovaUpdateNotificationPreferenceStatus {
+                [pscustomobject]@{
+                    PrereleaseNotificationsEnabled = $false
+                    StableReleaseNotificationsEnabled = $true
+                    SettingsPath = '/tmp/nova/settings.json'
+                }
+            }
+
+            $result = Invoke-NovaUpdateNotificationPreferenceChange -WorkflowContext $workflowContext
+
+            $result.PrereleaseNotificationsEnabled | Should -BeFalse
+            $result.SettingsPath | Should -Be '/tmp/nova/settings.json'
+            Assert-MockCalled Write-NovaUpdateNotificationPreference -Times 1 -ParameterFilter {
+                -not $PrereleaseNotificationsEnabled
+            }
+            Assert-MockCalled Get-NovaUpdateNotificationPreferenceStatus -Times 1
+        }
+    }
+
+    It 'Set-NovaUpdateNotificationPreference delegates context resolution and workflow execution to private helpers' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaUpdateNotificationPreferenceChangeContext {
+                [pscustomobject]@{
+                    PrereleaseNotificationsEnabled = $true
+                    Target = '/tmp/nova/settings.json'
+                    Action = 'Enable prerelease update notifications'
+                }
+            }
+            Mock Invoke-NovaUpdateNotificationPreferenceChange {
+                [pscustomobject]@{
+                    PrereleaseNotificationsEnabled = $true
+                    StableReleaseNotificationsEnabled = $true
+                    SettingsPath = '/tmp/nova/settings.json'
+                }
+            }
+
+            $result = Set-NovaUpdateNotificationPreference -EnablePrereleaseNotifications -Confirm:$false
+
+            $result.PrereleaseNotificationsEnabled | Should -BeTrue
+            Assert-MockCalled Get-NovaUpdateNotificationPreferenceChangeContext -Times 1 -ParameterFilter {
+                $EnablePrereleaseNotifications -and -not $DisablePrereleaseNotifications
+            }
+            Assert-MockCalled Invoke-NovaUpdateNotificationPreferenceChange -Times 1 -ParameterFilter {
+                $WorkflowContext.PrereleaseNotificationsEnabled -and
+                        $WorkflowContext.Target -eq '/tmp/nova/settings.json' -and
+                        $WorkflowContext.Action -eq 'Enable prerelease update notifications'
+            }
+        }
+    }
+
     It 'Get-NovaUpdateNotificationPreference defaults prerelease notifications to enabled when no settings file exists' {
         $configRoot = Join-Path $TestDrive 'config-default'
         $originalConfigHome = $env:XDG_CONFIG_HOME


### PR DESCRIPTION
## Summary

- What changed?
  - Completed the public-command maintainability refactor across Nova public entrypoints so user-facing commands now focus on orchestration while private helpers own workflow context resolution, sequencing, and result shaping.
  - Refactored these public commands into thinner orchestration layers:
    - `Invoke-NovaBuild`
    - `Test-NovaBuild`
    - `Update-NovaModuleVersion`
    - `Publish-NovaModule`
    - `Invoke-NovaRelease`
    - `New-NovaModulePackage`
    - `Deploy-NovaPackage`
    - `Get-NovaProjectInfo`
    - `Get-NovaUpdateNotificationPreference`
    - `Set-NovaUpdateNotificationPreference`
    - `Update-NovaModuleTool`
    - `Install-NovaCli`
    - `Initialize-NovaModule`
    - `Invoke-NovaCli`
  - Added focused private workflow/context helpers and seam-level tests to make routing and workflow behavior easier to review and maintain.
- Why was this change needed?
  - Public commands were carrying too much mixed responsibility across orchestration, domain/workflow decisions, and infrastructure side effects.
  - That made the code harder to understand, harder to test in isolation, and harder to evolve consistently.
  - The refactor establishes a repeatable pattern for future Nova command work and keeps Code Health at the target standard for touched files.
- Link the issue, discussion, or follow-up work (for example `Closes #123`).
  - Follow-up plan: private CLI helper consolidation and sharper contracts tracked in `plan.md`.

## Affected area

- [x] `nova` CLI or command routing
- [x] Public PowerShell cmdlet behavior
- [x] Scaffolding or `project.json` handling
- [x] Build, test, analyzer, coverage, or CI helper flow
- [x] Package, raw upload, or package metadata workflow
- [x] Publish, release, semantic-release, or GitHub Actions automation
- [x] Self-update or notification preference behavior
- [ ] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
- [ ] End-user docs (`docs/*.html`)
- [ ] Command help (`docs/NovaModuleTools/en-US/*.md`)
- [ ] `src/resources/example/`
- [ ] Dependency or manifest changes (`package.json`, workflow dependencies, release tooling)
- [ ] Security-sensitive change
- [ ] Documentation-only change
- [x] Other

## Review guidance

- Highlight the main code path or workflow reviewers should start with.
  - Start with `src/public/InvokeNovaCli.ps1` and compare it with the new private CLI seams:
    - `src/private/cli/GetNovaCliInvocationContext.ps1`
    - `src/private/cli/InvokeNovaCliCommandRoute.ps1`
  - Then review representative public-command patterns in:
    - `src/public/UpdateNovaModuleTools.ps1`
    - `src/public/InstallNovaCli.ps1`
    - `src/public/InitializeNovaModule.ps1`
    - `src/public/GetNovaProjectInfo.ps1`
  - Finally review how the seam tests protect the new boundaries in:
    - `tests/CoverageGaps.Cli.Tests.ps1`
    - `tests/CoverageGaps.Tests.ps1`
    - `tests/UpdateNotification.Tests.ps1`
    - `tests/RemainingCommandCoverage.Tests.ps1`
- Call out the primary files or folders changed (for example `src/public/`, `src/private/cli/`, `scripts/build/ci/`,
  `.github/workflows/`, `docs/`, or `src/resources/example/`).
  - Primary folders:
    - `src/public/`
    - `src/private/cli/`
    - `src/private/update/`
    - `src/private/scaffold/`
    - `src/private/shared/`
    - `src/private/package/`
    - `tests/`
  - Documentation touched during the initiative:
    - `CHANGELOG.md`
- Call out any trade-offs, follow-up work, or known limitations.
  - Trade-off: the code now has more small private helpers, but the boundaries are more explicit and easier to test.
  - Follow-up work is already identified in `plan.md` for reviewing private CLI helpers for further consolidation and sharper contracts.
  - Known limitation: the CLI layer is clearer than before, but some private CLI helpers may still be small pass-through seams that should be reviewed for cohesion in the next pass.

## Validation

- [x] `Invoke-NovaBuild`
- [x] `Test-NovaBuild`
- [x] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
- [x] Targeted Nova workflow validated (`nova build`, `nova test`, `nova merge`, `nova deploy`, `nova publish`,
  `nova release`, `nova update`, `nova notification`, or `nova init` as relevant)
- [ ] Docs/example only; executable validation not needed

Validation notes:

```text
Most relevant final validation state for the completed initiative:

- Full repository validation:
  pwsh -NoLogo -NoProfile -File "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools/run.ps1"
  Result: Tests Passed: 362, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 0

- Focused workflow suites were also exercised incrementally during the initiative, including:
  - ./tests/CoverageGaps.Cli.Tests.ps1
  - ./tests/NovaCommandModel.StandaloneCli.Tests.ps1
  - ./tests/CoverageGaps.Tests.ps1
  - ./tests/UpdateNotification.Tests.ps1
  - ./tests/RemainingCommandCoverage.Tests.ps1
  - ./tests/NovaCommandModel.Tests.ps1
  - ./tests/NovaCommandModel.BumpAndCli.Tests.ps1
  - ./tests/NovaCommandModel.ReleasePublish.Tests.ps1
  - ./tests/NovaCommandModel.PackageUpload.Tests.ps1

- Final workspace checks:
  - git --no-pager diff --check → passed
  - pre-commit Code Health safeguard → passed

- Targeted Nova workflows validated during the initiative:
  - nova init
  - nova update
  - nova notification
  - nova deploy
  - nova publish
  - nova release
  - nova package
  - nova version

- ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1 was not run as part of the final closeout summary.
```

## Documentation and release follow-up

- [ ] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
- [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
- [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [ ] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
- [ ] `docs/*.html` updated if end-user workflows or examples changed
- [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
  changed
- [x] No documentation, changelog, or example updates were needed

## Maintainability, compatibility, and risk

- [x] Code Health / maintainability impact considered
- [x] No breaking change
- [ ] Breaking change
- [ ] Security-sensitive change
- [ ] CI, workflow, or release-pipeline impact
- [ ] Dependency-review impact

Risk, rollout, or rollback notes:

```text
Compatibility impact is intended to be internal/architectural only.
No public command contracts were intentionally changed.

Primary risk:
- accidental routing or orchestration regressions in CLI and public command flows

Mitigation:
- incremental seam tests were added as each flow was refactored
- focused workflow suites were run repeatedly
- the full repository run.ps1 pipeline passed at the end
- Code Health remained at the target standard for touched files

Rollback strategy:
- revert the refactor commits for the affected public command family if a workflow-specific regression appears
- because behavior was kept stable and changes were made in small steps, rollback can be done command-by-command if needed
```

> [!IMPORTANT]
> Do not use a public pull request to disclose a vulnerability before coordinated handling.
> Use the private reporting path in `SECURITY.md` for new security issues.

