### PR TITLE
Feature/95 introduce a more consistent central error model for novamoduletools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failures,
   and local installed-version lookup so the remaining environment and dependency flows can be verified with structured
   assertions instead of brittle whole-message checks.
+- Continue the shared error-model migration for test workflow failures, duplicate-function validation, preamble and
+  manifest validation, help-locale conflicts, and package output safety checks so more build and packaging paths expose
+  stable error ids and categories.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add optional `Preamble` support in `project.json` to write module-level setup lines at the top of generated `.psm1`
   files.
 - Add `Initialize-NovaModule -Example` and `nova init -Example` to scaffold a full working project from the packaged
-  example
-  resources.
+  example resources.
+- git initialization failures so more build and release paths now expose stable error ids and categories.
     - Runs the normal init flow
     - Applies the metadata entered during init to the generated `project.json`
     - Always creates the example test structure without prompting to enable tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Continue the shared error-model migration for local installed-version CLI checks, no-commit version bump handling,
   and invalid package-type project loading so more public command coverage now asserts stable error ids and categories
   instead of brittle whole-message matches.
+- Continue the shared error-model migration for `project.json` schema validation so Build/Pester schema failures now
+  expose a stable error id and category instead of raw `Test-Json` exception text.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Continue the shared error-model migration for public self-update entrypoints so `Update-NovaModuleTool` and
   `nova update` now expose a stable self-update failure id and category while preserving the underlying
   `Update-Module` guidance text.
+- Finish the broader repo-wide assertion cleanup so only the two intentional wording-contract checks remain
+  message-based;
+  all other remaining test failures now use explicit captured-error assertions or structured error checks.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix configuration and validation errors so empty `project.json` files and unsupported `Manifest` keys fail fast with
   clear messages.
+- Continue the shared error-model migration for package upload, build help/manifest, package metadata, and version bump
+  workflow failures so tests can assert stable error ids and categories without losing the existing user guidance.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,9 +69,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change `CopyResourcesToModuleRoot` to the canonical project setting name while keeping the default value `false`.
 - Change `Publish-NovaModule -Local` and `nova publish -local` so a successful local publish also reloads the published
   module from the local install path into the active PowerShell session.
-- Introduce a shared Nova error-record pattern across the current project-loading, shared validation, and CLI
-  parsing/help flows so those failures can expose stable error ids and categories while preserving clear user-facing
-  messages.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,25 +74,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix configuration and validation errors so empty `project.json` files and unsupported `Manifest` keys fail fast with
   clear messages.
-- Continue the shared error-model migration for package upload, build help/manifest, package metadata, and version bump
-  workflow failures so tests can assert stable error ids and categories without losing the existing user guidance.
-- Continue the shared error-model migration for CLI launcher/route failures, package repository and upload request
-  failures,
-  and local installed-version lookup so the remaining environment and dependency flows can be verified with structured
-  assertions instead of brittle whole-message checks.
-- Continue the shared error-model migration for test workflow failures, duplicate-function validation, preamble and
-  manifest validation, help-locale conflicts, and package output safety checks so more build and packaging paths expose
-  stable error ids and categories.
-- Continue the shared error-model migration for scaffold project-name validation, scaffold base-path checks, and
-  existing-project detection so the remaining initialization paths expose stable error ids and categories.
-- Continue the shared error-model migration for update-notification selection, self-update candidate lookup, release
-  publish dist checks, and packaged example configuration lookup so those remaining update/release/example paths expose
-  stable error ids and categories.
-- Continue the shared error-model migration for local installed-version CLI checks, no-commit version bump handling,
-  and invalid package-type project loading so more public command coverage now asserts stable error ids and categories
-  instead of brittle whole-message matches.
-- Continue the shared error-model migration for `project.json` schema validation so Build/Pester schema failures now
-  expose a stable error id and category instead of raw `Test-Json` exception text.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix configuration and validation errors so empty `project.json` files and unsupported `Manifest` keys fail fast with
   clear messages.
+- Continue the shared error-model migration for standalone CLI argument failures so removed subcommands, unsupported
+  `nova init` usage, and unknown CLI tokens are verified through stable error ids and categories instead of raw
+  whole-message matches.
+- Continue the shared error-model migration for CI coverage remapping so missing built-module source markers now expose
+  a stable coverage error id and category instead of a raw script throw.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,17 +40,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       appending or incrementing trailing digits, for example `preview -> preview01`, `preview09 -> preview10`,
       `rc -> rc01`, `rc1 -> rc2`, `SNAPSHOT -> SNAPSHOT01`, and `SNAPSHOT1 -> SNAPSHOT2`.
 - Add `New-NovaModulePackage` and `nova package` so projects can build, test, and package the built module output as a
-  `.nupkg`
-  artifact by using generic metadata from `project.json`, including repositories whose test runs reload or remove
+  `.nupkg` artifact by using generic metadata from `project.json`, including repositories whose test runs reload or
+  remove
   `NovaModuleTools` before the final package step.
-    - Package output now supports `Package.Types` with case-insensitive `NuGet`, `Zip`, `.nupkg`, and `.zip` values.
+    - Package output supports `Package.Types` with case-insensitive `NuGet`, `Zip`, `.nupkg`, and `.zip` values.
     - Omitting `Package.Types` still defaults packaging to a `.nupkg` artifact.
     - Selecting both `NuGet` and `Zip` creates both package formats in the configured output directory.
   - `Package.AddVersionToFileName` can append the top-level project version to a custom `Package.PackageFileName`
     before the package extension is applied.
   - Setting `Package.Latest` to `true` also creates a companion `*.latest.*` artifact for each selected package type
     while keeping the normal versioned file.
-    - Package output now uses `Package.OutputDirectory.Path` with `Package.OutputDirectory.Clean` defaulting to `true`.
+      - Package output uses `Package.OutputDirectory.Path` with `Package.OutputDirectory.Clean` defaulting to `true`.
   - Add `Deploy-NovaPackage` and `nova deploy` for raw HTTP package uploads that stay separate from PowerShell
     repository publishing.
       - Package upload resolves `-Url`, `Package.RepositoryUrl`, or named `Package.Repositories` targets and can merge
@@ -63,34 +63,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change the project to a Nova command model, replacing the previous mixed MT/Nova workflow.
     - All public commands are now Nova commands, and the `nova` CLI/Powershell alias is the primary entry point for all
       operations.
-- Clarify `Invoke-NovaBuild` layering so the public command focuses on orchestration while private helpers own build
-  workflow context, sequencing, and explicit reuse of resolved project metadata.
-- Clarify `Get-NovaProjectInfo` layering so the public command focuses on orchestration while private helpers own
-  project-info context resolution and result shaping.
-- Clarify `Get-NovaUpdateNotificationPreference` layering so the public command focuses on orchestration while private
-  helpers own notification-status shaping and settings-path resolution.
-- Clarify `Set-NovaUpdateNotificationPreference` layering so the public command focuses on orchestration while private
-  helpers own preference-change context resolution and write/status sequencing.
-- Clarify `Update-NovaModuleTool` layering so the public command focuses on orchestration while private helpers own
-  self-update workflow context resolution and update/release-notes execution.
-- Clarify `Install-NovaCli` layering so the public command focuses on orchestration while private helpers own install
-  workflow context resolution and launcher install execution.
-- Clarify `Initialize-NovaModule` layering so the public command focuses on orchestration while private helpers own
-  scaffold workflow context resolution and scaffold/project-file execution.
-- Clarify `Invoke-NovaCli` layering so the public command focuses on orchestration while private helpers own CLI
-  invocation-context preparation and command routing.
-- Clarify `Test-NovaBuild` layering so the public command focuses on orchestration while private helpers own Pester
-  workflow context, artifact preparation, and pass/fail translation.
-- Clarify `New-NovaModulePackage` layering so the public command focuses on orchestration while private helpers own
-  package workflow context, build/test/package sequencing, and package-helper reload fallback.
-- Clarify `Deploy-NovaPackage` layering so the public command focuses on orchestration while private helpers own upload
-  workflow context, upload planning, and artifact upload sequencing.
-- Clarify `Update-NovaModuleVersion` layering so the public command focuses on orchestration while private helpers own
-  bump workflow context, result shaping, and version persistence.
-- Clarify publish and release layering so public commands focus on orchestration while private workflow helpers own
-  publish/release sequencing and shared publish context resolution.
-- Centralize runtime `project.json` writing behind one shared helper so scaffold and version-bump flows use the same
-  serialization policy for nested arrays, nested objects, JSON depth, and UTF-8 output.
 - **BREAKING CHANGE**: Rename the public Nova scaffold cmdlets to approved verbs.
     - `New-NovaModule` → `Initialize-NovaModule`
     - No compatibility aliases are exported for the retired cmdlet names or CLI subcommands.
@@ -102,10 +74,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix configuration and validation errors so empty `project.json` files and unsupported `Manifest` keys fail fast with
   clear messages.
-- Fix `Update-NovaModuleVersion` / `nova bump` so prerelease versions finalize the correct SemVer target instead of
-  carrying old prerelease labels like `preview7` into the next major, minor, or patch line.
-- Fix `Update-NovaModuleVersion` / `nova bump` so bumping `project.json` preserves nested `Package.Repositories` and
-  other nested JSON objects instead of truncating them during serialization.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,17 +74,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix configuration and validation errors so empty `project.json` files and unsupported `Manifest` keys fail fast with
   clear messages.
-- Continue the shared error-model migration for standalone CLI argument failures so removed subcommands, unsupported
-  `nova init` usage, and unknown CLI tokens are verified through stable error ids and categories instead of raw
-  whole-message matches.
-- Continue the shared error-model migration for CI coverage remapping so missing built-module source markers now expose
-  a stable coverage error id and category instead of a raw script throw.
-- Continue the shared error-model migration for public self-update entrypoints so `Update-NovaModuleTool` and
-  `nova update` now expose a stable self-update failure id and category while preserving the underlying
-  `Update-Module` guidance text.
-- Finish the broader repo-wide assertion cleanup so only the two intentional wording-contract checks remain
-  message-based;
-  all other remaining test failures now use explicit captured-error assertions or structured error checks.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change `CopyResourcesToModuleRoot` to the canonical project setting name while keeping the default value `false`.
 - Change `Publish-NovaModule -Local` and `nova publish -local` so a successful local publish also reloads the published
   module from the local install path into the active PowerShell session.
+- Introduce a shared Nova error-record pattern across the current project-loading, shared validation, and CLI
+  parsing/help flows so those failures can expose stable error ids and categories while preserving clear user-facing
+  messages.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Continue the shared error-model migration for test workflow failures, duplicate-function validation, preamble and
   manifest validation, help-locale conflicts, and package output safety checks so more build and packaging paths expose
   stable error ids and categories.
+- Continue the shared error-model migration for scaffold project-name validation, scaffold base-path checks, and
+  existing-project detection so the remaining initialization paths expose stable error ids and categories.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stable error ids and categories.
 - Continue the shared error-model migration for scaffold project-name validation, scaffold base-path checks, and
   existing-project detection so the remaining initialization paths expose stable error ids and categories.
+- Continue the shared error-model migration for update-notification selection, self-update candidate lookup, release
+  publish dist checks, and packaged example configuration lookup so those remaining update/release/example paths expose
+  stable error ids and categories.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   clear messages.
 - Continue the shared error-model migration for package upload, build help/manifest, package metadata, and version bump
   workflow failures so tests can assert stable error ids and categories without losing the existing user guidance.
+- Continue the shared error-model migration for CLI launcher/route failures, package repository and upload request
+  failures,
+  and local installed-version lookup so the remaining environment and dependency flows can be verified with structured
+  assertions instead of brittle whole-message checks.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Continue the shared error-model migration for update-notification selection, self-update candidate lookup, release
   publish dist checks, and packaged example configuration lookup so those remaining update/release/example paths expose
   stable error ids and categories.
+- Continue the shared error-model migration for local installed-version CLI checks, no-commit version bump handling,
+  and invalid package-type project loading so more public command coverage now asserts stable error ids and categories
+  instead of brittle whole-message matches.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whole-message matches.
 - Continue the shared error-model migration for CI coverage remapping so missing built-module source markers now expose
   a stable coverage error id and category instead of a raw script throw.
+- Continue the shared error-model migration for public self-update entrypoints so `Update-NovaModuleTool` and
+  `nova update` now expose a stable self-update failure id and category while preserving the underlying
+  `Update-Module` guidance text.
 
 ### Documentation
 

--- a/scripts/build/ci/CodeSceneCoverageMap.ps1
+++ b/scripts/build/ci/CodeSceneCoverageMap.ps1
@@ -4,6 +4,22 @@ function ConvertTo-CoberturaRelativePath {
     return ($Path -replace '\\', '/')
 }
 
+function Get-CodeSceneCoverageErrorRecord {
+    param(
+        [Parameter(Mandatory)][string]$Message,
+        [Parameter(Mandatory)][string]$ErrorId,
+        [Parameter(Mandatory)][System.Management.Automation.ErrorCategory]$Category,
+        [AllowNull()]$TargetObject
+    )
+
+    return [System.Management.Automation.ErrorRecord]::new(
+            [System.InvalidOperationException]::new($Message),
+            $ErrorId,
+            $Category,
+            $TargetObject
+    )
+}
+
 function Get-SourceSectionListFromBuiltModule {
     param(
         [Parameter(Mandatory)][string]$BuiltModulePath,
@@ -12,14 +28,14 @@ function Get-SourceSectionListFromBuiltModule {
 
     $sourceMarkers = Select-String -Path $BuiltModulePath -Pattern '^# Source:\s+(.+)$'
     if (@($sourceMarkers).Count -eq 0) {
-        throw "Could not find any '# Source:' markers in built module: $BuiltModulePath"
+        throw (Get-CodeSceneCoverageErrorRecord -Message "Could not find any '# Source:' markers in built module: $BuiltModulePath" -ErrorId 'Nova.Coverage.BuiltModuleSourceMarkersMissing' -Category ObjectNotFound -TargetObject $BuiltModulePath)
     }
 
     $sections = foreach ($sourceMarker in $sourceMarkers) {
         $relativePath = ConvertTo-CoberturaRelativePath $sourceMarker.Matches[0].Groups[1].Value.Trim()
         $sourcePath = Join-Path $RepoRoot $relativePath
         if (-not (Test-Path -LiteralPath $sourcePath)) {
-            throw "Source file referenced by built module was not found: $sourcePath"
+            throw (Get-CodeSceneCoverageErrorRecord -Message "Source file referenced by built module was not found: $sourcePath" -ErrorId 'Nova.Coverage.BuiltModuleSourceFileNotFound' -Category ObjectNotFound -TargetObject $sourcePath)
         }
 
         $sourceLineCount = @(Get-Content -LiteralPath $sourcePath).Count
@@ -164,13 +180,13 @@ function Get-CoberturaLineBucketMap {
     [xml]$originalCoverageXml = Get-Content -LiteralPath $CoveragePath -Raw
     $originalCoverageNode = $originalCoverageXml.SelectSingleNode('/coverage')
     if ($null -eq $originalCoverageNode) {
-        throw "No Cobertura coverage root node was found in coverage file: $CoveragePath"
+        throw (Get-CodeSceneCoverageErrorRecord -Message "No Cobertura coverage root node was found in coverage file: $CoveragePath" -ErrorId 'Nova.Coverage.CoberturaRootNodeNotFound' -Category InvalidData -TargetObject $CoveragePath)
     }
 
     $sourceSections = Get-SourceSectionListFromBuiltModule -BuiltModulePath $BuiltModulePath -RepoRoot $RepoRoot
     $classNodes = @($originalCoverageXml.SelectNodes('/coverage/packages/package/classes/class'))
     if (@($classNodes).Count -eq 0) {
-        throw "No Cobertura class nodes were found in coverage file: $CoveragePath"
+        throw (Get-CodeSceneCoverageErrorRecord -Message "No Cobertura class nodes were found in coverage file: $CoveragePath" -ErrorId 'Nova.Coverage.CoberturaClassNodesNotFound' -Category InvalidData -TargetObject $CoveragePath)
     }
 
     $sourceLineRange = Get-CoberturaSourceLineRange -Sections $sourceSections
@@ -188,7 +204,7 @@ function Get-CoberturaLineBucketMap {
 
     if (@($unmappedLineNumbers).Count -gt 0) {
         $preview = ($unmappedLineNumbers | Sort-Object -Unique | Select-Object -First 10) -join ', '
-        throw "Could not map one or more covered built-module lines back to source files. Example line numbers: $preview"
+        throw (Get-CodeSceneCoverageErrorRecord -Message "Could not map one or more covered built-module lines back to source files. Example line numbers: $preview" -ErrorId 'Nova.Coverage.CoberturaLineMappingFailed' -Category InvalidData -TargetObject $preview)
     }
 
     return [pscustomobject]@{

--- a/src/private/build/BuildHelp.ps1
+++ b/src/private/build/BuildHelp.ps1
@@ -14,7 +14,7 @@ function Build-Help {
     }
     
     if (-not (Get-Module -Name Microsoft.PowerShell.PlatyPS -ListAvailable)) {
-        throw 'The module Microsoft.PowerShell.PlatyPS must be installed for Markdown documentation to be generated.'
+        Stop-NovaOperation -Message 'The module Microsoft.PowerShell.PlatyPS must be installed for Markdown documentation to be generated.' -ErrorId 'Nova.Dependency.BuildHelpDependencyMissing' -Category ResourceUnavailable -TargetObject 'Microsoft.PowerShell.PlatyPS'
     }
 
     $AllCommandHelpFiles = $helpMarkdownFiles | Measure-PlatyPSMarkdown | Where-Object FileType -Match CommandHelp

--- a/src/private/build/BuildManifest.ps1
+++ b/src/private/build/BuildManifest.ps1
@@ -66,6 +66,6 @@ function Build-Manifest {
     try {
         New-ModuleManifest @ParmsManifest
     } catch {
-        throw ('Failed to create Manifest: {0}' -f $_.Exception.Message)
+        Stop-NovaOperation -Message ('Failed to create Manifest: {0}' -f $_.Exception.Message) -ErrorId 'Nova.Dependency.ModuleManifestCreationFailed' -Category OpenError -TargetObject $data.ManifestFilePSD1
     }
 }

--- a/src/private/build/BuildModule.ps1
+++ b/src/private/build/BuildModule.ps1
@@ -19,7 +19,7 @@ function Build-Module {
     )
 
     if ($files.Count -eq 0 -and $allSourceFiles.Count -eq 0) {
-        throw 'No source files found to build. Add one or more scripts under src/public, src/private, or src/classes.'
+        Stop-NovaOperation -Message 'No source files found to build. Add one or more scripts under src/public, src/private, or src/classes.' -ErrorId 'Nova.Environment.BuildSourceFilesNotFound' -Category ObjectNotFound -TargetObject 'src'
     }
 
     foreach ($file in $files) {
@@ -28,6 +28,6 @@ function Build-Module {
     try {
         Set-Content -Path $data.ModuleFilePSM1 -Value $sb.ToString() -Encoding 'UTF8' # psm1 file
     } catch {
-        throw ('Failed to create psm1 file: {0}' -f $_.Exception.Message)
+        Stop-NovaOperation -Message ('Failed to create psm1 file: {0}' -f $_.Exception.Message) -ErrorId 'Nova.Dependency.ModulePsm1CreationFailed' -Category OpenError -TargetObject $data.ModuleFilePSM1
     }
 }

--- a/src/private/build/Get-ProjectPreamble.ps1
+++ b/src/private/build/Get-ProjectPreamble.ps1
@@ -12,7 +12,7 @@ function Get-ProjectPreamble {
     if ($preamble -is [string] -or $preamble -isnot [System.Collections.IEnumerable]) {
         $typeName = Get-ProjectJsonValueTypeName -Value $preamble
         $valueText = Format-ProjectJsonValue -Value $preamble
-        throw "Invalid project.json Preamble value: expected top-level Preamble as string[] but found type '$typeName' with value $valueText. Preamble must be a top-level project.json array of strings."
+        Stop-NovaOperation -Message "Invalid project.json Preamble value: expected top-level Preamble as string[] but found type '$typeName' with value $valueText. Preamble must be a top-level project.json array of strings." -ErrorId 'Nova.Configuration.ProjectPreambleInvalidType' -Category InvalidData -TargetObject $preamble
     }
 
     $lines = New-Object 'System.Collections.Generic.List[string]'
@@ -21,7 +21,7 @@ function Get-ProjectPreamble {
         if ($item -isnot [string]) {
             $typeName = Get-ProjectJsonValueTypeName -Value $item
             $valueText = Format-ProjectJsonValue -Value $item
-            throw "Invalid project.json Preamble value: expected top-level Preamble as string[] but found entry at index $index with type '$typeName' and value $valueText. Preamble must be a top-level project.json array of strings."
+            Stop-NovaOperation -Message "Invalid project.json Preamble value: expected top-level Preamble as string[] but found entry at index $index with type '$typeName' and value $valueText. Preamble must be a top-level project.json array of strings." -ErrorId 'Nova.Configuration.ProjectPreambleInvalidType' -Category InvalidData -TargetObject $item
         }
 
         $lines.Add($item)

--- a/src/private/build/GetNovaHelpLocale.ps1
+++ b/src/private/build/GetNovaHelpLocale.ps1
@@ -14,7 +14,7 @@ function Get-NovaHelpLocale {
     $distinctLocales = @($locales | Where-Object {-not [string]::IsNullOrWhiteSpace($_)} | Select-Object -Unique)
 
     if ($distinctLocales.Count -gt 1) {
-        throw "Multiple help locales found in docs metadata: $( $distinctLocales -join ', ' )"
+        Stop-NovaOperation -Message "Multiple help locales found in docs metadata: $( $distinctLocales -join ', ' )" -ErrorId 'Nova.Configuration.HelpLocaleConflict' -Category InvalidData -TargetObject $distinctLocales
     }
 
     if ($distinctLocales.Count -eq 1) {

--- a/src/private/build/ResetProjectDist.ps1
+++ b/src/private/build/ResetProjectDist.ps1
@@ -13,6 +13,6 @@ function Reset-ProjectDist {
         New-Item -Path $data.OutputDir -ItemType Directory -Force -ErrorAction Stop | Out-Null # Dist folder
         New-Item -Path $data.OutputModuleDir -Type Directory -Force -ErrorAction Stop | Out-Null # Module Folder
     } catch {
-        throw "Failed to reset Dist folder: $( $_.Exception.Message )"
+        Stop-NovaOperation -Message "Failed to reset Dist folder: $( $_.Exception.Message )" -ErrorId 'Nova.Dependency.DistResetFailed' -Category OpenError -TargetObject $data.OutputDir
     }
 }

--- a/src/private/build/TestProjectSchema.ps1
+++ b/src/private/build/TestProjectSchema.ps1
@@ -11,13 +11,19 @@ function Test-ProjectSchema {
         Build  = Get-ResourceFilePath -FileName 'Schema-Build.json'
         Pester = Get-ResourceFilePath -FileName 'Schema-Pester.json'
     }
-    $result = switch ($Schema) {
-        'Build' {
-            Test-Json -Path 'project.json' -Schema (Get-Content $SchemaPath.Build -Raw)
-        }
-        'Pester' {
-            Test-Json -Path 'project.json' -Schema (Get-Content $SchemaPath.Pester -Raw)
+    try {
+        $result = switch ($Schema) {
+            'Build' {
+                Test-Json -Path 'project.json' -Schema (Get-Content $SchemaPath.Build -Raw)
+            }
+            'Pester' {
+                Test-Json -Path 'project.json' -Schema (Get-Content $SchemaPath.Pester -Raw)
+            }
         }
     }
+    catch {
+        Stop-NovaOperation -Message "Invalid project.json for the $Schema schema: $( $_.Exception.Message )" -ErrorId 'Nova.Configuration.ProjectSchemaValidationFailed' -Category InvalidData -TargetObject 'project.json'
+    }
+
     return $result
 }

--- a/src/private/build/manifest/AssertManifestSchema.ps1
+++ b/src/private/build/manifest/AssertManifestSchema.ps1
@@ -15,5 +15,5 @@ function Assert-ManifestSchema {
         return
     }
 
-    throw "Unknown parameter(s) in Manifest: $( $unknownParameter -join ', ' )"
+    Stop-NovaOperation -Message "Unknown parameter(s) in Manifest: $( $unknownParameter -join ', ' )" -ErrorId 'Nova.Configuration.ManifestUnknownParameter' -Category InvalidData -TargetObject $unknownParameter
 }

--- a/src/private/cli/AddNovaCliHeaderOption.ps1
+++ b/src/private/cli/AddNovaCliHeaderOption.ps1
@@ -6,15 +6,17 @@ function Add-NovaCliHeaderOption {
     )
 
     $separatorIndex = $HeaderArgument.IndexOf('=')
-    if ($separatorIndex -lt 1) {
-        throw "Invalid header argument: $HeaderArgument. Use Name=Value."
+    $headerName = if ($separatorIndex -ge 1) {
+        $HeaderArgument.Substring(0, $separatorIndex).Trim()
+    }
+    else {
+        $null
+    }
+    if ($separatorIndex -lt 1 -or [string]::IsNullOrWhiteSpace($headerName)) {
+        Stop-NovaOperation -Message "Invalid header argument: $HeaderArgument. Use Name=Value." -ErrorId 'Nova.Validation.InvalidCliHeaderArgument' -Category InvalidArgument -TargetObject $HeaderArgument
     }
 
-    $headerName = $HeaderArgument.Substring(0, $separatorIndex).Trim()
     $headerValue = $HeaderArgument.Substring($separatorIndex + 1)
-    if ( [string]::IsNullOrWhiteSpace($headerName)) {
-        throw "Invalid header argument: $HeaderArgument. Use Name=Value."
-    }
 
     if (-not $Options.ContainsKey('Headers')) {
         $Options.Headers = @{}

--- a/src/private/cli/ConvertFromNovaBumpCliArgument.ps1
+++ b/src/private/cli/ConvertFromNovaBumpCliArgument.ps1
@@ -13,7 +13,7 @@ function ConvertFrom-NovaBumpCliArgument {
                 $options.Preview = $true
             }
             default {
-                throw "Unknown argument: $token"
+                Stop-NovaOperation -Message "Unknown argument: $token" -ErrorId 'Nova.Validation.UnknownCliArgument' -Category InvalidArgument -TargetObject $token
             }
         }
     }

--- a/src/private/cli/ConvertFromNovaDeployCliArgument.ps1
+++ b/src/private/cli/ConvertFromNovaDeployCliArgument.ps1
@@ -40,7 +40,7 @@ function ConvertFrom-NovaDeployCliArgument {
                 Add-NovaCliHeaderOption -Options $options -HeaderArgument (Get-NovaCliRequiredArgumentValue -Arguments $Arguments -Index ([ref]$index) -OptionName '--header')
             }
             default {
-                throw "Unknown argument: $token"
+                Stop-NovaOperation -Message "Unknown argument: $token" -ErrorId 'Nova.Validation.UnknownCliArgument' -Category InvalidArgument -TargetObject $token
             }
         }
 

--- a/src/private/cli/ConvertFromNovaInitCliArgument.ps1
+++ b/src/private/cli/ConvertFromNovaInitCliArgument.ps1
@@ -13,22 +13,17 @@ function ConvertFrom-NovaInitCliArgument {
 
         switch -Regex ($token) {
             '^(--path|-Path)$' {
-                $index++
-                if ($index -ge $Arguments.Count) {
-                    throw 'Missing value for --path'
-                }
-
-                $options.Path = $Arguments[$index]
+                $options.Path = Get-NovaCliRequiredArgumentValue -Arguments $Arguments -Index ([ref]$index) -OptionName '--path'
             }
             '^(--example|-Example)$' {
                 $options.Example = $true
             }
             default {
                 if ( $token.StartsWith('-')) {
-                    throw "Unknown argument: $token"
+                    Stop-NovaOperation -Message "Unknown argument: $token" -ErrorId 'Nova.Validation.UnknownCliArgument' -Category InvalidArgument -TargetObject $token
                 }
 
-                throw "Unsupported 'nova init' usage: positional paths are no longer accepted. Use 'nova init -Path $token' instead."
+                Stop-NovaOperation -Message "Unsupported 'nova init' usage: positional paths are no longer accepted. Use 'nova init -Path $token' instead." -ErrorId 'Nova.Validation.UnsupportedInitCliUsage' -Category InvalidArgument -TargetObject $token
             }
         }
 

--- a/src/private/cli/ConvertFromNovaNotificationCliArgument.ps1
+++ b/src/private/cli/ConvertFromNovaNotificationCliArgument.ps1
@@ -10,7 +10,7 @@ function ConvertFrom-NovaNotificationCliArgument {
     }
 
     if ($Arguments.Count -ne 1) {
-        throw "Unsupported 'nova notification' usage. Use 'nova notification', 'nova notification -enable', or 'nova notification -disable'."
+        Stop-NovaOperation -Message "Unsupported 'nova notification' usage. Use 'nova notification', 'nova notification -enable', or 'nova notification -disable'." -ErrorId 'Nova.Validation.UnsupportedNotificationCliUsage' -Category InvalidArgument -TargetObject $Arguments
     }
 
     switch -Regex ($Arguments[0]) {
@@ -21,7 +21,7 @@ function ConvertFrom-NovaNotificationCliArgument {
             return 'disable'
         }
         default {
-            throw "Unknown argument: $( $Arguments[0] )"
+            Stop-NovaOperation -Message "Unknown argument: $( $Arguments[0] )" -ErrorId 'Nova.Validation.UnknownCliArgument' -Category InvalidArgument -TargetObject $Arguments[0]
         }
     }
 }

--- a/src/private/cli/ConvertFromNovaUpdateCliArgument.ps1
+++ b/src/private/cli/ConvertFromNovaUpdateCliArgument.ps1
@@ -9,5 +9,5 @@ function ConvertFrom-NovaUpdateCliArgument {
         return @{}
     }
 
-    throw "Unsupported 'nova update' usage. Use 'nova update'."
+    Stop-NovaOperation -Message "Unsupported 'nova update' usage. Use 'nova update'." -ErrorId 'Nova.Validation.UnsupportedUpdateCliUsage' -Category InvalidArgument -TargetObject $Arguments
 }

--- a/src/private/cli/ConvertFromNovaVersionCliArgument.ps1
+++ b/src/private/cli/ConvertFromNovaVersionCliArgument.ps1
@@ -13,5 +13,5 @@ function ConvertFrom-NovaVersionCliArgument {
         return @{Installed = $true}
     }
 
-    throw "Unsupported 'nova version' usage. Use 'nova version' or 'nova version -Installed'."
+    Stop-NovaOperation -Message "Unsupported 'nova version' usage. Use 'nova version' or 'nova version -Installed'." -ErrorId 'Nova.Validation.UnsupportedVersionCliUsage' -Category InvalidArgument -TargetObject $Arguments
 }

--- a/src/private/cli/GetNovaCliCommandHelp.ps1
+++ b/src/private/cli/GetNovaCliCommandHelp.ps1
@@ -51,7 +51,7 @@ function Get-NovaCliCommandHelp {
             'Invoke-NovaRelease'
         }
         default {
-            throw "Unknown command: <$Command> | Use 'nova --help' to see available commands."
+            Stop-NovaOperation -Message "Unknown command: <$Command> | Use 'nova --help' to see available commands." -ErrorId 'Nova.Validation.UnknownCliCommand' -Category InvalidArgument -TargetObject $Command
         }
     }
 

--- a/src/private/cli/GetNovaCliInstallDirectory.ps1
+++ b/src/private/cli/GetNovaCliInstallDirectory.ps1
@@ -11,7 +11,7 @@ function Get-NovaCliInstallDirectory {
     $homeDirectory = $env:HOME
 
     if ( [string]::IsNullOrWhiteSpace($homeDirectory)) {
-        throw 'HOME environment variable is not set. Provide -DestinationDirectory explicitly.'
+        Stop-NovaOperation -Message 'HOME environment variable is not set. Provide -DestinationDirectory explicitly.' -ErrorId 'Nova.Environment.HomeDirectoryMissing' -Category ResourceUnavailable -TargetObject 'HOME'
     }
 
     return [System.IO.Path]::Join($homeDirectory, '.local', 'bin')

--- a/src/private/cli/GetNovaCliInstallWorkflowContext.ps1
+++ b/src/private/cli/GetNovaCliInstallWorkflowContext.ps1
@@ -6,7 +6,7 @@ function Get-NovaCliInstallWorkflowContext {
     )
 
     if ($IsWindows) {
-        throw 'Install-NovaCli currently supports macOS/Linux only. On Windows, use the nova alias inside pwsh after importing NovaModuleTools.'
+        Stop-NovaOperation -Message 'Install-NovaCli currently supports macOS/Linux only. On Windows, use the nova alias inside pwsh after importing NovaModuleTools.' -ErrorId 'Nova.Environment.UnsupportedCliInstallPlatform' -Category NotImplemented -TargetObject 'Windows'
     }
 
     $targetDirectory = Get-NovaCliInstallDirectory -DestinationDirectory $DestinationDirectory
@@ -14,7 +14,7 @@ function Get-NovaCliInstallWorkflowContext {
     $targetPath = Join-Path $targetDirectory 'nova'
 
     if ((Test-Path -LiteralPath $targetPath) -and -not $Force) {
-        throw "Target file already exists: $targetPath. Use -Force to overwrite it."
+        Stop-NovaOperation -Message "Target file already exists: $targetPath. Use -Force to overwrite it." -ErrorId 'Nova.Workflow.CliInstallTargetExists' -Category ResourceExists -TargetObject $targetPath
     }
 
     return [pscustomobject]@{

--- a/src/private/cli/GetNovaCliLauncherPath.ps1
+++ b/src/private/cli/GetNovaCliLauncherPath.ps1
@@ -4,12 +4,12 @@ function Get-NovaCliLauncherPath {
 
     $command = Get-Command -Name 'Install-NovaCli' -CommandType Function -ErrorAction SilentlyContinue
     if ($null -eq $command) {
-        throw 'Install-NovaCli command not found.'
+        Stop-NovaOperation -Message 'Install-NovaCli command not found.' -ErrorId 'Nova.Environment.CliInstallCommandNotFound' -Category ObjectNotFound -TargetObject 'Install-NovaCli'
     }
 
     $commandFile = $command.ScriptBlock.File
     if ( [string]::IsNullOrWhiteSpace($commandFile)) {
-        throw 'Install-NovaCli must be loaded from a file-backed module.'
+        Stop-NovaOperation -Message 'Install-NovaCli must be loaded from a file-backed module.' -ErrorId 'Nova.Environment.CliInstallCommandNotFileBacked' -Category ResourceUnavailable -TargetObject 'Install-NovaCli'
     }
 
     $commandRoot = Split-Path -Parent $commandFile
@@ -25,5 +25,5 @@ function Get-NovaCliLauncherPath {
         }
     }
 
-    throw "Nova CLI launcher not found. Checked: $( ($candidateList | ForEach-Object {[System.IO.Path]::GetFullPath($_)}) -join ', ' )"
+    Stop-NovaOperation -Message "Nova CLI launcher not found. Checked: $( ($candidateList | ForEach-Object {[System.IO.Path]::GetFullPath($_)}) -join ', ' )" -ErrorId 'Nova.Environment.CliLauncherNotFound' -Category ObjectNotFound -TargetObject 'nova'
 }

--- a/src/private/cli/GetNovaCliOptions.ps1
+++ b/src/private/cli/GetNovaCliOptions.ps1
@@ -16,31 +16,16 @@ function ConvertFrom-NovaCliArgument {
                 $options.Local = $true
             }
             '^(--repository|-Repository)$' {
-                $index++
-                if ($index -ge $Arguments.Count) {
-                    throw 'Missing value for --repository'
-                }
-
-                $options.Repository = $Arguments[$index]
+                $options.Repository = Get-NovaCliRequiredArgumentValue -Arguments $Arguments -Index ([ref]$index) -OptionName '--repository'
             }
             '^(--path|-Path|-ModuleDirectoryPath)$' {
-                $index++
-                if ($index -ge $Arguments.Count) {
-                    throw 'Missing value for --path'
-                }
-
-                $options.ModuleDirectoryPath = $Arguments[$index]
+                $options.ModuleDirectoryPath = Get-NovaCliRequiredArgumentValue -Arguments $Arguments -Index ([ref]$index) -OptionName '--path'
             }
             '^(--apikey|-ApiKey)$' {
-                $index++
-                if ($index -ge $Arguments.Count) {
-                    throw 'Missing value for --apikey'
-                }
-
-                $options.ApiKey = $Arguments[$index]
+                $options.ApiKey = Get-NovaCliRequiredArgumentValue -Arguments $Arguments -Index ([ref]$index) -OptionName '--apikey'
             }
             default {
-                throw "Unknown argument: $token"
+                Stop-NovaOperation -Message "Unknown argument: $token" -ErrorId 'Nova.Validation.UnknownCliArgument' -Category InvalidArgument -TargetObject $token
             }
         }
 

--- a/src/private/cli/GetNovaCliRequiredArgumentValue.ps1
+++ b/src/private/cli/GetNovaCliRequiredArgumentValue.ps1
@@ -8,7 +8,7 @@ function Get-NovaCliRequiredArgumentValue {
 
     $Index.Value++
     if ($Index.Value -ge $Arguments.Count) {
-        throw "Missing value for $OptionName"
+        Stop-NovaOperation -Message "Missing value for $OptionName" -ErrorId 'Nova.Validation.MissingCliOptionValue' -Category InvalidArgument -TargetObject $OptionName
     }
 
     return $Arguments[$Index.Value]

--- a/src/private/cli/InvokeNovaCliCommandRoute.ps1
+++ b/src/private/cli/InvokeNovaCliCommandRoute.ps1
@@ -65,7 +65,7 @@ function Invoke-NovaCliCommandRoute {
 
     $commandHandler = $commandHandlerMap[$command]
     if ($null -eq $commandHandler) {
-        throw "Unknown command: <$command> | Use 'nova --help' to see available commands."
+        Stop-NovaOperation -Message "Unknown command: <$command> | Use 'nova --help' to see available commands." -ErrorId 'Nova.Validation.UnknownCliCommand' -Category InvalidArgument -TargetObject $command
     }
 
     return & $commandHandler

--- a/src/private/cli/InvokeNovaCliInitCommand.ps1
+++ b/src/private/cli/InvokeNovaCliInitCommand.ps1
@@ -7,7 +7,7 @@ function Invoke-NovaCliInitCommand {
     )
 
     if ($WhatIfEnabled) {
-        throw "The 'nova init' CLI command does not support -WhatIf. Run 'nova init' or 'nova init -Path <path>' without -WhatIf."
+        Stop-NovaOperation -Message "The 'nova init' CLI command does not support -WhatIf. Run 'nova init' or 'nova init -Path <path>' without -WhatIf." -ErrorId 'Nova.Validation.UnsupportedInitCliWhatIf' -Category InvalidOperation -TargetObject 'WhatIf'
     }
 
     $options = ConvertFrom-NovaInitCliArgument -Arguments $Arguments

--- a/src/private/cli/SetNovaCliExecutablePermission.ps1
+++ b/src/private/cli/SetNovaCliExecutablePermission.ps1
@@ -14,6 +14,6 @@ function Set-NovaCliExecutablePermission {
 
     & chmod '+x' $Path
     if ($LASTEXITCODE -ne 0) {
-        throw "Failed to make nova launcher executable: $Path"
+        Stop-NovaOperation -Message "Failed to make nova launcher executable: $Path" -ErrorId 'Nova.Dependency.CliLauncherPermissionUpdateFailed' -Category InvalidOperation -TargetObject $Path
     }
 }

--- a/src/private/package/AssertNovaPackageMetadata.ps1
+++ b/src/private/package/AssertNovaPackageMetadata.ps1
@@ -7,12 +7,12 @@ function Assert-NovaPackageMetadata {
 
     foreach ($requiredField in @('Type', 'Id', 'Version', 'Description', 'OutputDirectory', 'PackageFileName', 'PackagePath')) {
         if ( [string]::IsNullOrWhiteSpace($PackageMetadata.$requiredField)) {
-            throw "Missing package metadata value: $requiredField"
+            Stop-NovaOperation -Message "Missing package metadata value: $requiredField" -ErrorId 'Nova.Configuration.PackageMetadataValueMissing' -Category InvalidData -TargetObject $requiredField
         }
     }
 
     if (@($PackageMetadata.Authors).Count -eq 0) {
-        throw 'Missing package metadata value: Authors'
+        Stop-NovaOperation -Message 'Missing package metadata value: Authors' -ErrorId 'Nova.Configuration.PackageMetadataValueMissing' -Category InvalidData -TargetObject 'Authors'
     }
 }
 

--- a/src/private/package/AssertNovaPackageOutputDirectoryCanBeCleared.ps1
+++ b/src/private/package/AssertNovaPackageOutputDirectoryCanBeCleared.ps1
@@ -7,12 +7,12 @@ function Assert-NovaPackageOutputDirectoryCanBeCleared {
 
     $resolvedOutputDirectory = [System.IO.Path]::GetFullPath($OutputDirectory)
     if ($resolvedOutputDirectory -eq [System.IO.Path]::GetPathRoot($resolvedOutputDirectory)) {
-        throw 'Package.OutputDirectory.Path cannot be a filesystem root when Package.OutputDirectory.Clean is true.'
+        Stop-NovaOperation -Message 'Package.OutputDirectory.Path cannot be a filesystem root when Package.OutputDirectory.Clean is true.' -ErrorId 'Nova.Configuration.PackageOutputDirectoryRootNotAllowed' -Category InvalidData -TargetObject $resolvedOutputDirectory
     }
 
     foreach ($protectedPath in @($ProjectInfo.ProjectRoot, $ProjectInfo.OutputModuleDir)) {
         if (Test-NovaPathContainsPath -ParentPath $resolvedOutputDirectory -ChildPath $protectedPath) {
-            throw "Package.OutputDirectory.Path cannot be cleaned because it would remove required project content: $protectedPath"
+            Stop-NovaOperation -Message "Package.OutputDirectory.Path cannot be cleaned because it would remove required project content: $protectedPath" -ErrorId 'Nova.Configuration.PackageOutputDirectoryProtectedPath' -Category InvalidData -TargetObject $protectedPath
         }
     }
 }

--- a/src/private/package/GetNovaPackageArtifactType.ps1
+++ b/src/private/package/GetNovaPackageArtifactType.ps1
@@ -5,15 +5,16 @@ function Get-NovaPackageArtifactType {
     )
 
     $extension = [System.IO.Path]::GetExtension($PackagePath)
+    $errorMessage = "Unsupported package file extension for upload: $PackagePath. Supported extensions: .nupkg, .zip."
     if ( [string]::IsNullOrWhiteSpace($extension)) {
-        throw "Unsupported package file extension for upload: $PackagePath. Supported extensions: .nupkg, .zip."
+        Stop-NovaOperation -Message $errorMessage -ErrorId 'Nova.Validation.UnsupportedPackageUploadFileType' -Category InvalidArgument -TargetObject $PackagePath
     }
 
     try {
         return ConvertTo-NovaPackageType -Type $extension
     }
     catch {
-        throw "Unsupported package file extension for upload: $PackagePath. Supported extensions: .nupkg, .zip."
+        Stop-NovaOperation -Message $errorMessage -ErrorId 'Nova.Validation.UnsupportedPackageUploadFileType' -Category InvalidArgument -TargetObject $PackagePath
     }
 }
 

--- a/src/private/package/GetNovaPackageAuthorList.ps1
+++ b/src/private/package/GetNovaPackageAuthorList.ps1
@@ -17,7 +17,7 @@ function Get-NovaPackageAuthorList {
     }
 
     if ($AuthorValue -isnot [System.Collections.IEnumerable]) {
-        throw 'Package.Authors must be a string or an array of strings.'
+        Stop-NovaOperation -Message 'Package.Authors must be a string or an array of strings.' -ErrorId 'Nova.Configuration.PackageAuthorsInvalidType' -Category InvalidData -TargetObject $AuthorValue
     }
 
     return @(

--- a/src/private/package/GetNovaPackageContentItemList.ps1
+++ b/src/private/package/GetNovaPackageContentItemList.ps1
@@ -6,12 +6,12 @@ function Get-NovaPackageContentItemList {
     )
 
     if (-not (Test-Path -LiteralPath $ProjectInfo.OutputModuleDir)) {
-        throw "Built module output not found: $( $ProjectInfo.OutputModuleDir ). Run Invoke-NovaBuild before packaging."
+        Stop-NovaOperation -Message "Built module output not found: $( $ProjectInfo.OutputModuleDir ). Run Invoke-NovaBuild before packaging." -ErrorId 'Nova.Environment.PackageBuildOutputNotFound' -Category ObjectNotFound -TargetObject $ProjectInfo.OutputModuleDir
     }
 
     $sourceFiles = @(Get-ChildItem -LiteralPath $ProjectInfo.OutputModuleDir -File -Recurse | Sort-Object FullName)
     if ($sourceFiles.Count -eq 0) {
-        throw "Built module output has no files to package: $( $ProjectInfo.OutputModuleDir )"
+        Stop-NovaOperation -Message "Built module output has no files to package: $( $ProjectInfo.OutputModuleDir )" -ErrorId 'Nova.Workflow.PackageBuildOutputEmpty' -Category InvalidOperation -TargetObject $ProjectInfo.OutputModuleDir
     }
 
     return @(

--- a/src/private/package/GetNovaPackageRepository.ps1
+++ b/src/private/package/GetNovaPackageRepository.ps1
@@ -24,6 +24,6 @@ function Get-NovaPackageRepository {
         return $resolvedRepository[0]
     }
 
-    throw "Package repository not found: $Repository. Define it under Package.Repositories in project.json or provide -Url."
+    Stop-NovaOperation -Message "Package repository not found: $Repository. Define it under Package.Repositories in project.json or provide -Url." -ErrorId 'Nova.Configuration.PackageRepositoryNotFound' -Category InvalidData -TargetObject $Repository
 }
 

--- a/src/private/package/GetNovaPackageUploadTargetUrl.ps1
+++ b/src/private/package/GetNovaPackageUploadTargetUrl.ps1
@@ -17,7 +17,7 @@ function Get-NovaPackageUploadTargetUrl {
         $resolvedUrl = Get-NovaPackageSettingValue -InputObject $PackageSettings -Name 'RawRepositoryUrl'
     }
     if ( [string]::IsNullOrWhiteSpace("$resolvedUrl")) {
-        throw 'Upload target URL is missing. Provide -Url or configure Package.RepositoryUrl or Package.Repositories[].Url.'
+        Stop-NovaOperation -Message 'Upload target URL is missing. Provide -Url or configure Package.RepositoryUrl or Package.Repositories[].Url.' -ErrorId 'Nova.Configuration.PackageUploadTargetUrlMissing' -Category InvalidData -TargetObject 'Url'
     }
 
     return "$resolvedUrl".Trim()

--- a/src/private/package/InitializeNovaPackageOutputDirectory.ps1
+++ b/src/private/package/InitializeNovaPackageOutputDirectory.ps1
@@ -8,7 +8,7 @@ function Initialize-NovaPackageOutputDirectory {
 
     $packageMetadata = @($PackageMetadataList)[0]
     if ($null -eq $packageMetadata) {
-        throw 'Package metadata list cannot be empty.'
+        Stop-NovaOperation -Message 'Package metadata list cannot be empty.' -ErrorId 'Nova.Validation.PackageMetadataListEmpty' -Category InvalidArgument -TargetObject 'PackageMetadataList'
     }
 
     if ($PackageMetadata.CleanOutputDirectory) {

--- a/src/private/package/InvokeNovaPackageArtifactUpload.ps1
+++ b/src/private/package/InvokeNovaPackageArtifactUpload.ps1
@@ -6,7 +6,7 @@ function Invoke-NovaPackageArtifactUpload {
     )
 
     if (-not (Test-Path -LiteralPath $UploadArtifact.PackagePath -PathType Leaf)) {
-        throw "Package file not found: $( $UploadArtifact.PackagePath )"
+        Stop-NovaOperation -Message "Package file not found: $( $UploadArtifact.PackagePath )" -ErrorId 'Nova.Environment.PackageUploadFileNotFound' -Category ObjectNotFound -TargetObject $UploadArtifact.PackagePath
     }
 
     $webRequestParameters = @{
@@ -27,7 +27,7 @@ function Invoke-NovaPackageArtifactUpload {
         $response = Invoke-WebRequest @webRequestParameters
     }
     catch {
-        throw "Package upload failed for $( $UploadArtifact.PackagePath ) -> $( $UploadArtifact.UploadUrl ). $( $_.Exception.Message )"
+        Stop-NovaOperation -Message "Package upload failed for $( $UploadArtifact.PackagePath ) -> $( $UploadArtifact.UploadUrl ). $( $_.Exception.Message )" -ErrorId 'Nova.Dependency.PackageUploadRequestFailed' -Category ConnectionError -TargetObject $UploadArtifact.UploadUrl
     }
 
     return [pscustomobject]@{

--- a/src/private/package/NewNovaPackageArtifact.ps1
+++ b/src/private/package/NewNovaPackageArtifact.ps1
@@ -20,7 +20,7 @@ function New-NovaPackageArtifact {
             New-NovaZipPackageArtifact -ProjectInfo $ProjectInfo -PackageMetadata $PackageMetadata
         }
         default {
-            throw "Unsupported package type: $( $PackageMetadata.Type )"
+            Stop-NovaOperation -Message "Unsupported package type: $( $PackageMetadata.Type )" -ErrorId 'Nova.Validation.UnsupportedPackageArtifactType' -Category InvalidArgument -TargetObject $PackageMetadata.Type
         }
     }
 

--- a/src/private/package/ResolveNovaPackageUploadExplicitFile.ps1
+++ b/src/private/package/ResolveNovaPackageUploadExplicitFile.ps1
@@ -6,13 +6,13 @@ function Resolve-NovaPackageUploadExplicitFile {
     )
 
     if (-not (Test-Path -LiteralPath $PackagePath -PathType Leaf)) {
-        throw "Package file not found: $PackagePath"
+        Stop-NovaOperation -Message "Package file not found: $PackagePath" -ErrorId 'Nova.Environment.PackageUploadFileNotFound' -Category ObjectNotFound -TargetObject $PackagePath
     }
 
     $resolvedPackagePath = (Resolve-Path -LiteralPath $PackagePath -ErrorAction Stop).Path
     $resolvedPackageType = Get-NovaPackageArtifactType -PackagePath $resolvedPackagePath
     if (@($RequestedPackageTypeList).Count -gt 0 -and $resolvedPackageType -notin $RequestedPackageTypeList) {
-        throw "Package selection is ambiguous. Explicit PackagePath '$resolvedPackagePath' resolves to type '$resolvedPackageType', but requested PackageType values are: $( $RequestedPackageTypeList -join ', ' )."
+        Stop-NovaOperation -Message "Package selection is ambiguous. Explicit PackagePath '$resolvedPackagePath' resolves to type '$resolvedPackageType', but requested PackageType values are: $( $RequestedPackageTypeList -join ', ' )." -ErrorId 'Nova.Validation.PackageUploadSelectionAmbiguous' -Category InvalidArgument -TargetObject $resolvedPackagePath
     }
 
     return [pscustomobject]@{

--- a/src/private/package/ResolveNovaPackageUploadOutputFileList.ps1
+++ b/src/private/package/ResolveNovaPackageUploadOutputFileList.ps1
@@ -8,7 +8,7 @@ function Resolve-NovaPackageUploadOutputFileList {
 
     $outputDirectory = Get-NovaPackageOutputDirectory -ProjectInfo $ProjectInfo
     if (-not (Test-Path -LiteralPath $outputDirectory -PathType Container)) {
-        throw "Package output directory not found: $outputDirectory. Run New-NovaModulePackage first or provide -PackagePath."
+        Stop-NovaOperation -Message "Package output directory not found: $outputDirectory. Run New-NovaModulePackage first or provide -PackagePath." -ErrorId 'Nova.Environment.PackageOutputDirectoryNotFound' -Category ObjectNotFound -TargetObject $outputDirectory
     }
 
     return @(

--- a/src/private/package/ResolveNovaPackageUploadOutputFileSet.ps1
+++ b/src/private/package/ResolveNovaPackageUploadOutputFileSet.ps1
@@ -15,7 +15,7 @@ function Resolve-NovaPackageUploadOutputFileSet {
     )
 
     if ($matchingFileList.Count -eq 0) {
-        throw "Package file not found for package type '$PackageType' in '$OutputDirectory'. Expected pattern: $searchPattern. Run New-NovaModulePackage first or provide -PackagePath."
+        Stop-NovaOperation -Message "Package file not found for package type '$PackageType' in '$OutputDirectory'. Expected pattern: $searchPattern. Run New-NovaModulePackage first or provide -PackagePath." -ErrorId 'Nova.Workflow.PackageOutputArtifactNotFound' -Category InvalidOperation -TargetObject $PackageType
     }
 
     return @(

--- a/src/private/package/ResolveNovaPackageUploadTypeList.ps1
+++ b/src/private/package/ResolveNovaPackageUploadTypeList.ps1
@@ -46,6 +46,6 @@ function Resolve-NovaRequestedPackageUploadTypeList {
         return $matchingRequestedTypeList
     }
 
-    throw "Package.FileNamePattern '$( $PatternInfo.Pattern )' resolves to type '$( $PatternInfo.ExplicitPackageType )', but requested PackageType values are: $( $resolvedTypeList -join ', ' )."
+    Stop-NovaOperation -Message "Package.FileNamePattern '$( $PatternInfo.Pattern )' resolves to type '$( $PatternInfo.ExplicitPackageType )', but requested PackageType values are: $( $resolvedTypeList -join ', ' )." -ErrorId 'Nova.Validation.PackageUploadPatternConflict' -Category InvalidArgument -TargetObject $PatternInfo.Pattern
 }
 

--- a/src/private/quality/InvokeNovaTestWorkflow.ps1
+++ b/src/private/quality/InvokeNovaTestWorkflow.ps1
@@ -10,7 +10,7 @@ function Invoke-NovaTestWorkflow {
     & $WorkflowContext.TestResultArtifactWriter.ScriptBlock -TestResult $testResult -OutputPath $WorkflowContext.TestResultPath -ReportWriter $WorkflowContext.TestResultReportWriter.ScriptBlock
 
     if ($testResult.Result -ne 'Passed') {
-        throw 'Tests failed'
+        Stop-NovaOperation -Message 'Tests failed' -ErrorId 'Nova.Workflow.TestRunFailed' -Category InvalidOperation -TargetObject $WorkflowContext.TestResultPath
     }
 }
 

--- a/src/private/quality/duplicates/AssertBuiltModuleHasNoDuplicateFunctionNames.ps1
+++ b/src/private/quality/duplicates/AssertBuiltModuleHasNoDuplicateFunctionNames.ps1
@@ -6,18 +6,18 @@ function Assert-BuiltModuleHasNoDuplicateFunctionName {
 
     $psm1Path = $ProjectInfo.ModuleFilePSM1
     if (-not (Test-Path -LiteralPath $psm1Path)) {
-        throw "Built module file not found: $psm1Path"
+        Stop-NovaOperation -Message "Built module file not found: $psm1Path" -ErrorId 'Nova.Environment.BuiltModuleFileNotFound' -Category ObjectNotFound -TargetObject $psm1Path
     }
 
     $parsed = Get-PowerShellAstFromFile -Path $psm1Path
     if ($parsed.Errors -and $parsed.Errors.Count -gt 0) {
         $messages = @($parsed.Errors | ForEach-Object { $_.Message }) -join '; '
-        throw "Built module contains parse errors and cannot be validated for duplicates. File: $psm1Path. Errors: $messages"
+        Stop-NovaOperation -Message "Built module contains parse errors and cannot be validated for duplicates. File: $psm1Path. Errors: $messages" -ErrorId 'Nova.Configuration.BuiltModuleDuplicateValidationParseFailed' -Category ParserError -TargetObject $psm1Path
     }
 
     $topLevelFunctions = @(Get-TopLevelFunctionAst -Ast $parsed.Ast)
     if ($topLevelFunctions.Count -eq 0) {
-        throw "No functions found to build. Add a function to the source file."
+        Stop-NovaOperation -Message 'No functions found to build. Add a function to the source file.' -ErrorId 'Nova.Workflow.BuiltModuleFunctionListEmpty' -Category InvalidOperation -TargetObject $psm1Path
     }
 
     $duplicates = Get-DuplicateFunctionGroup -FunctionAst $topLevelFunctions
@@ -30,5 +30,5 @@ function Assert-BuiltModuleHasNoDuplicateFunctionName {
     $sourceIndex = Get-FunctionSourceIndex -File $sourceFiles
 
     $errorText = Format-DuplicateFunctionErrorMessage -Psm1Path $psm1Path -DuplicateGroup $duplicates -SourceIndex $sourceIndex
-    throw $errorText
+    Stop-NovaOperation -Message $errorText -ErrorId 'Nova.Validation.BuiltModuleDuplicateFunctionName' -Category InvalidData -TargetObject $psm1Path
 }

--- a/src/private/release/FindLocalModulePathMatch.ps1
+++ b/src/private/release/FindLocalModulePathMatch.ps1
@@ -2,7 +2,7 @@ function Find-LocalModulePathMatch {
     param(
         [Parameter(Mandatory)][string[]]$ModulePaths,
         [Parameter(Mandatory)][string]$MatchPattern,
-        [Parameter(Mandatory)][string]$ErrorMessage
+        [Parameter(Mandatory)][pscustomobject]$ErrorDetails
     )
 
     $result = $ModulePaths |
@@ -13,5 +13,5 @@ function Find-LocalModulePathMatch {
         return $result
     }
 
-    throw $ErrorMessage
+    Stop-NovaOperation -Message $ErrorDetails.Message -ErrorId $ErrorDetails.ErrorId -Category $ErrorDetails.Category -TargetObject $ErrorDetails.TargetObject
 }

--- a/src/private/release/GetLocalModulePath.ps1
+++ b/src/private/release/GetLocalModulePath.ps1
@@ -2,6 +2,12 @@ function Get-LocalModulePath {
     $modulePaths = Get-LocalModulePathEntryList
     $matchPattern = Get-LocalModulePathPattern
     $errorMessage = Get-LocalModulePathErrorMessage -MatchPattern $matchPattern
+    $errorDetails = [pscustomobject]@{
+        Message = $errorMessage
+        ErrorId = 'Nova.Environment.LocalModulePathNotFound'
+        Category = [System.Management.Automation.ErrorCategory]::ObjectNotFound
+        TargetObject = $matchPattern
+    }
 
-    return Find-LocalModulePathMatch -ModulePaths $modulePaths -MatchPattern $matchPattern -ErrorMessage $errorMessage
+    return Find-LocalModulePathMatch -ModulePaths $modulePaths -MatchPattern $matchPattern -ErrorDetails $errorDetails
 }

--- a/src/private/release/GetNovaInstalledProjectVersion.ps1
+++ b/src/private/release/GetNovaInstalledProjectVersion.ps1
@@ -7,7 +7,7 @@ function Get-NovaInstalledProjectVersion {
 
     $manifestPath = Get-NovaInstalledProjectManifestPath -ProjectInfo $ProjectInfo -ModuleDirectoryPath $ModuleDirectoryPath
     if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
-        throw "Local module install not found for $( $ProjectInfo.ProjectName ). Expected manifest at: $manifestPath. Run 'nova publish -local' first."
+        Stop-NovaOperation -Message "Local module install not found for $( $ProjectInfo.ProjectName ). Expected manifest at: $manifestPath. Run 'nova publish -local' first." -ErrorId 'Nova.Environment.LocalModuleInstallNotFound' -Category ObjectNotFound -TargetObject $manifestPath
     }
 
     $manifest = Test-ModuleManifest -Path $manifestPath -ErrorAction Stop

--- a/src/private/release/GetNovaVersionLabelForBump.ps1
+++ b/src/private/release/GetNovaVersionLabelForBump.ps1
@@ -14,11 +14,11 @@ function Get-NovaVersionLabelForBump {
     }
 
     if (-not (Test-GitRepositoryHasCommittedHead -ProjectRoot $ProjectRoot)) {
-        throw 'Cannot bump version because the repository has no commits yet. Create an initial commit first.'
+        Stop-NovaOperation -Message 'Cannot bump version because the repository has no commits yet. Create an initial commit first.' -ErrorId 'Nova.Workflow.GitRepositoryHasNoCommits' -Category InvalidOperation -TargetObject $ProjectRoot
     }
 
     if (-not (Test-GitRepositoryHasCommitsSinceLatestTag -ProjectRoot $ProjectRoot)) {
-        throw 'Cannot bump version because there are no commits since the latest tag.'
+        Stop-NovaOperation -Message 'Cannot bump version because there are no commits since the latest tag.' -ErrorId 'Nova.Workflow.NoCommitsSinceLatestTag' -Category InvalidOperation -TargetObject $ProjectRoot
     }
 
     return 'Patch'

--- a/src/private/release/ImportNovaPublishedLocalModule.ps1
+++ b/src/private/release/ImportNovaPublishedLocalModule.ps1
@@ -6,7 +6,7 @@ function Import-NovaPublishedLocalModule {
     )
 
     if (-not (Test-Path -LiteralPath $ManifestPath -PathType Leaf)) {
-        throw "Expected locally published module manifest at: $ManifestPath"
+        Stop-NovaOperation -Message "Expected locally published module manifest at: $ManifestPath" -ErrorId 'Nova.Environment.LocalPublishedModuleManifestNotFound' -Category ObjectNotFound -TargetObject $ManifestPath
     }
 
     $loadedModules = @(Get-Module -Name $ProjectName -All)

--- a/src/private/release/InitiateGitRepo.ps1
+++ b/src/private/release/InitiateGitRepo.ps1
@@ -25,7 +25,7 @@ function New-InitiateGitRepo {
             try {
                 git init | Out-Null
             } catch {
-                throw "Failed to initialize Git repo: $( $_.Exception.Message )"
+                Stop-NovaOperation -Message "Failed to initialize Git repo: $( $_.Exception.Message )" -ErrorId 'Nova.Dependency.GitRepositoryInitializationFailed' -Category OpenError -TargetObject $DirectoryPath
             }
         }
         Write-Verbose 'Git repository initialized successfully'

--- a/src/private/release/PublishNovaBuiltModule.ps1
+++ b/src/private/release/PublishNovaBuiltModule.ps1
@@ -10,7 +10,7 @@ function Publish-NovaBuiltModule {
     )
 
     if (-not (Test-Path -LiteralPath $ProjectInfo.OutputModuleDir)) {
-        throw 'Dist folder is empty, build the module before running publish command'
+        Stop-NovaOperation -Message 'Dist folder is empty, build the module before running publish command' -ErrorId 'Nova.Environment.ReleaseBuildOutputNotFound' -Category ObjectNotFound -TargetObject $ProjectInfo.OutputModuleDir
     }
 
     if ( $PSBoundParameters.ContainsKey('Repository')) {

--- a/src/private/scaffold/InitializeNovaModuleScaffold.ps1
+++ b/src/private/scaffold/InitializeNovaModuleScaffold.ps1
@@ -7,7 +7,7 @@ function Initialize-NovaModuleScaffold {
     )
 
     if (Test-Path $Paths.Project) {
-        throw 'Project already exists, aborting'
+        Stop-NovaOperation -Message 'Project already exists, aborting' -ErrorId 'Nova.Workflow.ScaffoldProjectAlreadyExists' -Category ResourceExists -TargetObject $Paths.Project
     }
 
     Write-Message "`nStarted Module Scaffolding" -color Green

--- a/src/private/scaffold/ReadNovaModuleAnswers.ps1
+++ b/src/private/scaffold/ReadNovaModuleAnswers.ps1
@@ -10,7 +10,7 @@ function Read-NovaModuleAnswerSet {
     }
 
     if ($answer.ProjectName -notmatch '^[A-Za-z][A-Za-z0-9_.]*$') {
-        throw 'Module name is invalid. Use a single word that starts with a letter and contains only letters, numbers, underscores, or periods.'
+        Stop-NovaOperation -Message 'Module name is invalid. Use a single word that starts with a letter and contains only letters, numbers, underscores, or periods.' -ErrorId 'Nova.Validation.ScaffoldProjectNameInvalid' -Category InvalidData -TargetObject $answer.ProjectName
     }
 
     return $answer

--- a/src/private/scaffold/ResolveNovaModuleScaffoldBasePath.ps1
+++ b/src/private/scaffold/ResolveNovaModuleScaffoldBasePath.ps1
@@ -9,7 +9,7 @@ function Resolve-NovaModuleScaffoldBasePath {
     $resolvedPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($normalizedPath)
 
     if (-not (Test-Path -LiteralPath $resolvedPath -PathType Container)) {
-        throw "Not a valid path: $Path"
+        Stop-NovaOperation -Message "Not a valid path: $Path" -ErrorId 'Nova.Environment.ScaffoldBasePathNotFound' -Category ObjectNotFound -TargetObject $Path
     }
 
     return [System.IO.Path]::GetFullPath($resolvedPath)

--- a/src/private/shared/ConvertToNovaPackageType.ps1
+++ b/src/private/shared/ConvertToNovaPackageType.ps1
@@ -18,7 +18,7 @@ function ConvertTo-NovaPackageType {
             return 'Zip'
         }
         default {
-            throw "Unsupported Package.Types value: $Type. Supported values: NuGet, Zip, .nupkg, .zip."
+            Stop-NovaOperation -Message "Unsupported Package.Types value: $Type. Supported values: NuGet, Zip, .nupkg, .zip." -ErrorId 'Nova.Configuration.UnsupportedPackageType' -Category InvalidData -TargetObject $Type
         }
     }
 }

--- a/src/private/shared/GetNovaProjectInfoContext.ps1
+++ b/src/private/shared/GetNovaProjectInfoContext.ps1
@@ -7,7 +7,7 @@ function Get-NovaProjectInfoContext {
     $projectRoot = (Resolve-Path -LiteralPath $Path).Path
     $projectJson = [System.IO.Path]::Join($projectRoot, 'project.json')
     if (-not (Test-Path -LiteralPath $projectJson)) {
-        throw "Not a project folder. project.json not found: $projectJson"
+        Stop-NovaOperation -Message "Not a project folder. project.json not found: $projectJson" -ErrorId 'Nova.Environment.ProjectJsonNotFound' -Category ObjectNotFound -TargetObject $projectJson
     }
 
     return [pscustomobject]@{

--- a/src/private/shared/GetResourceFilePath.ps1
+++ b/src/private/shared/GetResourceFilePath.ps1
@@ -31,5 +31,5 @@ function Get-ResourceFilePath {
         }
     }
 
-    throw "Resource file not found: $FileName. Checked: $( $candidates -join ', ' )"
+    Stop-NovaOperation -Message "Resource file not found: $FileName. Checked: $( $candidates -join ', ' )" -ErrorId 'Nova.Environment.ResourceFileNotFound' -Category ObjectNotFound -TargetObject $FileName
 }

--- a/src/private/shared/NewNovaErrorRecord.ps1
+++ b/src/private/shared/NewNovaErrorRecord.ps1
@@ -1,0 +1,19 @@
+function New-NovaErrorRecord {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'New-NovaErrorRecord only constructs and returns an ErrorRecord object.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Message,
+        [Parameter(Mandatory)][string]$ErrorId,
+        [Parameter(Mandatory)][System.Management.Automation.ErrorCategory]$Category,
+        [AllowNull()]$TargetObject
+    )
+
+    $resolvedException = [System.InvalidOperationException]::new($Message)
+
+    return [System.Management.Automation.ErrorRecord]::new(
+            $resolvedException,
+            $ErrorId,
+            $Category,
+            $TargetObject
+    )
+}

--- a/src/private/shared/Read-ProjectJsonData.ps1
+++ b/src/private/shared/Read-ProjectJsonData.ps1
@@ -6,18 +6,18 @@ function Read-ProjectJsonData {
 
     $projectJsonContent = Get-Content -LiteralPath $ProjectJsonPath -Raw
     if ( [string]::IsNullOrWhiteSpace($projectJsonContent)) {
-        throw "project.json is empty: $ProjectJsonPath"
+        Stop-NovaOperation -Message "project.json is empty: $ProjectJsonPath" -ErrorId 'Nova.Configuration.ProjectJsonEmpty' -Category InvalidData -TargetObject $ProjectJsonPath
     }
 
     try {
         $jsonData = $projectJsonContent | ConvertFrom-Json -AsHashtable
     }
     catch {
-        throw "project.json is not valid JSON: $ProjectJsonPath. $( $_.Exception.Message )"
+        Stop-NovaOperation -Message "project.json is not valid JSON: $ProjectJsonPath. $( $_.Exception.Message )" -ErrorId 'Nova.Configuration.ProjectJsonInvalidJson' -Category ParserError -TargetObject $ProjectJsonPath
     }
 
     if ($jsonData -isnot [hashtable]) {
-        throw "project.json must contain a top-level JSON object: $ProjectJsonPath"
+        Stop-NovaOperation -Message "project.json must contain a top-level JSON object: $ProjectJsonPath" -ErrorId 'Nova.Configuration.ProjectJsonTopLevelObjectRequired' -Category InvalidData -TargetObject $ProjectJsonPath
     }
 
     return $jsonData

--- a/src/private/shared/StopNovaOperation.ps1
+++ b/src/private/shared/StopNovaOperation.ps1
@@ -1,0 +1,12 @@
+function Stop-NovaOperation {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Stop-NovaOperation only raises a terminating error and does not mutate repository or runtime state.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Message,
+        [Parameter(Mandatory)][string]$ErrorId,
+        [Parameter(Mandatory)][System.Management.Automation.ErrorCategory]$Category,
+        [AllowNull()]$TargetObject
+    )
+
+    throw (New-NovaErrorRecord @PSBoundParameters)
+}

--- a/src/private/update/GetNovaModuleSelfUpdateWorkflowContext.ps1
+++ b/src/private/update/GetNovaModuleSelfUpdateWorkflowContext.ps1
@@ -27,7 +27,7 @@ function Get-NovaModuleSelfUpdateWorkflowContext {
     }
 
     if ($null -eq $resolvedLookupResult) {
-        throw 'Unable to determine a NovaModuleTools update candidate. Try again when the PowerShell Gallery is reachable.'
+        Stop-NovaOperation -Message 'Unable to determine a NovaModuleTools update candidate. Try again when the PowerShell Gallery is reachable.' -ErrorId 'Nova.Dependency.ModuleSelfUpdateCandidateUnavailable' -Category ResourceUnavailable -TargetObject 'NovaModuleTools'
     }
 
     $plan = Get-NovaModuleSelfUpdatePlan -InstalledModule $resolvedInstalledModule -LookupResult $resolvedLookupResult -PrereleaseNotificationsEnabled $resolvedPreference.PrereleaseNotificationsEnabled

--- a/src/private/update/GetNovaUpdateNotificationPreferenceChangeContext.ps1
+++ b/src/private/update/GetNovaUpdateNotificationPreferenceChangeContext.ps1
@@ -21,5 +21,5 @@ function Get-NovaUpdateNotificationPreferenceChangeContext {
         }
     }
 
-    throw 'Specify either -EnablePrereleaseNotifications or -DisablePrereleaseNotifications.'
+    Stop-NovaOperation -Message 'Specify either -EnablePrereleaseNotifications or -DisablePrereleaseNotifications.' -ErrorId 'Nova.Validation.UpdateNotificationPreferenceChangeRequired' -Category InvalidArgument -TargetObject 'PrereleaseNotifications'
 }

--- a/src/private/update/InvokeNovaModuleSelfUpdateWorkflow.ps1
+++ b/src/private/update/InvokeNovaModuleSelfUpdateWorkflow.ps1
@@ -1,3 +1,17 @@
+function Invoke-NovaModuleSelfUpdateOrStop {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Plan
+    )
+
+    try {
+        $null = Invoke-NovaModuleSelfUpdate -ModuleName $Plan.ModuleName -AllowPrerelease:$Plan.UsedAllowPrerelease
+    }
+    catch {
+        Stop-NovaOperation -Message $_.Exception.Message -ErrorId 'Nova.Dependency.ModuleSelfUpdateFailed' -Category InvalidOperation -TargetObject $Plan.ModuleName
+    }
+}
+
 function Invoke-NovaModuleSelfUpdateWorkflow {
     [CmdletBinding()]
     param(
@@ -9,7 +23,7 @@ function Invoke-NovaModuleSelfUpdateWorkflow {
         return $plan
     }
 
-    $null = Invoke-NovaModuleSelfUpdate -ModuleName $plan.ModuleName -AllowPrerelease:$plan.UsedAllowPrerelease
+    Invoke-NovaModuleSelfUpdateOrStop -Plan $plan
     $plan.Updated = $true
     Write-NovaModuleReleaseNotesLink
     return $plan

--- a/src/resources/example/src/private/Get-ExampleConfiguration.ps1
+++ b/src/resources/example/src/private/Get-ExampleConfiguration.ps1
@@ -4,7 +4,7 @@ function Get-ExampleConfiguration {
 
     $configurationPath = Join-Path $PSScriptRoot 'resources/greeting-config.json'
     if (-not (Test-Path -LiteralPath $configurationPath)) {
-        throw "Example configuration not found: $configurationPath"
+        Stop-NovaOperation -Message "Example configuration not found: $configurationPath" -ErrorId 'Nova.Environment.ExampleConfigurationNotFound' -Category ObjectNotFound -TargetObject $configurationPath
     }
 
     $configuration = Get-Content -LiteralPath $configurationPath -Raw | ConvertFrom-Json

--- a/tests/BuildOptions.TestSupport.ps1
+++ b/tests/BuildOptions.TestSupport.ps1
@@ -260,27 +260,6 @@ function Assert-InvokeNovaBuildThrows {
     }
 }
 
-function Get-InvokeNovaBuildErrorMessage {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)][string]$ProjectRoot
-    )
-
-    Push-Location -LiteralPath $ProjectRoot
-    try {
-        try {
-            Invoke-NovaBuild
-        }
-        catch {
-            return $_.Exception.Message
-        }
-    }
-    finally {
-        Pop-Location
-    }
-
-    throw 'Expected Invoke-NovaBuild to throw, but it succeeded.'
-}
 
 function Get-TopLevelFunctionAstFromAst {
     [CmdletBinding()]

--- a/tests/BuildOptions.TestSupport.ps1
+++ b/tests/BuildOptions.TestSupport.ps1
@@ -219,10 +219,10 @@ function Assert-InvokeNovaBuildThrows {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string]$ProjectRoot,
-        [string]$ExpectedMessage
+        [AllowNull()][pscustomobject]$ExpectedError
     )
 
-    $scriptBlock = {
+    $invokeAction = {
         Push-Location -LiteralPath $ProjectRoot
         try {
             Invoke-NovaBuild
@@ -232,12 +232,32 @@ function Assert-InvokeNovaBuildThrows {
         }
     }
 
-    if ( [string]::IsNullOrWhiteSpace($ExpectedMessage)) {
-        $scriptBlock | Should -Throw
+    if ($null -eq $ExpectedError) {
+        $invokeAction | Should -Throw
         return
     }
 
-    $scriptBlock | Should -Throw $ExpectedMessage
+    $thrown = $null
+    try {
+        & $invokeAction
+    }
+    catch {
+        $thrown = $_
+    }
+
+    $thrown | Should -Not -BeNullOrEmpty
+    if ($ExpectedError.PSObject.Properties.Name -contains 'Message') {
+        $thrown.Exception.Message | Should -BeLike $ExpectedError.Message
+    }
+    if ($ExpectedError.PSObject.Properties.Name -contains 'ErrorId') {
+        $thrown.FullyQualifiedErrorId | Should -Be $ExpectedError.ErrorId
+    }
+    if ($ExpectedError.PSObject.Properties.Name -contains 'Category') {
+        $thrown.CategoryInfo.Category | Should -Be $ExpectedError.Category
+    }
+    if ($ExpectedError.PSObject.Properties.Name -contains 'TargetObject') {
+        $thrown.TargetObject | Should -Be $ExpectedError.TargetObject
+    }
 }
 
 function Get-InvokeNovaBuildErrorMessage {

--- a/tests/BuildOptions.TestSupport.ps1
+++ b/tests/BuildOptions.TestSupport.ps1
@@ -232,11 +232,6 @@ function Assert-InvokeNovaBuildThrows {
         }
     }
 
-    if ($null -eq $ExpectedError) {
-        $invokeAction | Should -Throw
-        return
-    }
-
     $thrown = $null
     try {
         & $invokeAction
@@ -246,6 +241,10 @@ function Assert-InvokeNovaBuildThrows {
     }
 
     $thrown | Should -Not -BeNullOrEmpty
+    if ($null -eq $ExpectedError) {
+        return
+    }
+
     if ($ExpectedError.PSObject.Properties.Name -contains 'Message') {
         $thrown.Exception.Message | Should -BeLike $ExpectedError.Message
     }

--- a/tests/BuildOptions.Tests.ps1
+++ b/tests/BuildOptions.Tests.ps1
@@ -301,7 +301,8 @@ Describe 'Invoke-NovaBuild options' {
         $project.Manifest['BogusKey'] = 'nope'
         $project | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $projectJsonPath -Encoding utf8
 
-        {
+        $thrown = $null
+        try {
             Push-Location -LiteralPath $root
             try {
                 Invoke-NovaBuild
@@ -309,7 +310,16 @@ Describe 'Invoke-NovaBuild options' {
             finally {
                 Pop-Location
             }
-        } | Should -Throw 'Unknown parameter(s) in Manifest: BogusKey'
+        }
+        catch {
+            $thrown = $_
+        }
+
+        $thrown | Should -Not -BeNullOrEmpty
+        $thrown.Exception.Message | Should -Be 'Unknown parameter(s) in Manifest: BogusKey'
+        $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Configuration.ManifestUnknownParameter'
+        $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidData)
+        @($thrown.TargetObject) | Should -Be @('BogusKey')
     }
 
     It 'FailOnDuplicateFunctionNames=true fails when built psm1 contains duplicate top-level function names' {

--- a/tests/BuildOptions.Tests.ps1
+++ b/tests/BuildOptions.Tests.ps1
@@ -313,9 +313,15 @@ Describe 'Invoke-NovaBuild options' {
 
     It 'missing FailOnDuplicateFunctionNames defaults to true and fails on duplicate top-level function names' {
         $root = New-TestProjectWithDuplicateFunctions -TestDriveRoot $TestDrive -Name 'DupDefault' -Options @{ ProjectName = 'DupDefault'; BuildRecursiveFolders = $false; SetSourcePath = $false }
+        $expectedModulePath = Get-BuiltModuleFilePath -ProjectRoot $root
 
         (Get-TestProjectInfoValue -ProjectRoot $root -PropertyName 'FailOnDuplicateFunctionNames') | Should -BeTrue
-        Assert-InvokeNovaBuildThrows -ProjectRoot $root
+        Assert-InvokeNovaBuildThrows -ProjectRoot $root -ExpectedError ([pscustomobject]@{
+            Message = 'Duplicate top-level function names detected in built module:*'
+            ErrorId = 'Nova.Validation.BuiltModuleDuplicateFunctionName'
+            Category = [System.Management.Automation.ErrorCategory]::InvalidData
+            TargetObject = $expectedModulePath
+        })
     }
 
     It 'fails build when Manifest contains unsupported New-ModuleManifest parameters' {
@@ -351,7 +357,14 @@ Describe 'Invoke-NovaBuild options' {
 
     It 'FailOnDuplicateFunctionNames=true fails when built psm1 contains duplicate top-level function names' {
         $root = New-TestProjectWithDuplicateFunctions -TestDriveRoot $TestDrive -Name 'DupFail' -Options @{ ProjectName = 'DupFail'; BuildRecursiveFolders = $false; FailOnDuplicateFunctionNames = $true }
-        Assert-InvokeNovaBuildThrows -ProjectRoot $root
+        $expectedModulePath = Get-BuiltModuleFilePath -ProjectRoot $root
+
+        Assert-InvokeNovaBuildThrows -ProjectRoot $root -ExpectedError ([pscustomobject]@{
+            Message = 'Duplicate top-level function names detected in built module:*'
+            ErrorId = 'Nova.Validation.BuiltModuleDuplicateFunctionName'
+            Category = [System.Management.Automation.ErrorCategory]::InvalidData
+            TargetObject = $expectedModulePath
+        })
     }
 
     It 'FailOnDuplicateFunctionNames=false allows duplicates (last wins) for backward compatibility' {

--- a/tests/BuildOptions.Tests.ps1
+++ b/tests/BuildOptions.Tests.ps1
@@ -124,7 +124,12 @@ Describe 'Invoke-NovaBuild options' {
         $root = New-TestProjectRoot -TestDriveRoot $TestDrive -Name 'EmptyProject'
         Write-TestProjectJson -ProjectRoot $root -Options @{ProjectName = 'EmptyProject'; BuildRecursiveFolders = $false}
 
-        Assert-InvokeNovaBuildThrows -ProjectRoot $root -ExpectedMessage 'No source files found to build*'
+        Assert-InvokeNovaBuildThrows -ProjectRoot $root -ExpectedError ([pscustomobject]@{
+            Message = 'No source files found to build*'
+            ErrorId = 'Nova.Environment.BuildSourceFilesNotFound'
+            Category = [System.Management.Automation.ErrorCategory]::ObjectNotFound
+            TargetObject = 'src'
+        })
     }
 
     It 'BuildRecursiveFolders=false excludes nested classes/private and nested public' {

--- a/tests/BuildOptions.Tests.ps1
+++ b/tests/BuildOptions.Tests.ps1
@@ -80,6 +80,33 @@ Describe 'Invoke-NovaBuild options' {
         (Test-Path -LiteralPath (Join-Path $distModuleDir 'resources/example/tests/Pester.Some.Tests.ps1')) | Should -BeTrue
     }
 
+    It 'Get-ExampleConfiguration exposes a structured error when the packaged example config is missing' {
+        $newNovaErrorRecordPath = Join-Path $repoRoot 'src/private/shared/NewNovaErrorRecord.ps1'
+        $stopNovaOperationPath = Join-Path $repoRoot 'src/private/shared/StopNovaOperation.ps1'
+        $exampleConfigurationPath = Join-Path $repoRoot 'src/resources/example/src/private/Get-ExampleConfiguration.ps1'
+        $expectedConfigurationPath = Join-Path $repoRoot 'src/resources/example/src/private/resources/greeting-config.json'
+
+        . $newNovaErrorRecordPath
+        . $stopNovaOperationPath
+        . $exampleConfigurationPath
+
+        Mock Test-Path {$false} -ParameterFilter {$LiteralPath -eq $expectedConfigurationPath}
+
+        $thrown = $null
+        try {
+            Get-ExampleConfiguration
+        }
+        catch {
+            $thrown = $_
+        }
+
+        $thrown | Should -Not -BeNullOrEmpty
+        $thrown.Exception.Message | Should -Be "Example configuration not found: $expectedConfigurationPath"
+        $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Environment.ExampleConfigurationNotFound'
+        $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::ObjectNotFound)
+        $thrown.TargetObject | Should -Be $expectedConfigurationPath
+    }
+
     It 'ScriptAnalyzer ignores generated packaged example dist and artifacts content' {
         if (-not (Get-Module -ListAvailable -Name PSScriptAnalyzer)) {
             Set-ItResult -Skipped -Because 'PSScriptAnalyzer is not available in this environment'

--- a/tests/CiCoverage.Tests.ps1
+++ b/tests/CiCoverage.Tests.ps1
@@ -99,9 +99,19 @@ Describe 'CodeScene Cobertura remapping helpers' {
 </coverage>
 '@ | Set-Content -LiteralPath $coveragePath -Encoding utf8
 
-        {
+        $thrown = $null
+        try {
             Convert-CoberturaCoverageToSourcePath -CoveragePath $coveragePath -BuiltModulePath $builtModulePath -RepoRoot $repoRoot
-        } | Should -Throw "Could not find any '# Source:' markers*"
+        }
+        catch {
+            $thrown = $_
+        }
+
+        $thrown | Should -Not -BeNullOrEmpty
+        $thrown.Exception.Message | Should -Be "Could not find any '# Source:' markers in built module: $builtModulePath"
+        $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Coverage.BuiltModuleSourceMarkersMissing'
+        $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::ObjectNotFound)
+        $thrown.TargetObject | Should -Be $builtModulePath
     }
 
     It 'ignores covered built-module preamble lines before the first source marker' {

--- a/tests/CoverageCompletion.Tests.ps1
+++ b/tests/CoverageCompletion.Tests.ps1
@@ -278,9 +278,19 @@ Describe 'Coverage completion for remaining low-coverage helpers' {
         InModuleScope $script:moduleName {
             Mock Test-Path {$false}
 
-            {
+            $thrown = $null
+            try {
                 Assert-BuiltModuleHasNoDuplicateFunctionName -ProjectInfo ([pscustomobject]@{ModuleFilePSM1 = '/tmp/missing.psm1'})
-            } | Should -Throw 'Built module file not found*'
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be 'Built module file not found: /tmp/missing.psm1'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Environment.BuiltModuleFileNotFound'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::ObjectNotFound)
+            $thrown.TargetObject | Should -Be '/tmp/missing.psm1'
         }
     }
 
@@ -294,9 +304,19 @@ Describe 'Coverage completion for remaining low-coverage helpers' {
                 }
             }
 
-            {
+            $thrown = $null
+            try {
                 Assert-BuiltModuleHasNoDuplicateFunctionName -ProjectInfo ([pscustomobject]@{ModuleFilePSM1 = '/tmp/bad.psm1'})
-            } | Should -Throw 'Built module contains parse errors*unexpected token'
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be 'Built module contains parse errors and cannot be validated for duplicates. File: /tmp/bad.psm1. Errors: unexpected token'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Configuration.BuiltModuleDuplicateValidationParseFailed'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::ParserError)
+            $thrown.TargetObject | Should -Be '/tmp/bad.psm1'
         }
     }
 
@@ -315,9 +335,19 @@ Describe 'Coverage completion for remaining low-coverage helpers' {
             }
             Mock Get-DuplicateFunctionGroup {}
 
-            {
+            $thrown = $null
+            try {
                 Assert-BuiltModuleHasNoDuplicateFunctionName -ProjectInfo ([pscustomobject]@{ModuleFilePSM1 = '/tmp/empty.psm1'})
-            } | Should -Throw 'No functions found to build. Add a function to the source file.'
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be 'No functions found to build. Add a function to the source file.'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Workflow.BuiltModuleFunctionListEmpty'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidOperation)
+            $thrown.TargetObject | Should -Be '/tmp/empty.psm1'
             Assert-MockCalled Get-DuplicateFunctionGroup -Times 0
         }
     }
@@ -428,6 +458,8 @@ Describe 'Coverage completion for remaining low-coverage helpers' {
 
     It 'New-InitiateGitRepo initializes a git repository when git is available' {
         InModuleScope $script:moduleName {
+            Remove-Item -Path 'function:git' -Force -ErrorAction SilentlyContinue
+
             if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
                 Set-ItResult -Skipped -Because 'git is not available in this environment'
                 return

--- a/tests/CoverageGaps.BuildInternals.Tests.ps1
+++ b/tests/CoverageGaps.BuildInternals.Tests.ps1
@@ -164,6 +164,57 @@ Describe 'Coverage gaps for build and duplicate-analysis internals' {
         }
     }
 
+    It 'Build-Module exposes structured errors when there are no source files or the psm1 write fails' {
+        InModuleScope $script:moduleName {
+            $projectInfo = [pscustomobject]@{
+                ClassesDir = '/tmp/classes'
+                PublicDir = '/tmp/public'
+                PrivateDir = '/tmp/private'
+                ModuleFilePSM1 = '/tmp/NovaModuleTools.psm1'
+            }
+            $sourceFilePath = Join-Path $TestDrive 'Get-Thing.ps1'
+            Set-Content -LiteralPath $sourceFilePath -Value 'function Get-Thing { }' -Encoding utf8
+            $sourceFile = Get-Item -LiteralPath $sourceFilePath
+
+            Mock Get-NovaBuildProjectInfo {$projectInfo}
+            Mock Get-Command {[pscustomobject]@{Version = [version]'2.0.0'}} -ParameterFilter {$Name -eq 'Invoke-NovaBuild'}
+            Mock Test-ProjectSchema {}
+            Mock Add-ProjectPreambleToModuleBuilder {}
+            Mock Get-ProjectScriptFile {@()}
+            Mock Get-ChildItem {@()}
+
+            $missingSourceError = $null
+            try {
+                Build-Module -ProjectInfo $projectInfo
+            }
+            catch {
+                $missingSourceError = $_
+            }
+
+            $missingSourceError.Exception.Message | Should -Be 'No source files found to build. Add one or more scripts under src/public, src/private, or src/classes.'
+            $missingSourceError.FullyQualifiedErrorId | Should -Be 'Nova.Environment.BuildSourceFilesNotFound'
+            $missingSourceError.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::ObjectNotFound)
+            $missingSourceError.TargetObject | Should -Be 'src'
+
+            Mock Get-ProjectScriptFile {@($sourceFile)}
+            Mock Add-ScriptFileContentToModuleBuilder {}
+            Mock Set-Content {throw 'disk full'}
+
+            $psm1WriteError = $null
+            try {
+                Build-Module -ProjectInfo $projectInfo
+            }
+            catch {
+                $psm1WriteError = $_
+            }
+
+            $psm1WriteError.Exception.Message | Should -Be 'Failed to create psm1 file: disk full'
+            $psm1WriteError.FullyQualifiedErrorId | Should -Be 'Nova.Dependency.ModulePsm1CreationFailed'
+            $psm1WriteError.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::OpenError)
+            $psm1WriteError.TargetObject | Should -Be '/tmp/NovaModuleTools.psm1'
+        }
+    }
+
     It 'Build-Manifest includes expected resource paths and prerelease manifest metadata when resources go to <ResourceLocation>' -ForEach @(
         @{
             ResourceLocation = 'resources/'

--- a/tests/CoverageGaps.BuildInternals.Tests.ps1
+++ b/tests/CoverageGaps.BuildInternals.Tests.ps1
@@ -89,7 +89,18 @@ Describe 'Coverage gaps for build and duplicate-analysis internals' {
             Mock Get-ChildItem {@([pscustomobject]@{FullName = '/tmp/docs/Invoke-NovaBuild.md'})}
             Mock Get-Module {$null}
 
-            {Build-Help} | Should -Throw 'The module Microsoft.PowerShell.PlatyPS must be installed*'
+            $thrown = $null
+            try {
+                Build-Help
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown.Exception.Message | Should -BeLike 'The module Microsoft.PowerShell.PlatyPS must be installed*'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Dependency.BuildHelpDependencyMissing'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::ResourceUnavailable)
+            $thrown.TargetObject | Should -Be 'Microsoft.PowerShell.PlatyPS'
         }
     }
 
@@ -226,7 +237,8 @@ Describe 'Coverage gaps for build and duplicate-analysis internals' {
             Mock Assert-ManifestSchema {}
             Mock New-ModuleManifest {throw 'manifest failed'}
 
-            {
+            $thrown = $null
+            try {
                 Build-Manifest -ProjectInfo ([pscustomobject]@{
                     PublicDir = '/tmp/public'
                     ResourcesDir = '/tmp/resources'
@@ -237,7 +249,15 @@ Describe 'Coverage gaps for build and duplicate-analysis internals' {
                     ProjectName = 'NovaModuleTools'
                     ManifestFilePSD1 = '/tmp/NovaModuleTools.psd1'
                 })
-            } | Should -Throw 'Failed to create Manifest*'
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown.Exception.Message | Should -BeLike 'Failed to create Manifest*'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Dependency.ModuleManifestCreationFailed'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::OpenError)
+            $thrown.TargetObject | Should -Be '/tmp/NovaModuleTools.psd1'
         }
     }
 

--- a/tests/CoverageGaps.Cli.TestSupport.ps1
+++ b/tests/CoverageGaps.Cli.TestSupport.ps1
@@ -1,0 +1,16 @@
+function Assert-TestStructuredCliError {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]$ThrownError,
+        [Parameter(Mandatory)][pscustomobject]$ExpectedError
+    )
+
+    $ThrownError | Should -Not -BeNullOrEmpty
+    $ThrownError.Exception.Message | Should -BeLike $ExpectedError.Message
+    $ThrownError.FullyQualifiedErrorId | Should -Be $ExpectedError.ErrorId
+    $ThrownError.CategoryInfo.Category | Should -Be $ExpectedError.Category
+    if ($ExpectedError.PSObject.Properties.Name -contains 'TargetObject') {
+        $ThrownError.TargetObject | Should -Be $ExpectedError.TargetObject
+    }
+}
+

--- a/tests/CoverageGaps.Cli.Tests.ps1
+++ b/tests/CoverageGaps.Cli.Tests.ps1
@@ -1,12 +1,21 @@
 $script:gitTestSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'GitTestSupport.ps1')).Path
+$script:coverageGapsCliTestSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'CoverageGaps.Cli.TestSupport.ps1')).Path
 $global:gitTestSupportFunctionNameList = @(
     'Initialize-TestGitRepository'
     'New-TestGitCommit'
     'New-TestGitTag'
 )
+$global:coverageGapsCliTestSupportFunctionNameList = @(
+    'Assert-TestStructuredCliError'
+)
 . $script:gitTestSupportPath
+. $script:coverageGapsCliTestSupportPath
 
 foreach ($functionName in $global:gitTestSupportFunctionNameList) {
+    $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
+    Set-Item -Path "function:global:$functionName" -Value $scriptBlock
+}
+foreach ($functionName in $global:coverageGapsCliTestSupportFunctionNameList) {
     $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
     Set-Item -Path "function:global:$functionName" -Value $scriptBlock
 }
@@ -14,6 +23,7 @@ foreach ($functionName in $global:gitTestSupportFunctionNameList) {
 BeforeAll {
     $here = Split-Path -Parent $PSCommandPath
     $gitTestSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'GitTestSupport.ps1')).Path
+    $coverageGapsCliTestSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'CoverageGaps.Cli.TestSupport.ps1')).Path
     $script:repoRoot = Split-Path -Parent $here
     $script:moduleName = (Get-Content -LiteralPath (Join-Path $script:repoRoot 'project.json') -Raw | ConvertFrom-Json).ProjectName
     $script:distModuleDir = Join-Path $script:repoRoot "dist/$script:moduleName"
@@ -23,7 +33,12 @@ BeforeAll {
     }
 
     . $gitTestSupportPath
+    . $coverageGapsCliTestSupportPath
     foreach ($functionName in $global:gitTestSupportFunctionNameList) {
+        $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
+        Set-Item -Path "function:global:$functionName" -Value $scriptBlock
+    }
+    foreach ($functionName in $global:coverageGapsCliTestSupportFunctionNameList) {
         $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
         Set-Item -Path "function:global:$functionName" -Value $scriptBlock
     }
@@ -179,39 +194,89 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
         }
     }
 
-    It 'ConvertFrom-NovaInitCliArgument rejects positional init paths' {
-        InModuleScope $script:moduleName {
-            $thrown = $null
-            try {
-                ConvertFrom-NovaInitCliArgument -Arguments @('some/path')
+    It 'the migrated CLI parsers expose structured validation errors for invalid usage cases' -ForEach @(
+        [pscustomobject]@{
+            CommandName = 'ConvertFrom-NovaInitCliArgument'
+            Arguments = @('some/path')
+            ExpectedError = [pscustomobject]@{
+                Message = "Unsupported 'nova init' usage*"
+                ErrorId = 'Nova.Validation.UnsupportedInitCliUsage'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                TargetObject = 'some/path'
             }
-            catch {
-                $thrown = $_
-            }
-
-            $thrown | Should -Not -BeNullOrEmpty
-            $thrown.Exception.Message | Should -BeLike "Unsupported 'nova init' usage*"
-            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Validation.UnsupportedInitCliUsage'
-            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidArgument)
-            $thrown.TargetObject | Should -Be 'some/path'
         }
-    }
+        [pscustomobject]@{
+            CommandName = 'ConvertFrom-NovaInitCliArgument'
+            Arguments = @('--path')
+            ExpectedError = [pscustomobject]@{
+                Message = 'Missing value for --path'
+                ErrorId = 'Nova.Validation.MissingCliOptionValue'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                TargetObject = '--path'
+            }
+        }
+        [pscustomobject]@{
+            CommandName = 'ConvertFrom-NovaNotificationCliArgument'
+            Arguments = @('-enable', '-disable')
+            ExpectedError = [pscustomobject]@{
+                Message = "Unsupported 'nova notification' usage*"
+                ErrorId = 'Nova.Validation.UnsupportedNotificationCliUsage'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+            }
+        }
+        [pscustomobject]@{
+            CommandName = 'ConvertFrom-NovaNotificationCliArgument'
+            Arguments = @('--bogus')
+            ExpectedError = [pscustomobject]@{
+                Message = 'Unknown argument: --bogus'
+                ErrorId = 'Nova.Validation.UnknownCliArgument'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                TargetObject = '--bogus'
+            }
+        }
+        [pscustomobject]@{
+            CommandName = 'ConvertFrom-NovaDeployCliArgument'
+            Arguments = @('--url')
+            ExpectedError = [pscustomobject]@{
+                Message = 'Missing value for --url'
+                ErrorId = 'Nova.Validation.MissingCliOptionValue'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                TargetObject = '--url'
+            }
+        }
+        [pscustomobject]@{
+            CommandName = 'ConvertFrom-NovaDeployCliArgument'
+            Arguments = @('--bogus')
+            ExpectedError = [pscustomobject]@{
+                Message = 'Unknown argument: --bogus'
+                ErrorId = 'Nova.Validation.UnknownCliArgument'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                TargetObject = '--bogus'
+            }
+        }
+    ) {
+        InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+            param($TestCase)
 
-    It 'ConvertFrom-NovaInitCliArgument reports a missing path value' {
-        InModuleScope $script:moduleName {
             $thrown = $null
             try {
-                ConvertFrom-NovaInitCliArgument -Arguments @('--path')
+                switch ($TestCase.CommandName) {
+                    'ConvertFrom-NovaInitCliArgument' {
+                        ConvertFrom-NovaInitCliArgument -Arguments $TestCase.Arguments
+                    }
+                    'ConvertFrom-NovaNotificationCliArgument' {
+                        ConvertFrom-NovaNotificationCliArgument -Arguments $TestCase.Arguments
+                    }
+                    'ConvertFrom-NovaDeployCliArgument' {
+                        ConvertFrom-NovaDeployCliArgument -Arguments $TestCase.Arguments
+                    }
+                }
             }
             catch {
                 $thrown = $_
             }
 
-            $thrown | Should -Not -BeNullOrEmpty
-            $thrown.Exception.Message | Should -Be 'Missing value for --path'
-            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Validation.MissingCliOptionValue'
-            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidArgument)
-            $thrown.TargetObject | Should -Be '--path'
+            Assert-TestStructuredCliError -ThrownError $thrown -ExpectedError $TestCase.ExpectedError
         }
     }
 
@@ -223,18 +288,62 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
         }
     }
 
-    It 'ConvertFrom-NovaNotificationCliArgument rejects unsupported notification usage' {
-        InModuleScope $script:moduleName {
-            {ConvertFrom-NovaNotificationCliArgument -Arguments @('-enable', '-disable')} | Should -Throw "Unsupported 'nova notification' usage*"
-            {ConvertFrom-NovaNotificationCliArgument -Arguments @('--bogus')} | Should -Throw 'Unknown argument: --bogus'
-        }
-    }
-
     It 'ConvertFrom-NovaVersionCliArgument resolves default and installed version modes' {
         InModuleScope $script:moduleName {
             (ConvertFrom-NovaVersionCliArgument).Installed | Should -BeFalse
             (ConvertFrom-NovaVersionCliArgument -Arguments @('-Installed')).Installed | Should -BeTrue
-            {ConvertFrom-NovaVersionCliArgument -Arguments @('--bogus')} | Should -Throw "Unsupported 'nova version' usage*"
+
+            $unsupportedUsageError = $null
+            try {
+                ConvertFrom-NovaVersionCliArgument -Arguments @('--bogus')
+            }
+            catch {
+                $unsupportedUsageError = $_
+            }
+
+            Assert-TestStructuredCliError -ThrownError $unsupportedUsageError -ExpectedError ([pscustomobject]@{
+                Message = "Unsupported 'nova version' usage*"
+                ErrorId = 'Nova.Validation.UnsupportedVersionCliUsage'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+            })
+        }
+    }
+
+    It 'Get-NovaCliCommandHelp and Add-NovaCliHeaderOption expose structured CLI validation errors' {
+        InModuleScope $script:moduleName {
+            $unknownCommandError = $null
+            try {
+                Get-NovaCliCommandHelp -Command 'banana'
+            }
+            catch {
+                $unknownCommandError = $_
+            }
+
+            Assert-TestStructuredCliError -ThrownError $unknownCommandError -ExpectedError ([pscustomobject]@{
+                Message = "Unknown command: <banana> | Use 'nova --help' to see available commands."
+                ErrorId = 'Nova.Validation.UnknownCliCommand'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                TargetObject = 'banana'
+            })
+
+            $options = @{}
+            Add-NovaCliHeaderOption -Options $options -HeaderArgument 'X-Trace-Id=trace-123'
+            $options.Headers['X-Trace-Id'] | Should -Be 'trace-123'
+
+            $invalidHeaderError = $null
+            try {
+                Add-NovaCliHeaderOption -Options @{} -HeaderArgument '=value'
+            }
+            catch {
+                $invalidHeaderError = $_
+            }
+
+            Assert-TestStructuredCliError -ThrownError $invalidHeaderError -ExpectedError ([pscustomobject]@{
+                Message = 'Invalid header argument: =value. Use Name=Value.'
+                ErrorId = 'Nova.Validation.InvalidCliHeaderArgument'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                TargetObject = '=value'
+            })
         }
     }
 
@@ -267,44 +376,13 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
                     $thrown = $_
                 }
 
-                $thrown | Should -Not -BeNullOrEmpty
-                $thrown.Exception.Message | Should -Be $testCase.ExpectedMessage
-                $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Validation.MissingCliOptionValue'
-                $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidArgument)
-                $thrown.TargetObject | Should -Be $testCase.Target
+                Assert-TestStructuredCliError -ThrownError $thrown -ExpectedError ([pscustomobject]@{
+                    Message = $testCase.ExpectedMessage
+                    ErrorId = 'Nova.Validation.MissingCliOptionValue'
+                    Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                    TargetObject = $testCase.Target
+                })
             }
-        }
-    }
-
-    It 'ConvertFrom-NovaDeployCliArgument reports structured parsing errors' {
-        InModuleScope $script:moduleName {
-            $missingValueError = $null
-            try {
-                ConvertFrom-NovaDeployCliArgument -Arguments @('--url')
-            }
-            catch {
-                $missingValueError = $_
-            }
-
-            $missingValueError | Should -Not -BeNullOrEmpty
-            $missingValueError.Exception.Message | Should -Be 'Missing value for --url'
-            $missingValueError.FullyQualifiedErrorId | Should -Be 'Nova.Validation.MissingCliOptionValue'
-            $missingValueError.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidArgument)
-            $missingValueError.TargetObject | Should -Be '--url'
-
-            $unknownArgumentError = $null
-            try {
-                ConvertFrom-NovaDeployCliArgument -Arguments @('--bogus')
-            }
-            catch {
-                $unknownArgumentError = $_
-            }
-
-            $unknownArgumentError | Should -Not -BeNullOrEmpty
-            $unknownArgumentError.Exception.Message | Should -Be 'Unknown argument: --bogus'
-            $unknownArgumentError.FullyQualifiedErrorId | Should -Be 'Nova.Validation.UnknownCliArgument'
-            $unknownArgumentError.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidArgument)
-            $unknownArgumentError.TargetObject | Should -Be '--bogus'
         }
     }
 

--- a/tests/CoverageGaps.Cli.Tests.ps1
+++ b/tests/CoverageGaps.Cli.Tests.ps1
@@ -454,14 +454,40 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
     It 'Get-NovaCliLauncherPath reports missing commands, missing file-backed commands, and missing launcher files' {
         InModuleScope $script:moduleName {
             Mock Get-Command {$null}
-            {Get-NovaCliLauncherPath} | Should -Throw 'Install-NovaCli command not found.'
+            $missingCommandError = $null
+            try {
+                Get-NovaCliLauncherPath
+            }
+            catch {
+                $missingCommandError = $_
+            }
+
+            Assert-TestStructuredCliError -ThrownError $missingCommandError -ExpectedError ([pscustomobject]@{
+                Message = 'Install-NovaCli command not found.'
+                ErrorId = 'Nova.Environment.CliInstallCommandNotFound'
+                Category = [System.Management.Automation.ErrorCategory]::ObjectNotFound
+                TargetObject = 'Install-NovaCli'
+            })
 
             Mock Get-Command {
                 [pscustomobject]@{
                     ScriptBlock = [pscustomobject]@{File = $null}
                 }
             }
-            {Get-NovaCliLauncherPath} | Should -Throw 'Install-NovaCli must be loaded from a file-backed module.'
+            $nonFileBackedCommandError = $null
+            try {
+                Get-NovaCliLauncherPath
+            }
+            catch {
+                $nonFileBackedCommandError = $_
+            }
+
+            Assert-TestStructuredCliError -ThrownError $nonFileBackedCommandError -ExpectedError ([pscustomobject]@{
+                Message = 'Install-NovaCli must be loaded from a file-backed module.'
+                ErrorId = 'Nova.Environment.CliInstallCommandNotFileBacked'
+                Category = [System.Management.Automation.ErrorCategory]::ResourceUnavailable
+                TargetObject = 'Install-NovaCli'
+            })
 
             Mock Get-Command {
                 [pscustomobject]@{
@@ -469,7 +495,20 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
                 }
             }
             Mock Test-Path {$false}
-            {Get-NovaCliLauncherPath} | Should -Throw 'Nova CLI launcher not found*'
+            $missingLauncherError = $null
+            try {
+                Get-NovaCliLauncherPath
+            }
+            catch {
+                $missingLauncherError = $_
+            }
+
+            Assert-TestStructuredCliError -ThrownError $missingLauncherError -ExpectedError ([pscustomobject]@{
+                Message = 'Nova CLI launcher not found*'
+                ErrorId = 'Nova.Environment.CliLauncherNotFound'
+                Category = [System.Management.Automation.ErrorCategory]::ObjectNotFound
+                TargetObject = 'nova'
+            })
         }
     }
 
@@ -570,7 +609,20 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
 
             Mock Resolve-NovaLocalPublishPath {'/tmp/local-modules'}
 
-            {Get-NovaInstalledProjectVersion -ProjectInfo $projectInfo} | Should -Throw 'Local module install not found for AzureDevOpsAgentInstaller*Run ''nova publish -local'' first*'
+            $thrown = $null
+            try {
+                Get-NovaInstalledProjectVersion -ProjectInfo $projectInfo
+            }
+            catch {
+                $thrown = $_
+            }
+
+            Assert-TestStructuredCliError -ThrownError $thrown -ExpectedError ([pscustomobject]@{
+                Message = 'Local module install not found for AzureDevOpsAgentInstaller*Run ''nova publish -local'' first*'
+                ErrorId = 'Nova.Environment.LocalModuleInstallNotFound'
+                Category = [System.Management.Automation.ErrorCategory]::ObjectNotFound
+                TargetObject = '/tmp/local-modules/AzureDevOpsAgentInstaller/AzureDevOpsAgentInstaller.psd1'
+            })
         }
     }
 
@@ -597,7 +649,21 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
                 return
             }
 
-            {Set-NovaCliExecutablePermission -Path (Join-Path $TestDrive 'missing-nova') -Confirm:$false} | Should -Throw 'Failed to make nova launcher executable*'
+            $path = Join-Path $TestDrive 'missing-nova'
+            $thrown = $null
+            try {
+                Set-NovaCliExecutablePermission -Path $path -Confirm:$false
+            }
+            catch {
+                $thrown = $_
+            }
+
+            Assert-TestStructuredCliError -ThrownError $thrown -ExpectedError ([pscustomobject]@{
+                Message = 'Failed to make nova launcher executable*'
+                ErrorId = 'Nova.Dependency.CliLauncherPermissionUpdateFailed'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidOperation
+                TargetObject = $path
+            })
         }
     }
 

--- a/tests/CoverageGaps.Cli.Tests.ps1
+++ b/tests/CoverageGaps.Cli.Tests.ps1
@@ -181,7 +181,21 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
         InModuleScope $script:moduleName {
             (ConvertFrom-NovaBumpCliArgument -Arguments @('--preview')).Preview | Should -BeTrue
             (ConvertFrom-NovaBumpCliArgument -Arguments @('-Preview')).Preview | Should -BeTrue
-            {ConvertFrom-NovaBumpCliArgument -Arguments @('--bogus')} | Should -Throw 'Unknown argument: --bogus'
+
+            $unknownArgumentError = $null
+            try {
+                ConvertFrom-NovaBumpCliArgument -Arguments @('--bogus')
+            }
+            catch {
+                $unknownArgumentError = $_
+            }
+
+            Assert-TestStructuredCliError -ThrownError $unknownArgumentError -ExpectedError ([pscustomobject]@{
+                Message = 'Unknown argument: --bogus'
+                ErrorId = 'Nova.Validation.UnknownCliArgument'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                TargetObject = '--bogus'
+            })
         }
     }
 
@@ -396,11 +410,44 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
                 $env:HOME = $TestDrive
                 Get-NovaCliInstallDirectory | Should -Be ([System.IO.Path]::Join($TestDrive, '.local', 'bin'))
                 $env:HOME = ''
-                {Get-NovaCliInstallDirectory} | Should -Throw 'HOME environment variable is not set*'
+
+                $missingHomeError = $null
+                try {
+                    Get-NovaCliInstallDirectory
+                }
+                catch {
+                    $missingHomeError = $_
+                }
+
+                Assert-TestStructuredCliError -ThrownError $missingHomeError -ExpectedError ([pscustomobject]@{
+                    Message = 'HOME environment variable is not set*'
+                    ErrorId = 'Nova.Environment.HomeDirectoryMissing'
+                    Category = [System.Management.Automation.ErrorCategory]::ResourceUnavailable
+                    TargetObject = 'HOME'
+                })
             }
             finally {
                 $env:HOME = $originalHome
             }
+        }
+    }
+
+    It 'Invoke-NovaCliInitCommand rejects WhatIf with a structured validation error' {
+        InModuleScope $script:moduleName {
+            $unsupportedWhatIfError = $null
+            try {
+                Invoke-NovaCliInitCommand -Arguments @('--path', '/tmp/project') -ForwardedParameters @{} -WhatIfEnabled
+            }
+            catch {
+                $unsupportedWhatIfError = $_
+            }
+
+            Assert-TestStructuredCliError -ThrownError $unsupportedWhatIfError -ExpectedError ([pscustomobject]@{
+                Message = "The 'nova init' CLI command does not support -WhatIf*"
+                ErrorId = 'Nova.Validation.UnsupportedInitCliWhatIf'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidOperation
+                TargetObject = 'WhatIf'
+            })
         }
     }
 

--- a/tests/CoverageGaps.Cli.Tests.ps1
+++ b/tests/CoverageGaps.Cli.Tests.ps1
@@ -181,13 +181,37 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
 
     It 'ConvertFrom-NovaInitCliArgument rejects positional init paths' {
         InModuleScope $script:moduleName {
-            {ConvertFrom-NovaInitCliArgument -Arguments @('some/path')} | Should -Throw "Unsupported 'nova init' usage*"
+            $thrown = $null
+            try {
+                ConvertFrom-NovaInitCliArgument -Arguments @('some/path')
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -BeLike "Unsupported 'nova init' usage*"
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Validation.UnsupportedInitCliUsage'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidArgument)
+            $thrown.TargetObject | Should -Be 'some/path'
         }
     }
 
     It 'ConvertFrom-NovaInitCliArgument reports a missing path value' {
         InModuleScope $script:moduleName {
-            {ConvertFrom-NovaInitCliArgument -Arguments @('--path')} | Should -Throw 'Missing value for --path'
+            $thrown = $null
+            try {
+                ConvertFrom-NovaInitCliArgument -Arguments @('--path')
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be 'Missing value for --path'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Validation.MissingCliOptionValue'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidArgument)
+            $thrown.TargetObject | Should -Be '--path'
         }
     }
 
@@ -225,10 +249,62 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
     }
 
     It 'ConvertFrom-NovaCliArgument reports missing values for repository, path, and api key' {
+        InModuleScope $script:moduleName -Parameters @{
+            TestCases = @(
+                @{Arguments = @('--repository'); ExpectedMessage = 'Missing value for --repository'; Target = '--repository'}
+                @{Arguments = @('--path'); ExpectedMessage = 'Missing value for --path'; Target = '--path'}
+                @{Arguments = @('--apikey'); ExpectedMessage = 'Missing value for --apikey'; Target = '--apikey'}
+            )
+        } {
+            param($TestCases)
+
+            foreach ($testCase in $TestCases) {
+                $thrown = $null
+                try {
+                    ConvertFrom-NovaCliArgument -Arguments $testCase.Arguments
+                }
+                catch {
+                    $thrown = $_
+                }
+
+                $thrown | Should -Not -BeNullOrEmpty
+                $thrown.Exception.Message | Should -Be $testCase.ExpectedMessage
+                $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Validation.MissingCliOptionValue'
+                $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidArgument)
+                $thrown.TargetObject | Should -Be $testCase.Target
+            }
+        }
+    }
+
+    It 'ConvertFrom-NovaDeployCliArgument reports structured parsing errors' {
         InModuleScope $script:moduleName {
-            {ConvertFrom-NovaCliArgument -Arguments @('--repository')} | Should -Throw 'Missing value for --repository'
-            {ConvertFrom-NovaCliArgument -Arguments @('--path')} | Should -Throw 'Missing value for --path'
-            {ConvertFrom-NovaCliArgument -Arguments @('--apikey')} | Should -Throw 'Missing value for --apikey'
+            $missingValueError = $null
+            try {
+                ConvertFrom-NovaDeployCliArgument -Arguments @('--url')
+            }
+            catch {
+                $missingValueError = $_
+            }
+
+            $missingValueError | Should -Not -BeNullOrEmpty
+            $missingValueError.Exception.Message | Should -Be 'Missing value for --url'
+            $missingValueError.FullyQualifiedErrorId | Should -Be 'Nova.Validation.MissingCliOptionValue'
+            $missingValueError.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidArgument)
+            $missingValueError.TargetObject | Should -Be '--url'
+
+            $unknownArgumentError = $null
+            try {
+                ConvertFrom-NovaDeployCliArgument -Arguments @('--bogus')
+            }
+            catch {
+                $unknownArgumentError = $_
+            }
+
+            $unknownArgumentError | Should -Not -BeNullOrEmpty
+            $unknownArgumentError.Exception.Message | Should -Be 'Unknown argument: --bogus'
+            $unknownArgumentError.FullyQualifiedErrorId | Should -Be 'Nova.Validation.UnknownCliArgument'
+            $unknownArgumentError.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidArgument)
+            $unknownArgumentError.TargetObject | Should -Be '--bogus'
         }
     }
 

--- a/tests/CoverageGaps.ReleaseInternals.Tests.ps1
+++ b/tests/CoverageGaps.ReleaseInternals.Tests.ps1
@@ -305,7 +305,20 @@ Describe 'Coverage gaps for release and git internals' {
     It 'Publish-NovaBuiltModule throws when dist is missing and Resolve-NovaLocalPublishPath returns explicit or local paths' {
         InModuleScope $script:moduleName {
             Mock Test-Path {$false}
-            {Publish-NovaBuiltModule -ProjectInfo ([pscustomobject]@{OutputModuleDir = '/tmp/missing'; ProjectName = 'Nova'})} | Should -Throw 'Dist folder is empty*'
+
+            $thrown = $null
+            try {
+                Publish-NovaBuiltModule -ProjectInfo ([pscustomobject]@{OutputModuleDir = '/tmp/missing'; ProjectName = 'Nova'})
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be 'Dist folder is empty, build the module before running publish command'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Environment.ReleaseBuildOutputNotFound'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::ObjectNotFound)
+            $thrown.TargetObject | Should -Be '/tmp/missing'
 
             Mock Get-LocalModulePath {'/tmp/local-modules'}
             Resolve-NovaLocalPublishPath -ModuleDirectoryPath '/tmp/custom' | Should -Be '/tmp/custom'

--- a/tests/CoverageGaps.ReleaseInternals.Tests.ps1
+++ b/tests/CoverageGaps.ReleaseInternals.Tests.ps1
@@ -426,7 +426,19 @@ Describe 'Coverage gaps for release and git internals' {
             Mock Get-NovaProjectInfo {throw 'not a project'}
             Mock Test-Path {$false}
 
-            {Get-ResourceFilePath -FileName 'missing.json'} | Should -Throw 'Resource file not found: missing.json*'
+            $thrown = $null
+            try {
+                Get-ResourceFilePath -FileName 'missing.json'
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -BeLike 'Resource file not found: missing.json*'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Environment.ResourceFileNotFound'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::ObjectNotFound)
+            $thrown.TargetObject | Should -Be 'missing.json'
         }
     }
 }

--- a/tests/CoverageGaps.ReleaseInternals.Tests.ps1
+++ b/tests/CoverageGaps.ReleaseInternals.Tests.ps1
@@ -343,7 +343,18 @@ Describe 'Coverage gaps for release and git internals' {
             $projectRoot = Join-Path $TestDrive 'empty-git-project'
             Initialize-TestGitRepository -Path $projectRoot
 
-            {Get-NovaVersionLabelForBump -ProjectRoot $projectRoot} | Should -Throw 'Cannot bump version because the repository has no commits yet. Create an initial commit first.'
+            $thrown = $null
+            try {
+                Get-NovaVersionLabelForBump -ProjectRoot $projectRoot
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown.Exception.Message | Should -Be 'Cannot bump version because the repository has no commits yet. Create an initial commit first.'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Workflow.GitRepositoryHasNoCommits'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidOperation)
+            $thrown.TargetObject | Should -Be $projectRoot
         }
     }
 
@@ -359,7 +370,18 @@ Describe 'Coverage gaps for release and git internals' {
             New-TestGitCommit -RepositoryPath $projectRoot -Message 'feat: initial release' -File @{Name = 'first.txt'; Content = 'first'}
             New-TestGitTag -RepositoryPath $projectRoot -TagName 'v1.0.0'
 
-            {Get-NovaVersionLabelForBump -ProjectRoot $projectRoot} | Should -Throw 'Cannot bump version because there are no commits since the latest tag.'
+            $thrown = $null
+            try {
+                Get-NovaVersionLabelForBump -ProjectRoot $projectRoot
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown.Exception.Message | Should -Be 'Cannot bump version because there are no commits since the latest tag.'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Workflow.NoCommitsSinceLatestTag'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidOperation)
+            $thrown.TargetObject | Should -Be $projectRoot
         }
     }
 

--- a/tests/CoverageGaps.Tests.ps1
+++ b/tests/CoverageGaps.Tests.ps1
@@ -205,7 +205,20 @@ Describe 'Coverage gaps for scaffold internals' {
                     }
                 }
             }
-            {Read-NovaModuleAnswerSet -Questions $questions} | Should -Throw 'Module name is invalid*'
+
+            $thrown = $null
+            try {
+                Read-NovaModuleAnswerSet -Questions $questions
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be 'Module name is invalid. Use a single word that starts with a letter and contains only letters, numbers, underscores, or periods.'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Validation.ScaffoldProjectNameInvalid'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidData)
+            $thrown.TargetObject | Should -Be 'bad name'
         }
     }
 
@@ -258,9 +271,19 @@ Describe 'Coverage gaps for scaffold internals' {
             Mock New-Item {}
             Mock New-InitiateGitRepo {}
 
-            {
+            $thrown = $null
+            try {
                 Initialize-NovaModuleScaffold -Answer @{EnablePester = 'No'; EnableGit = 'No'} -Paths $paths
-            } | Should -Throw 'Project already exists, aborting'
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be 'Project already exists, aborting'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Workflow.ScaffoldProjectAlreadyExists'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::ResourceExists)
+            $thrown.TargetObject | Should -Be $paths.Project
 
             Assert-MockCalled New-Item -Times 0
             Assert-MockCalled New-InitiateGitRepo -Times 0
@@ -532,7 +555,19 @@ Describe 'Coverage gaps for scaffold internals' {
             Mock Initialize-NovaModuleScaffold {}
             Mock Write-NovaModuleProjectJson {}
 
-            {Initialize-NovaModule -Path '/tmp/does-not-exist' -WhatIf} | Should -Throw 'Not a valid path*'
+            $thrown = $null
+            try {
+                Initialize-NovaModule -Path '/tmp/does-not-exist' -WhatIf
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be 'Not a valid path: /tmp/does-not-exist'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Environment.ScaffoldBasePathNotFound'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::ObjectNotFound)
+            $thrown.TargetObject | Should -Be '/tmp/does-not-exist'
 
             Assert-MockCalled Initialize-NovaModuleScaffold -Times 0
             Assert-MockCalled Write-NovaModuleProjectJson -Times 0
@@ -543,9 +578,19 @@ Describe 'Coverage gaps for scaffold internals' {
         InModuleScope $script:moduleName {
             Mock Read-AwesomeHost {'invalid name!'}
 
-            {
+            $thrown = $null
+            try {
                 Read-NovaModuleAnswerSet -Questions @{ProjectName = @{Prompt = 'Name?'}}
-            } | Should -Throw 'Module name is invalid*'
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be 'Module name is invalid. Use a single word that starts with a letter and contains only letters, numbers, underscores, or periods.'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Validation.ScaffoldProjectNameInvalid'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidData)
+            $thrown.TargetObject | Should -Be 'invalid name!'
         }
     }
 }

--- a/tests/NovaCommandModel.BumpAndCli.Tests.ps1
+++ b/tests/NovaCommandModel.BumpAndCli.Tests.ps1
@@ -315,7 +315,19 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
             Mock Get-NovaVersionUpdatePlan {throw 'should not calculate a version plan'}
             Mock Set-NovaModuleVersion {throw 'should not write project.json'}
 
-            {Update-NovaModuleVersion -Path $projectRoot -WhatIf} | Should -Throw 'Cannot bump version because the repository has no commits yet. Create an initial commit first.'
+            $thrown = $null
+            try {
+                Update-NovaModuleVersion -Path $projectRoot -WhatIf
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be 'Cannot bump version because the repository has no commits yet. Create an initial commit first.'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Workflow.GitRepositoryHasNoCommits'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidOperation)
+            $thrown.TargetObject | Should -Be $projectRoot
 
             Assert-MockCalled Get-NovaVersionUpdatePlan -Times 0
             Assert-MockCalled Set-NovaModuleVersion -Times 0

--- a/tests/NovaCommandModel.PackageUpload.TestSupport.ps1
+++ b/tests/NovaCommandModel.PackageUpload.TestSupport.ps1
@@ -276,7 +276,12 @@ function Get-TestNovaPackageUploadFailureCases {
         @{
             Name = 'the upload target URL is missing'
             ProjectRootName = 'missing-upload-url'
-            ExpectedMessage = 'Upload target URL is missing*'
+            ExpectedError = [pscustomobject]@{
+                Message = 'Upload target URL is missing*'
+                ErrorId = 'Nova.Configuration.PackageUploadTargetUrlMissing'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidData
+                TargetObject = 'Url'
+            }
             Invoke = {
                 param($PackagePath)
 
@@ -286,7 +291,11 @@ function Get-TestNovaPackageUploadFailureCases {
         @{
             Name = 'package selection is ambiguous'
             ProjectRootName = 'ambiguous-package-selection'
-            ExpectedMessage = 'Package selection is ambiguous*'
+            ExpectedError = [pscustomobject]@{
+                Message = 'Package selection is ambiguous*'
+                ErrorId = 'Nova.Validation.PackageUploadSelectionAmbiguous'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+            }
             Invoke = {
                 param($PackagePath)
 

--- a/tests/NovaCommandModel.PackageUpload.Tests.ps1
+++ b/tests/NovaCommandModel.PackageUpload.Tests.ps1
@@ -3,6 +3,7 @@ $script:packageUploadTestSupportPath = (Resolve-Path -LiteralPath (Join-Path $PS
 $global:novaCommandModelTestSupportFunctionNameList = @(
     'Get-TestRegexMatchGroup'
     'ConvertTo-TestNormalizedText'
+    'Assert-TestStructuredError'
     'Get-TestModuleDisplayVersion'
     'Get-TestHelpLocaleFromMarkdownFiles'
     'Get-CommandHelpActivationTestCase'
@@ -25,6 +26,8 @@ foreach ($functionName in $global:novaCommandModelPackageUploadTestSupportFuncti
     $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
     Set-Item -Path "function:global:$functionName" -Value $scriptBlock
 }
+$assertStructuredErrorScriptBlock = (Get-Command -Name 'Assert-TestStructuredError' -CommandType Function -ErrorAction Stop).ScriptBlock
+Set-Item -Path 'function:global:Assert-TestStructuredError' -Value $assertStructuredErrorScriptBlock
 
 BeforeAll {
     $testSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'NovaCommandModel.TestSupport.ps1')).Path
@@ -52,6 +55,9 @@ BeforeAll {
         $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
         Set-Item -Path "function:global:$functionName" -Value $scriptBlock
     }
+
+    $assertStructuredErrorScriptBlock = (Get-Command -Name 'Assert-TestStructuredError' -CommandType Function -ErrorAction Stop).ScriptBlock
+    Set-Item -Path 'function:global:Assert-TestStructuredError' -Value $assertStructuredErrorScriptBlock
 }
 
 Describe 'Nova command model - package upload behavior' {
@@ -452,6 +458,83 @@ Describe 'Nova command model - package upload behavior' {
         }
     }
 
+    It 'Get-NovaPackageArtifactType exposes a structured validation error for unsupported file extensions' {
+        InModuleScope $script:moduleName {
+            $thrown = $null
+
+            try {
+                Get-NovaPackageArtifactType -PackagePath '/tmp/package.invalid'
+            }
+            catch {
+                $thrown = $_
+            }
+
+            Assert-TestStructuredError -ThrownError $thrown -ExpectedError ([pscustomobject]@{
+                Message = 'Unsupported package file extension for upload: /tmp/package.invalid*'
+                ErrorId = 'Nova.Validation.UnsupportedPackageUploadFileType'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                TargetObject = '/tmp/package.invalid'
+            })
+        }
+    }
+
+    It 'Resolve-NovaPackageUploadOutputFileList exposes a structured error when the package output directory is missing' {
+        $layout = [pscustomobject]@{
+            ProjectRoot = (Join-Path $TestDrive 'missing-output-directory')
+            PackageOutputDir = (Join-Path $TestDrive 'missing-output-directory/artifacts/packages')
+        }
+
+        InModuleScope $script:moduleName -Parameters @{
+            ProjectInfo = (New-TestNovaPackageUploadProjectInfo -Layout $layout)
+        } {
+            param($ProjectInfo)
+
+            $thrown = $null
+
+            try {
+                Resolve-NovaPackageUploadOutputFileList -ProjectInfo $ProjectInfo
+            }
+            catch {
+                $thrown = $_
+            }
+
+            Assert-TestStructuredError -ThrownError $thrown -ExpectedError ([pscustomobject]@{
+                Message = "Package output directory not found: $( $ProjectInfo.Package.OutputDirectory.Path )*"
+                ErrorId = 'Nova.Environment.PackageOutputDirectoryNotFound'
+                Category = [System.Management.Automation.ErrorCategory]::ObjectNotFound
+                TargetObject = $ProjectInfo.Package.OutputDirectory.Path
+            })
+        }
+    }
+
+    It 'Resolve-NovaPackageUploadOutputFileSet exposes a structured workflow error when a requested artifact type is missing' {
+        $layout = Initialize-TestNovaPackageUploadLayout -ProjectRoot (Join-Path $TestDrive 'missing-output-artifact')
+        New-TestNovaPackageArtifactFile -Directory $layout.PackageOutputDir -Name 'PackageProject.2.3.4.zip' | Out-Null
+
+        InModuleScope $script:moduleName -Parameters @{
+            OutputDirectory = $layout.PackageOutputDir
+            ProjectInfo = (New-TestNovaPackageUploadProjectInfo -Layout $layout -Options @{PackageTypes = @('Zip', 'NuGet')})
+        } {
+            param($OutputDirectory, $ProjectInfo)
+
+            $thrown = $null
+
+            try {
+                Resolve-NovaPackageUploadOutputFileSet -OutputDirectory $OutputDirectory -ProjectInfo $ProjectInfo -PackageType 'NuGet'
+            }
+            catch {
+                $thrown = $_
+            }
+
+            Assert-TestStructuredError -ThrownError $thrown -ExpectedError ([pscustomobject]@{
+                Message = "Package file not found for package type 'NuGet' in '$OutputDirectory'*"
+                ErrorId = 'Nova.Workflow.PackageOutputArtifactNotFound'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidOperation
+                TargetObject = 'NuGet'
+            })
+        }
+    }
+
     It 'Deploy-NovaPackage fails clearly when PackageType conflicts with FileNamePattern' {
         $layout = Initialize-TestNovaPackageUploadLayout -ProjectRoot (Join-Path $TestDrive 'conflicting-package-type-and-pattern')
         New-TestNovaPackageArtifactFile -Directory $layout.PackageOutputDir -Name 'PackageProject.2.3.4.zip' | Out-Null
@@ -463,7 +546,20 @@ Describe 'Nova command model - package upload behavior' {
 
             Mock Get-NovaProjectInfo {$ProjectInfo}
 
-            {Deploy-NovaPackage -PackageType NuGet -Url 'https://packages.example/raw/'} | Should -Throw "Package.FileNamePattern 'PackageProject.*.zip' resolves to type 'Zip'*"
+            $conflictError = $null
+            try {
+                Deploy-NovaPackage -PackageType NuGet -Url 'https://packages.example/raw/'
+            }
+            catch {
+                $conflictError = $_
+            }
+
+            Assert-TestStructuredError -ThrownError $conflictError -ExpectedError ([pscustomobject]@{
+                Message = "Package.FileNamePattern 'PackageProject.*.zip' resolves to type 'Zip'*"
+                ErrorId = 'Nova.Validation.PackageUploadPatternConflict'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                TargetObject = 'PackageProject.*.zip'
+            })
         }
     }
 
@@ -477,7 +573,21 @@ Describe 'Nova command model - package upload behavior' {
 
             Mock Get-NovaProjectInfo {$ProjectInfo}
 
-            {Deploy-NovaPackage -PackagePath (Join-Path $ProjectInfo.ProjectRoot 'missing.zip') -Url 'https://packages.example/raw/'} | Should -Throw 'Package file not found:*'
+            $missingPath = Join-Path $ProjectInfo.ProjectRoot 'missing.zip'
+            $missingPackageError = $null
+            try {
+                Deploy-NovaPackage -PackagePath $missingPath -Url 'https://packages.example/raw/'
+            }
+            catch {
+                $missingPackageError = $_
+            }
+
+            Assert-TestStructuredError -ThrownError $missingPackageError -ExpectedError ([pscustomobject]@{
+                Message = 'Package file not found:*'
+                ErrorId = 'Nova.Environment.PackageUploadFileNotFound'
+                Category = [System.Management.Automation.ErrorCategory]::ObjectNotFound
+                TargetObject = $missingPath
+            })
         }
     }
 
@@ -488,14 +598,22 @@ Describe 'Nova command model - package upload behavior' {
         InModuleScope $script:moduleName -Parameters @{
             ProjectInfo = (New-TestNovaPackageUploadProjectInfo -Layout $layout)
             PackagePath = $packagePath
-            ExpectedMessage = $_.ExpectedMessage
+            ExpectedError = $_.ExpectedError
             InvokeAction = $_.Invoke
         } {
-            param($ProjectInfo, $PackagePath, $ExpectedMessage, $InvokeAction)
+            param($ProjectInfo, $PackagePath, $ExpectedError, $InvokeAction)
 
             Mock Get-NovaProjectInfo {$ProjectInfo}
 
-            {& $InvokeAction $PackagePath} | Should -Throw $ExpectedMessage
+            $thrown = $null
+            try {
+                & $InvokeAction $PackagePath
+            }
+            catch {
+                $thrown = $_
+            }
+
+            Assert-TestStructuredError -ThrownError $thrown -ExpectedError $ExpectedError
         }
     }
 

--- a/tests/NovaCommandModel.PackageUpload.Tests.ps1
+++ b/tests/NovaCommandModel.PackageUpload.Tests.ps1
@@ -617,6 +617,94 @@ Describe 'Nova command model - package upload behavior' {
         }
     }
 
+    It 'Get-NovaPackageRepository exposes a structured configuration error when a named repository cannot be resolved' {
+        $layout = Initialize-TestNovaPackageUploadLayout -ProjectRoot (Join-Path $TestDrive 'missing-package-repository')
+
+        InModuleScope $script:moduleName -Parameters @{
+            ProjectInfo = (New-TestNovaPackageUploadProjectInfo -Layout $layout)
+        } {
+            param($ProjectInfo)
+
+            $thrown = $null
+            try {
+                Get-NovaPackageRepository -ProjectInfo $ProjectInfo -Repository 'MissingRepo'
+            }
+            catch {
+                $thrown = $_
+            }
+
+            Assert-TestStructuredError -ThrownError $thrown -ExpectedError ([pscustomobject]@{
+                Message = 'Package repository not found: MissingRepo*'
+                ErrorId = 'Nova.Configuration.PackageRepositoryNotFound'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidData
+                TargetObject = 'MissingRepo'
+            })
+        }
+    }
+
+    It 'Invoke-NovaPackageArtifactUpload exposes a structured error when the package file is missing' {
+        InModuleScope $script:moduleName {
+            $uploadArtifact = [pscustomobject]@{
+                Type = 'Zip'
+                PackagePath = '/tmp/missing-package.zip'
+                PackageFileName = 'missing-package.zip'
+                Repository = ''
+                UploadUrl = 'https://packages.example/raw/missing-package.zip'
+                Headers = [ordered]@{}
+            }
+
+            $thrown = $null
+            try {
+                Invoke-NovaPackageArtifactUpload -UploadArtifact $uploadArtifact
+            }
+            catch {
+                $thrown = $_
+            }
+
+            Assert-TestStructuredError -ThrownError $thrown -ExpectedError ([pscustomobject]@{
+                Message = 'Package file not found: /tmp/missing-package.zip'
+                ErrorId = 'Nova.Environment.PackageUploadFileNotFound'
+                Category = [System.Management.Automation.ErrorCategory]::ObjectNotFound
+                TargetObject = '/tmp/missing-package.zip'
+            })
+        }
+    }
+
+    It 'Invoke-NovaPackageArtifactUpload exposes a structured dependency error when the upload request fails' {
+        $layout = Initialize-TestNovaPackageUploadLayout -ProjectRoot (Join-Path $TestDrive 'upload-request-fails')
+        $packagePath = New-TestNovaPackageArtifactFile -Directory $layout.PackageOutputDir -Name 'PackageProject.2.3.4.zip'
+
+        InModuleScope $script:moduleName -Parameters @{PackagePath = $packagePath} {
+            param($PackagePath)
+
+            $uploadArtifact = [pscustomobject]@{
+                Type = 'Zip'
+                PackagePath = $PackagePath
+                PackageFileName = 'PackageProject.2.3.4.zip'
+                Repository = ''
+                UploadUrl = 'https://packages.example/raw/PackageProject.2.3.4.zip'
+                Headers = [ordered]@{}
+            }
+
+            Mock Invoke-WebRequest {throw 'network down'}
+
+            $thrown = $null
+            try {
+                Invoke-NovaPackageArtifactUpload -UploadArtifact $uploadArtifact
+            }
+            catch {
+                $thrown = $_
+            }
+
+            Assert-TestStructuredError -ThrownError $thrown -ExpectedError ([pscustomobject]@{
+                Message = "Package upload failed for $PackagePath -> https://packages.example/raw/PackageProject.2.3.4.zip*"
+                ErrorId = 'Nova.Dependency.PackageUploadRequestFailed'
+                Category = [System.Management.Automation.ErrorCategory]::ConnectionError
+                TargetObject = 'https://packages.example/raw/PackageProject.2.3.4.zip'
+            })
+        }
+    }
+
     It 'Deploy-NovaPackage includes expected headers and auth when configured' {
         $layout = Initialize-TestNovaPackageUploadLayout -ProjectRoot (Join-Path $TestDrive 'upload-headers-and-auth')
         $packagePath = New-TestNovaPackageArtifactFile -Directory $layout.PackageOutputDir -Name 'PackageProject.2.3.4.zip'

--- a/tests/NovaCommandModel.ReleasePublish.Tests.ps1
+++ b/tests/NovaCommandModel.ReleasePublish.Tests.ps1
@@ -831,7 +831,7 @@ Describe 'Nova command model - release and publish behavior' {
 
             Mock Test-Path {$false}
 
-            $expectedError = if ($IsWindows) {
+            $expectedMessage = if ($IsWindows) {
                 'No windows module path matching*'
             }
             else {
@@ -839,11 +839,48 @@ Describe 'Nova command model - release and publish behavior' {
             }
 
             try {
-                {Get-LocalModulePath} | Should -Throw $expectedError
+                $thrown = $null
+                try {
+                    Get-LocalModulePath
+                }
+                catch {
+                    $thrown = $_
+                }
+
+                Assert-TestStructuredError -ThrownError $thrown -ExpectedError ([pscustomobject]@{
+                    Message = $expectedMessage
+                    ErrorId = 'Nova.Environment.LocalModulePathNotFound'
+                    Category = [System.Management.Automation.ErrorCategory]::ObjectNotFound
+                    TargetObject = if ($IsWindows) {
+                        '\\Documents\\PowerShell\\Modules'
+                    }
+                    else {
+                        '/\.local/share/powershell/Modules$'
+                    }
+                })
             }
             finally {
                 $env:PSModulePath = $originalModulePath
             }
+        }
+    }
+
+    It 'Import-NovaPublishedLocalModule exposes a structured error when the local manifest is missing' {
+        InModuleScope $script:moduleName {
+            $thrown = $null
+            try {
+                Import-NovaPublishedLocalModule -ProjectName 'NovaModuleTools' -ManifestPath '/tmp/missing/NovaModuleTools.psd1'
+            }
+            catch {
+                $thrown = $_
+            }
+
+            Assert-TestStructuredError -ThrownError $thrown -ExpectedError ([pscustomobject]@{
+                Message = 'Expected locally published module manifest at: /tmp/missing/NovaModuleTools.psd1'
+                ErrorId = 'Nova.Environment.LocalPublishedModuleManifestNotFound'
+                Category = [System.Management.Automation.ErrorCategory]::ObjectNotFound
+                TargetObject = '/tmp/missing/NovaModuleTools.psd1'
+            })
         }
     }
 

--- a/tests/NovaCommandModel.ReleasePublish.Tests.ps1
+++ b/tests/NovaCommandModel.ReleasePublish.Tests.ps1
@@ -85,7 +85,16 @@ Describe 'Nova command model - release and publish behavior' {
             Mock Test-NovaBuild {throw 'boom'}
             Mock Update-NovaModuleVersion {}
 
-            {Invoke-NovaRelease -PublishOption @{Local = $true} -Path (Get-Location).Path} | Should -Throw
+            $thrown = $null
+            try {
+                Invoke-NovaRelease -PublishOption @{Local = $true} -Path (Get-Location).Path
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be 'boom'
             Assert-MockCalled Update-NovaModuleVersion -Times 0
         }
     }

--- a/tests/NovaCommandModel.ReleasePublish.Tests.ps1
+++ b/tests/NovaCommandModel.ReleasePublish.Tests.ps1
@@ -2,6 +2,7 @@ $script:testSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'N
 $global:novaCommandModelTestSupportFunctionNameList = @(
     'Get-TestRegexMatchGroup'
     'ConvertTo-TestNormalizedText'
+    'Assert-TestStructuredError'
     'Get-TestModuleDisplayVersion'
     'Get-TestHelpLocaleFromMarkdownFiles'
     'Get-CommandHelpActivationTestCase'
@@ -19,6 +20,8 @@ foreach ($functionName in $global:novaCommandModelTestSupportFunctionNameList) {
     $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
     Set-Item -Path "function:global:$functionName" -Value $scriptBlock
 }
+$assertStructuredErrorScriptBlock = (Get-Command -Name 'Assert-TestStructuredError' -CommandType Function -ErrorAction Stop).ScriptBlock
+Set-Item -Path 'function:global:Assert-TestStructuredError' -Value $assertStructuredErrorScriptBlock
 
 BeforeAll {
     $testSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'NovaCommandModel.TestSupport.ps1')).Path
@@ -39,6 +42,9 @@ BeforeAll {
         $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
         Set-Item -Path "function:global:$functionName" -Value $scriptBlock
     }
+
+    $assertStructuredErrorScriptBlock = (Get-Command -Name 'Assert-TestStructuredError' -CommandType Function -ErrorAction Stop).ScriptBlock
+    Set-Item -Path 'function:global:Assert-TestStructuredError' -Value $assertStructuredErrorScriptBlock
 }
 
 Describe 'Nova command model - release and publish behavior' {
@@ -739,7 +745,20 @@ Describe 'Nova command model - release and publish behavior' {
             Mock Invoke-NovaBuild {throw 'should not build'}
             Mock Test-NovaBuild {throw 'should not test'}
 
-            {New-NovaModulePackage} | Should -Throw 'Missing package metadata value: Authors'
+            $thrown = $null
+            try {
+                New-NovaModulePackage
+            }
+            catch {
+                $thrown = $_
+            }
+
+            Assert-TestStructuredError -ThrownError $thrown -ExpectedError ([pscustomobject]@{
+                Message = 'Missing package metadata value: Authors'
+                ErrorId = 'Nova.Configuration.PackageMetadataValueMissing'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidData
+                TargetObject = 'Authors'
+            })
             Assert-MockCalled Invoke-NovaBuild -Times 0
             Assert-MockCalled Test-NovaBuild -Times 0
         }

--- a/tests/NovaCommandModel.StandaloneCli.Tests.ps1
+++ b/tests/NovaCommandModel.StandaloneCli.Tests.ps1
@@ -409,9 +409,72 @@ function Invoke-TestCliVerbose {
         }
     }
 
-    It 'Invoke-NovaCli deploy rejects the removed package subcommand token' {
-        InModuleScope $script:moduleName {
-            {Invoke-NovaCli deploy package --repository LocalRaw} | Should -Throw 'Unknown argument: package'
+    It 'Invoke-NovaCli surfaces structured CLI errors for <Name>' -ForEach @(
+        @{
+            Name = 'the removed deploy package subcommand token'
+            Action = {
+                Invoke-NovaCli deploy package --repository LocalRaw
+            }
+            ExpectedError = [pscustomobject]@{
+                Message = 'Unknown argument: package'
+                ErrorId = 'Nova.Validation.UnknownCliArgument'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                TargetObject = 'package'
+            }
+        }
+        @{
+            Name = 'an unsupported publish argument'
+            Action = {
+                Invoke-NovaCli publish --bogus
+            }
+            ExpectedError = [pscustomobject]@{
+                Message = 'Unknown argument: --bogus'
+                ErrorId = 'Nova.Validation.UnknownCliArgument'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                TargetObject = '--bogus'
+            }
+        }
+        @{
+            Name = 'unsupported init WhatIf usage'
+            Action = {
+                Invoke-NovaCli init -WhatIf
+            }
+            ExpectedError = [pscustomobject]@{
+                Message = "The 'nova init' CLI command does not support -WhatIf. Run 'nova init' or 'nova init -Path <path>' without -WhatIf."
+                ErrorId = 'Nova.Validation.UnsupportedInitCliWhatIf'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidOperation
+                TargetObject = 'WhatIf'
+            }
+        }
+        @{
+            Name = 'unsupported positional init path usage'
+            Action = {
+                Invoke-NovaCli init 'some/path'
+            }
+            ExpectedError = [pscustomobject]@{
+                Message = "Unsupported 'nova init' usage: positional paths are no longer accepted. Use 'nova init -Path some/path' instead."
+                ErrorId = 'Nova.Validation.UnsupportedInitCliUsage'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                TargetObject = 'some/path'
+            }
+        }
+    ) {
+        InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+            param($TestCase)
+
+            $thrown = $null
+            try {
+                & $TestCase.Action
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be $TestCase.ExpectedError.Message
+            $thrown.FullyQualifiedErrorId | Should -Be $TestCase.ExpectedError.ErrorId
+            $thrown.CategoryInfo.Category | Should -Be $TestCase.ExpectedError.Category
+            $thrown.TargetObject | Should -Be $TestCase.ExpectedError.TargetObject
         }
     }
 
@@ -455,21 +518,4 @@ function Invoke-TestCliVerbose {
         }
     }
 
-    It 'Invoke-NovaCli init rejects -WhatIf with a clear error' {
-        InModuleScope $script:moduleName {
-            {Invoke-NovaCli init -WhatIf} | Should -Throw '*does not support -WhatIf*'
-        }
-    }
-
-    It 'Invoke-NovaCli init rejects positional paths instead of treating them as -Path' {
-        InModuleScope $script:moduleName {
-            {Invoke-NovaCli init 'some/path'} | Should -Throw '*positional paths are no longer accepted*'
-        }
-    }
-
-    It 'Invoke-NovaCli throws on unsupported argument' {
-        InModuleScope $script:moduleName {
-            {Invoke-NovaCli publish --bogus} | Should -Throw 'Unknown argument*'
-        }
-    }
 }

--- a/tests/NovaCommandModel.TestSupport.ps1
+++ b/tests/NovaCommandModel.TestSupport.ps1
@@ -25,6 +25,22 @@ function ConvertTo-TestNormalizedText {
     return ($Text -replace '\s+', ' ').Trim()
 }
 
+function Assert-TestStructuredError {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]$ThrownError,
+        [Parameter(Mandatory)][pscustomobject]$ExpectedError
+    )
+
+    $ThrownError | Should -Not -BeNullOrEmpty
+    $ThrownError.Exception.Message | Should -BeLike $ExpectedError.Message
+    $ThrownError.FullyQualifiedErrorId | Should -Be $ExpectedError.ErrorId
+    $ThrownError.CategoryInfo.Category | Should -Be $ExpectedError.Category
+    if ($ExpectedError.PSObject.Properties.Name -contains 'TargetObject') {
+        $ThrownError.TargetObject | Should -Be $ExpectedError.TargetObject
+    }
+}
+
 function Get-TestModuleDisplayVersion {
     [CmdletBinding()]
     param(

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -351,7 +351,12 @@ Describe 'Nova command model - project, help, and build behavior' {
             Version = '0.0.5'
             Guid = '88888888-8888-8888-8888-888888888888'
             Types = @('Tar')
-            ErrorMessage = 'Unsupported Package.Types value: Tar*'
+            ExpectedError = [pscustomobject]@{
+                Message = 'Unsupported Package.Types value: Tar. Supported values: NuGet, Zip, .nupkg, .zip.'
+                ErrorId = 'Nova.Configuration.UnsupportedPackageType'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidData
+                TargetObject = 'Tar'
+            }
         }
     ) {
         InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
@@ -375,8 +380,20 @@ Describe 'Nova command model - project, help, and build behavior' {
 
             Set-Content -LiteralPath (Join-Path $projectRoot 'project.json') -Value $projectJson -Encoding utf8
 
-            if ( $TestCase.ContainsKey('ErrorMessage')) {
-                {Get-NovaProjectInfo -Path $projectRoot} | Should -Throw $TestCase.ErrorMessage
+            if ( $TestCase.ContainsKey('ExpectedError')) {
+                $thrown = $null
+                try {
+                    Get-NovaProjectInfo -Path $projectRoot
+                }
+                catch {
+                    $thrown = $_
+                }
+
+                $thrown | Should -Not -BeNullOrEmpty
+                $thrown.Exception.Message | Should -Be $TestCase.ExpectedError.Message
+                $thrown.FullyQualifiedErrorId | Should -Be $TestCase.ExpectedError.ErrorId
+                $thrown.CategoryInfo.Category | Should -Be $TestCase.ExpectedError.Category
+                $thrown.TargetObject | Should -Be $TestCase.ExpectedError.TargetObject
                 return
             }
 

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -112,7 +112,18 @@ Describe 'Nova command model - project, help, and build behavior' {
             $projectRoot = Join-Path $TestDrive 'missing-project-json'
             New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
 
-            {Get-NovaProjectInfo -Path $projectRoot} | Should -Throw 'Not a project folder. project.json not found:*'
+            $thrown = $null
+            try {
+                Get-NovaProjectInfo -Path $projectRoot
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -BeLike 'Not a project folder. project.json not found:*'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Environment.ProjectJsonNotFound'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::ObjectNotFound)
         }
     }
 
@@ -122,7 +133,18 @@ Describe 'Nova command model - project, help, and build behavior' {
             New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
             Set-Content -LiteralPath (Join-Path $projectRoot 'project.json') -Value '' -Encoding utf8
 
-            {Get-NovaProjectInfo -Path $projectRoot} | Should -Throw 'project.json is empty:*'
+            $thrown = $null
+            try {
+                Get-NovaProjectInfo -Path $projectRoot
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -BeLike 'project.json is empty:*'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Configuration.ProjectJsonEmpty'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidData)
         }
     }
 

--- a/tests/PreambleBuild.Tests.ps1
+++ b/tests/PreambleBuild.Tests.ps1
@@ -5,7 +5,6 @@ $global:preambleBuildTestSupportFunctionNameList = @(
     'Get-BuiltModuleFilePath'
     'Invoke-TestProjectBuild'
     'Get-BuiltModuleContent'
-    'Get-InvokeNovaBuildErrorMessage'
     'New-TestProjectWithPreamble'
 )
 
@@ -113,16 +112,31 @@ Describe 'Invoke-NovaBuild Preamble setting' {
     }
 
     Context 'invalid Preamble value <ProjectName>' -ForEach @(
-        @{ProjectName = 'PreambleInvalidType'; Preamble = 'Set-StrictMode -Version Latest'; ExpectedPatterns = @('Preamble', 'string\[\]', 'Set-StrictMode -Version Latest', 'top-level project\.json array of strings')}
-        @{ProjectName = 'PreambleInvalidItem'; Preamble = @('Set-StrictMode -Version Latest', 123); ExpectedPatterns = @('Preamble', 'string\[\]', 'index 1', '123', 'top-level project\.json array of strings')}
+        @{ProjectName = 'PreambleInvalidType'; Preamble = 'Set-StrictMode -Version Latest'; ExpectedMessage = 'Invalid project.json Preamble value: expected top-level Preamble as string[] but found type ''System.String'' with value "Set-StrictMode -Version Latest". Preamble must be a top-level project.json array of strings.'; ExpectedTarget = 'Set-StrictMode -Version Latest'}
+        @{ProjectName = 'PreambleInvalidItem'; Preamble = @('Set-StrictMode -Version Latest', 123); ExpectedMessage = 'Invalid project.json Preamble value: expected top-level Preamble as string[] but found entry at index 1 with type ''System.Int64'' and value 123. Preamble must be a top-level project.json array of strings.'; ExpectedTarget = 123}
     ) {
         It 'fails build with a clear validation error' {
             $root = New-TestProjectWithPreamble -TestDriveRoot $TestDrive -Name $ProjectName -Options @{Preamble = $Preamble}
-            $message = Get-InvokeNovaBuildErrorMessage -ProjectRoot $root
 
-            foreach ($pattern in $ExpectedPatterns) {
-                $message | Should -Match $pattern
+            $thrown = $null
+            try {
+                Push-Location -LiteralPath $root
+                try {
+                    Invoke-NovaBuild
+                }
+                finally {
+                    Pop-Location
+                }
             }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be $ExpectedMessage
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Configuration.ProjectPreambleInvalidType'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidData)
+            $thrown.TargetObject | Should -Be $ExpectedTarget
         }
     }
 }

--- a/tests/RemainingCommandCoverage.Tests.ps1
+++ b/tests/RemainingCommandCoverage.Tests.ps1
@@ -67,7 +67,18 @@ Describe 'Coverage for remaining command and filesystem branches' {
             Mock Test-Path {$false}
             Mock New-Item {throw 'access denied'} -ParameterFilter {$Path -eq $OutputDir}
 
-            {Reset-ProjectDist} | Should -Throw 'Failed to reset Dist folder: access denied'
+            $thrown = $null
+            try {
+                Reset-ProjectDist
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown.Exception.Message | Should -Be 'Failed to reset Dist folder: access denied'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Dependency.DistResetFailed'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::OpenError)
+            $thrown.TargetObject | Should -Be $OutputDir
         }
     }
 
@@ -101,7 +112,18 @@ Describe 'Coverage for remaining command and filesystem branches' {
             InModuleScope $script:moduleName -Parameters @{RepoPath = $repoPath} {
                 param($RepoPath)
 
-                {New-InitiateGitRepo -DirectoryPath $RepoPath -Confirm:$false} | Should -Throw 'Failed to initialize Git repo: init failed'
+                $thrown = $null
+                try {
+                    New-InitiateGitRepo -DirectoryPath $RepoPath -Confirm:$false
+                }
+                catch {
+                    $thrown = $_
+                }
+
+                $thrown.Exception.Message | Should -Be 'Failed to initialize Git repo: init failed'
+                $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Dependency.GitRepositoryInitializationFailed'
+                $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::OpenError)
+                $thrown.TargetObject | Should -Be $RepoPath
             }
         }
         finally {

--- a/tests/RemainingCommandCoverage.Tests.ps1
+++ b/tests/RemainingCommandCoverage.Tests.ps1
@@ -450,7 +450,18 @@ Describe 'Coverage for remaining command and filesystem branches' {
 
     It 'Invoke-NovaCli throws on an unknown top-level command' {
         InModuleScope $script:moduleName {
-            {Invoke-NovaCli banana} | Should -Throw 'Unknown command: <banana*'
+            $thrown = $null
+            try {
+                Invoke-NovaCli banana
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown.Exception.Message | Should -Be "Unknown command: <banana> | Use 'nova --help' to see available commands."
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Validation.UnknownCliCommand'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidArgument)
+            $thrown.TargetObject | Should -Be 'banana'
         }
     }
 

--- a/tests/RemainingCommandCoverage.Tests.ps1
+++ b/tests/RemainingCommandCoverage.Tests.ps1
@@ -202,7 +202,19 @@ Describe 'Coverage for remaining command and filesystem branches' {
             try {
                 Set-Variable -Name IsWindows -Value $true -Force
 
-                {Install-NovaCli} | Should -Throw 'Install-NovaCli currently supports macOS/Linux only*'
+                $unsupportedPlatformError = $null
+                try {
+                    Install-NovaCli
+                }
+                catch {
+                    $unsupportedPlatformError = $_
+                }
+
+                $unsupportedPlatformError | Should -Not -BeNullOrEmpty
+                $unsupportedPlatformError.Exception.Message | Should -BeLike 'Install-NovaCli currently supports macOS/Linux only*'
+                $unsupportedPlatformError.FullyQualifiedErrorId | Should -Be 'Nova.Environment.UnsupportedCliInstallPlatform'
+                $unsupportedPlatformError.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::NotImplemented)
+                $unsupportedPlatformError.TargetObject | Should -Be 'Windows'
             }
             finally {
                 Remove-Variable -Name IsWindows -Force -ErrorAction SilentlyContinue
@@ -301,7 +313,19 @@ Describe 'Coverage for remaining command and filesystem branches' {
                 Mock Get-NovaCliLauncherPath {'/tmp/source/nova'}
                 Mock Test-Path {$true}
 
-                {Install-NovaCli} | Should -Throw 'Target file already exists: /tmp/bin/nova*'
+                $targetExistsError = $null
+                try {
+                    Install-NovaCli
+                }
+                catch {
+                    $targetExistsError = $_
+                }
+
+                $targetExistsError | Should -Not -BeNullOrEmpty
+                $targetExistsError.Exception.Message | Should -BeLike 'Target file already exists: /tmp/bin/nova*'
+                $targetExistsError.FullyQualifiedErrorId | Should -Be 'Nova.Workflow.CliInstallTargetExists'
+                $targetExistsError.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::ResourceExists)
+                $targetExistsError.TargetObject | Should -Be '/tmp/bin/nova'
             }
             finally {
                 Remove-Variable -Name IsWindows -Force -ErrorAction SilentlyContinue

--- a/tests/RemainingCommandCoverage.Tests.ps1
+++ b/tests/RemainingCommandCoverage.Tests.ps1
@@ -520,11 +520,29 @@ Describe 'Coverage for remaining command and filesystem branches' {
         }
     }
 
-    It 'Invoke-NovaCli version -Installed throws a clear error when the current project is not installed locally' {
-        InModuleScope $script:moduleName {
-            Mock Get-NovaInstalledProjectVersion {throw "Local module install not found for AzureDevOpsAgentInstaller. Expected manifest at: /tmp/modules/AzureDevOpsAgentInstaller/AzureDevOpsAgentInstaller.psd1. Run 'nova publish -local' first."}
+    It 'Invoke-NovaCli version -Installed throws a clear structured error when the current project is not installed locally' {
+        InModuleScope $script:moduleName -Parameters @{
+            ExpectedManifestPath = '/tmp/modules/AzureDevOpsAgentInstaller/AzureDevOpsAgentInstaller.psd1'
+        } {
+            param($ExpectedManifestPath)
 
-            {Invoke-NovaCli version -Installed} | Should -Throw "Local module install not found for AzureDevOpsAgentInstaller*nova publish -local*"
+            Mock Get-NovaInstalledProjectVersion {
+                Stop-NovaOperation -Message "Local module install not found for AzureDevOpsAgentInstaller. Expected manifest at: $ExpectedManifestPath. Run 'nova publish -local' first." -ErrorId 'Nova.Environment.LocalModuleInstallNotFound' -Category ObjectNotFound -TargetObject $ExpectedManifestPath
+            }
+
+            $thrown = $null
+            try {
+                Invoke-NovaCli version -Installed
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be "Local module install not found for AzureDevOpsAgentInstaller. Expected manifest at: $ExpectedManifestPath. Run 'nova publish -local' first."
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Environment.LocalModuleInstallNotFound'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::ObjectNotFound)
+            $thrown.TargetObject | Should -Be $ExpectedManifestPath
         }
     }
 }

--- a/tests/RemainingCommandCoverage.Tests.ps1
+++ b/tests/RemainingCommandCoverage.Tests.ps1
@@ -197,7 +197,19 @@ Describe 'Coverage for remaining command and filesystem branches' {
             Mock Test-Path {$true}
             Mock Invoke-NovaPester {[pscustomobject]@{Result = 'Failed'}}
 
-            {Invoke-NovaTestWorkflow -WorkflowContext $workflowContext} | Should -Throw 'Tests failed'
+            $thrown = $null
+            try {
+                Invoke-NovaTestWorkflow -WorkflowContext $workflowContext
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be 'Tests failed'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Workflow.TestRunFailed'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidOperation)
+            $thrown.TargetObject | Should -Be '/tmp/nova-project/artifacts/TestResults.xml'
         }
     }
 

--- a/tests/RemainingHelperCoverage.Tests.ps1
+++ b/tests/RemainingHelperCoverage.Tests.ps1
@@ -429,6 +429,60 @@ Locale: en-US
         }
     }
 
+    It 'Get-NovaPackageAuthorList exposes a structured configuration error for unsupported values' {
+        InModuleScope $script:moduleName {
+            $thrown = $null
+            try {
+                Get-NovaPackageAuthorList -AuthorValue ([pscustomobject]@{Name = 'Author One'})
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown.Exception.Message | Should -Be 'Package.Authors must be a string or an array of strings.'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Configuration.PackageAuthorsInvalidType'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidData)
+        }
+    }
+
+    It 'Get-NovaPackageContentItemList exposes structured errors when built output is missing or empty' {
+        InModuleScope $script:moduleName {
+            $projectInfo = [pscustomobject]@{OutputModuleDir = '/tmp/dist/NovaModuleTools'}
+            $packageMetadata = [pscustomobject]@{ContentRoot = 'content'}
+
+            Mock Test-Path {$false}
+
+            $missingOutputError = $null
+            try {
+                Get-NovaPackageContentItemList -ProjectInfo $projectInfo -PackageMetadata $packageMetadata
+            }
+            catch {
+                $missingOutputError = $_
+            }
+
+            $missingOutputError.Exception.Message | Should -Be 'Built module output not found: /tmp/dist/NovaModuleTools. Run Invoke-NovaBuild before packaging.'
+            $missingOutputError.FullyQualifiedErrorId | Should -Be 'Nova.Environment.PackageBuildOutputNotFound'
+            $missingOutputError.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::ObjectNotFound)
+            $missingOutputError.TargetObject | Should -Be '/tmp/dist/NovaModuleTools'
+
+            Mock Test-Path {$true}
+            Mock Get-ChildItem {@()}
+
+            $emptyOutputError = $null
+            try {
+                Get-NovaPackageContentItemList -ProjectInfo $projectInfo -PackageMetadata $packageMetadata
+            }
+            catch {
+                $emptyOutputError = $_
+            }
+
+            $emptyOutputError.Exception.Message | Should -Be 'Built module output has no files to package: /tmp/dist/NovaModuleTools'
+            $emptyOutputError.FullyQualifiedErrorId | Should -Be 'Nova.Workflow.PackageBuildOutputEmpty'
+            $emptyOutputError.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidOperation)
+            $emptyOutputError.TargetObject | Should -Be '/tmp/dist/NovaModuleTools'
+        }
+    }
+
     It 'New-NovaPackageArtifact writes the expected package structure for <ExpectedType>' -ForEach @(
         @{ProjectRootName = 'package-project'; PackageTypes = @('NuGet'); RequestedPackageType = 'NuGet'; ExpectedType = 'NuGet'}
         @{ProjectRootName = 'zip-package-project'; PackageTypes = @('Zip'); RequestedPackageType = 'Zip'; ExpectedType = 'Zip'}

--- a/tests/RemainingHelperCoverage.Tests.ps1
+++ b/tests/RemainingHelperCoverage.Tests.ps1
@@ -246,33 +246,75 @@ function Get-Second {
         }
     }
 
+    It 'New-NovaErrorRecord and Stop-NovaOperation expose a stable error contract' {
+        InModuleScope $script:moduleName {
+            $errorRecord = New-NovaErrorRecord -Message 'Missing value for --path' -ErrorId 'Nova.Validation.MissingCliOptionValue' -Category InvalidArgument -TargetObject '--path'
+
+            $errorRecord.FullyQualifiedErrorId | Should -Be 'Nova.Validation.MissingCliOptionValue'
+            $errorRecord.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidArgument)
+            $errorRecord.TargetObject | Should -Be '--path'
+            $errorRecord.Exception.Message | Should -Be 'Missing value for --path'
+
+            $thrown = $null
+            try {
+                Stop-NovaOperation -Message 'Missing value for --path' -ErrorId 'Nova.Validation.MissingCliOptionValue' -Category InvalidArgument -TargetObject '--path'
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Validation.MissingCliOptionValue'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidArgument)
+            $thrown.TargetObject | Should -Be '--path'
+            $thrown.Exception.Message | Should -Be 'Missing value for --path'
+        }
+    }
+
     It 'Read-ProjectJsonData throws when project.json is <Name>' -ForEach @(
         @{
             Name = 'empty'
             FileName = 'empty-project.json'
             Content = ''
             ExpectedMessage = 'project.json is empty*'
+            ExpectedErrorId = 'Nova.Configuration.ProjectJsonEmpty'
+            ExpectedCategory = [System.Management.Automation.ErrorCategory]::InvalidData
         }
         @{
             Name = 'not valid JSON'
             FileName = 'invalid-project.json'
             Content = '{ invalid json }'
             ExpectedMessage = 'project.json is not valid JSON*'
+            ExpectedErrorId = 'Nova.Configuration.ProjectJsonInvalidJson'
+            ExpectedCategory = [System.Management.Automation.ErrorCategory]::ParserError
         }
         @{
             Name = 'not a top-level object'
             FileName = 'array-project.json'
             Content = '[1,2,3]'
             ExpectedMessage = 'project.json must contain a top-level JSON object*'
+            ExpectedErrorId = 'Nova.Configuration.ProjectJsonTopLevelObjectRequired'
+            ExpectedCategory = [System.Management.Automation.ErrorCategory]::InvalidData
         }
     ) {
         $projectJsonPath = Join-Path $TestDrive $_.FileName
         $_.Content | Set-Content -LiteralPath $projectJsonPath -Encoding utf8
 
-        InModuleScope $script:moduleName -Parameters @{ProjectJsonPath = $projectJsonPath; ExpectedMessage = $_.ExpectedMessage} {
-            param($ProjectJsonPath, $ExpectedMessage)
+        InModuleScope $script:moduleName -Parameters @{ProjectJsonPath = $projectJsonPath; ExpectedMessage = $_.ExpectedMessage; ExpectedErrorId = $_.ExpectedErrorId; ExpectedCategory = $_.ExpectedCategory} {
+            param($ProjectJsonPath, $ExpectedMessage, $ExpectedErrorId, $ExpectedCategory)
 
-            {Read-ProjectJsonData -ProjectJsonPath $ProjectJsonPath} | Should -Throw $ExpectedMessage
+            $thrown = $null
+            try {
+                Read-ProjectJsonData -ProjectJsonPath $ProjectJsonPath
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -BeLike $ExpectedMessage
+            $thrown.FullyQualifiedErrorId | Should -Be $ExpectedErrorId
+            $thrown.CategoryInfo.Category | Should -Be $ExpectedCategory
         }
     }
 

--- a/tests/RemainingHelperCoverage.Tests.ps1
+++ b/tests/RemainingHelperCoverage.Tests.ps1
@@ -5,13 +5,67 @@ $global:remainingHelperCoverageTestSupportFunctionNameList = @(
     'Initialize-TestNovaPackageProjectLayout',
     'Get-TestNovaPackageProjectInfo'
 )
+$script:remainingHelperCoverageLocalHelperFunctionNameList = @(
+    'Get-TestPackageOutputDirectorySafetyCases'
+)
 
-. $script:remainingHelperCoverageTestSupportPath
+function Publish-RemainingHelperCoverageTestSupportFunctions {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$SupportPath,
+        [Parameter(Mandatory)][string[]]$FunctionNameList
+    )
 
-foreach ($functionName in $global:remainingHelperCoverageTestSupportFunctionNameList) {
+    . $SupportPath
+
+    foreach ($functionName in $FunctionNameList) {
+        $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
+        Set-Item -Path "function:global:$functionName" -Value $scriptBlock
+    }
+}
+
+function Get-TestPackageOutputDirectorySafetyCases {
+    [CmdletBinding()]
+    param()
+
+    $rootPath = if ($IsWindows) {
+        'C:\'
+    } else {
+        '/'
+    }
+
+    return @(
+        @{
+            Name = 'filesystem root'
+            OutputDirectory = $rootPath
+            ProjectInfo = [pscustomobject]@{
+                ProjectRoot = '/tmp/project-root'
+                OutputModuleDir = '/tmp/project-root/dist/NovaModuleTools'
+            }
+            ErrorId = 'Nova.Configuration.PackageOutputDirectoryRootNotAllowed'
+            Message = 'Package.OutputDirectory.Path cannot be a filesystem root when Package.OutputDirectory.Clean is true.'
+            TargetObject = $rootPath
+        }
+        @{
+            Name = 'protected project content'
+            OutputDirectory = '/tmp/packages'
+            ProjectInfo = [pscustomobject]@{
+                ProjectRoot = '/tmp/packages/project-root'
+                OutputModuleDir = '/tmp/project-root/dist/NovaModuleTools'
+            }
+            ErrorId = 'Nova.Configuration.PackageOutputDirectoryProtectedPath'
+            Message = 'Package.OutputDirectory.Path cannot be cleaned because it would remove required project content: /tmp/packages/project-root'
+            TargetObject = '/tmp/packages/project-root'
+        }
+    )
+}
+
+foreach ($functionName in $script:remainingHelperCoverageLocalHelperFunctionNameList) {
     $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
     Set-Item -Path "function:global:$functionName" -Value $scriptBlock
 }
+
+Publish-RemainingHelperCoverageTestSupportFunctions -SupportPath $script:remainingHelperCoverageTestSupportPath -FunctionNameList $global:remainingHelperCoverageTestSupportFunctionNameList
 
 BeforeAll {
     $remainingHelperCoverageTestSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'RemainingHelperCoverage.TestSupport.ps1')).Path
@@ -20,6 +74,12 @@ BeforeAll {
         'Assert-TestNovaZipPackageArtifactContent',
         'Initialize-TestNovaPackageProjectLayout',
         'Get-TestNovaPackageProjectInfo'
+    )
+    $remainingHelperCoverageLocalHelperFunctionNameList = @(
+        'Get-TestSchemaResourceFilePath',
+        'Get-TestSchemaResourceContent',
+        'Get-TestPackageOutputDirectorySafetyCases',
+        'Assert-TestPackageArtifactContentForType'
     )
 
     . $remainingHelperCoverageTestSupportPath
@@ -122,6 +182,8 @@ Describe 'Coverage for remaining manifest, JSON, and help-locale helpers' {
     It 'Test-ProjectSchema validates the Build schema' {
         InModuleScope $script:moduleName {
             Mock Get-ResourceFilePath {
+                param($FileName)
+
                 if ($FileName -eq 'Schema-Build.json') {
                     return '/tmp/build-schema.json'
                 }
@@ -129,7 +191,9 @@ Describe 'Coverage for remaining manifest, JSON, and help-locale helpers' {
                 return '/tmp/pester-schema.json'
             }
             Mock Get-Content {
-                if ($Path -eq '/tmp/build-schema.json') {
+                param($Path)
+
+                if ([string]$Path -eq '/tmp/build-schema.json') {
                     return '{"title":"build"}'
                 }
 
@@ -418,7 +482,19 @@ Locale: en-US
                 Get-Item -LiteralPath $SecondDocPath
             )
 
-            {Get-NovaHelpLocale -HelpMarkdownFiles $helpFiles} | Should -Throw 'Multiple help locales found in docs metadata*'
+            $thrown = $null
+            try {
+                Get-NovaHelpLocale -HelpMarkdownFiles $helpFiles
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be 'Multiple help locales found in docs metadata: da-DK, en-US'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Configuration.HelpLocaleConflict'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidData)
+            @($thrown.TargetObject) | Should -Be @('da-DK', 'en-US')
         }
     }
 
@@ -442,6 +518,26 @@ Locale: en-US
             $thrown.Exception.Message | Should -Be 'Package.Authors must be a string or an array of strings.'
             $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Configuration.PackageAuthorsInvalidType'
             $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidData)
+        }
+    }
+
+    It 'Assert-NovaPackageOutputDirectoryCanBeCleared exposes structured validation errors for unsafe cleanup targets' -ForEach (Get-TestPackageOutputDirectorySafetyCases) {
+        InModuleScope $script:moduleName -Parameters @{Case = $_} {
+            param($Case)
+
+            $thrown = $null
+            try {
+                Assert-NovaPackageOutputDirectoryCanBeCleared -ProjectInfo $Case.ProjectInfo -OutputDirectory $Case.OutputDirectory
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be $Case.Message
+            $thrown.FullyQualifiedErrorId | Should -Be $Case.ErrorId
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidData)
+            $thrown.TargetObject | Should -Be $Case.TargetObject
         }
     }
 
@@ -488,6 +584,18 @@ Locale: en-US
         @{ProjectRootName = 'zip-package-project'; PackageTypes = @('Zip'); RequestedPackageType = 'Zip'; ExpectedType = 'Zip'}
     ) {
         $layout = Initialize-TestNovaPackageProjectLayout -ProjectRoot (Join-Path $TestDrive $_.ProjectRootName)
+        $assertPackageContentByType = @{
+            NuGet = {
+                param($PackagePath)
+
+                Assert-TestNovaPackageArtifactContent -PackagePath $PackagePath
+            }
+            Zip = {
+                param($PackagePath)
+
+                Assert-TestNovaZipPackageArtifactContent -PackagePath $PackagePath
+            }
+        }
 
         $packagePath = InModuleScope $script:moduleName -Parameters @{
             ProjectInfo = (Get-TestNovaPackageProjectInfo -Layout $layout -CleanOutputDirectory $true -PackageTypes $_.PackageTypes)
@@ -505,12 +613,7 @@ Locale: en-US
         }
 
         $packagePath | Should -Not -BeNullOrEmpty
-        if ($_.ExpectedType -eq 'Zip') {
-            Assert-TestNovaZipPackageArtifactContent -PackagePath $packagePath
-            return
-        }
-
-        Assert-TestNovaPackageArtifactContent -PackagePath $packagePath
+        & $assertPackageContentByType[$_.ExpectedType] $packagePath
     }
 
     It 'New-NovaPackageArtifact honors Package.OutputDirectory.Clean when stale package files exist' -ForEach @(
@@ -554,6 +657,34 @@ Locale: en-US
         Test-Path -LiteralPath $staleFilePath | Should -BeFalse
         Assert-TestNovaPackageArtifactContent -PackagePath $result[0].PackagePath
         Assert-TestNovaZipPackageArtifactContent -PackagePath $result[1].PackagePath
+    }
+
+    It 'New-NovaPackageArtifact rejects unsupported package types with a structured validation error' {
+        InModuleScope $script:moduleName {
+            Mock Assert-NovaPackageMetadata {}
+
+            $thrown = $null
+            try {
+                New-NovaPackageArtifact -ProjectInfo ([pscustomobject]@{OutputModuleDir = '/tmp/dist/NovaModuleTools'}) -PackageMetadata ([pscustomobject]@{
+                    Type = 'Tar'
+                    Latest = $false
+                    Id = 'PackageProject'
+                    Version = '2.3.4'
+                    PackageFileName = 'PackageProject.2.3.4.tar'
+                    PackagePath = '/tmp/packages/PackageProject.2.3.4.tar'
+                    OutputDirectory = '/tmp/packages'
+                }) -OutputDirectoryReady
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be 'Unsupported package type: Tar'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Validation.UnsupportedPackageArtifactType'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidArgument)
+            $thrown.TargetObject | Should -Be 'Tar'
+        }
     }
 
     It 'New-NovaPackageArtifacts also creates latest-named artifacts when Package.Latest is true' {

--- a/tests/RemainingHelperCoverage.Tests.ps1
+++ b/tests/RemainingHelperCoverage.Tests.ps1
@@ -184,6 +184,29 @@ Describe 'Coverage for remaining manifest, JSON, and help-locale helpers' {
         }
     }
 
+    It 'ConvertTo-NovaPackageType normalizes supported aliases and exposes a structured error for unsupported values' {
+        InModuleScope $script:moduleName {
+            ConvertTo-NovaPackageType -Type 'NuGet' | Should -Be 'NuGet'
+            ConvertTo-NovaPackageType -Type '.nupkg' | Should -Be 'NuGet'
+            ConvertTo-NovaPackageType -Type 'zip' | Should -Be 'Zip'
+            ConvertTo-NovaPackageType -Type '.zip' | Should -Be 'Zip'
+
+            $thrown = $null
+            try {
+                ConvertTo-NovaPackageType -Type 'tar.gz'
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be 'Unsupported Package.Types value: tar.gz. Supported values: NuGet, Zip, .nupkg, .zip.'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Configuration.UnsupportedPackageType'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidData)
+            $thrown.TargetObject | Should -Be 'tar.gz'
+        }
+    }
+
     It 'Get-AliasInFunctionFromFile returns aliases declared on the function' {
         $filePath = Join-Path $script:repoRoot 'src/public/InvokeNovaCli.ps1'
 

--- a/tests/RemainingHelperCoverage.Tests.ps1
+++ b/tests/RemainingHelperCoverage.Tests.ps1
@@ -209,11 +209,8 @@ Describe 'Coverage for remaining manifest, JSON, and help-locale helpers' {
         }
     }
 
-    It 'Test-ProjectSchema accepts Package.Types aliases case-insensitively and rejects unsupported values' -ForEach @(
-        @{Name = 'accepts mixed-case aliases'; Types = @('.NuPkg', 'ZIP'); Expected = $true; Throws = $false; ErrorMessage = $null}
-        @{Name = 'rejects unsupported type'; Types = @('Tar'); Expected = $null; Throws = $true; ErrorMessage = '*The JSON is not valid with the schema*'}
-    ) {
-        $projectRoot = Join-Path $TestDrive $_.Name.Replace(' ', '-')
+    It 'Test-ProjectSchema accepts Package.Types aliases case-insensitively' {
+        $projectRoot = Join-Path $TestDrive 'accepts-mixed-case-aliases'
         New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
         $projectJson = ([ordered]@{
             ProjectName = 'SchemaTypesProject'
@@ -225,22 +222,56 @@ Describe 'Coverage for remaining manifest, JSON, and help-locale helpers' {
                 GUID = '99999999-9999-9999-9999-999999999999'
             }
             Package = [ordered]@{
-                Types = $_.Types
+                Types = @('.NuPkg', 'ZIP')
             }
         } | ConvertTo-Json -Depth 5)
         Set-Content -LiteralPath (Join-Path $projectRoot 'project.json') -Value $projectJson -Encoding utf8
 
         Push-Location $projectRoot
         try {
-            InModuleScope $script:moduleName -Parameters @{Expected = $_.Expected; Throws = $_.Throws; ErrorMessage = $_.ErrorMessage} {
-                param($Expected, $Throws, $ErrorMessage)
+            InModuleScope $script:moduleName {
+                Test-ProjectSchema -Schema Build | Should -BeTrue
+            }
+        }
+        finally {
+            Pop-Location
+        }
+    }
 
-                if ($Throws) {
-                    {Test-ProjectSchema -Schema Build} | Should -Throw $ErrorMessage
-                    return
+    It 'Test-ProjectSchema exposes a structured error for unsupported Package.Types values' {
+        $projectRoot = Join-Path $TestDrive 'rejects-unsupported-type'
+        New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+        $projectJson = ([ordered]@{
+            ProjectName = 'SchemaTypesProject'
+            Description = 'Schema package types test'
+            Version = '0.0.1'
+            Manifest = [ordered]@{
+                Author = 'Test Author'
+                PowerShellHostVersion = '7.4'
+                GUID = '99999999-9999-9999-9999-999999999999'
+            }
+            Package = [ordered]@{
+                Types = @('Tar')
+            }
+        } | ConvertTo-Json -Depth 5)
+        Set-Content -LiteralPath (Join-Path $projectRoot 'project.json') -Value $projectJson -Encoding utf8
+
+        Push-Location $projectRoot
+        try {
+            InModuleScope $script:moduleName {
+                $thrown = $null
+                try {
+                    Test-ProjectSchema -Schema Build
+                }
+                catch {
+                    $thrown = $_
                 }
 
-                Test-ProjectSchema -Schema Build | Should -Be $Expected
+                $thrown | Should -Not -BeNullOrEmpty
+                $thrown.Exception.Message | Should -BeLike 'Invalid project.json for the Build schema: *The JSON is not valid with the schema*'
+                $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Configuration.ProjectSchemaValidationFailed'
+                $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidData)
+                $thrown.TargetObject | Should -Be 'project.json'
             }
         }
         finally {

--- a/tests/UpdateNotification.Tests.ps1
+++ b/tests/UpdateNotification.Tests.ps1
@@ -94,7 +94,19 @@ Describe 'Update notification behavior' {
 
     It 'Get-NovaUpdateNotificationPreferenceChangeContext throws when neither enable nor disable was requested' {
         InModuleScope $script:moduleName {
-            {Get-NovaUpdateNotificationPreferenceChangeContext} | Should -Throw 'Specify either -EnablePrereleaseNotifications or -DisablePrereleaseNotifications.'
+            $thrown = $null
+            try {
+                Get-NovaUpdateNotificationPreferenceChangeContext
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be 'Specify either -EnablePrereleaseNotifications or -DisablePrereleaseNotifications.'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Validation.UpdateNotificationPreferenceChangeRequired'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidArgument)
+            $thrown.TargetObject | Should -Be 'PrereleaseNotifications'
         }
     }
 
@@ -204,9 +216,19 @@ Describe 'Update notification behavior' {
             Mock Get-NovaInstalledModuleVersionInfo {[pscustomobject]@{ModuleName = 'NovaModuleTools'}}
             Mock Invoke-NovaModuleUpdateLookup {$null}
 
-            {
+            $thrown = $null
+            try {
                 Get-NovaModuleSelfUpdateWorkflowContext
-            } | Should -Throw 'Unable to determine a NovaModuleTools update candidate. Try again when the PowerShell Gallery is reachable.'
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be 'Unable to determine a NovaModuleTools update candidate. Try again when the PowerShell Gallery is reachable.'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Dependency.ModuleSelfUpdateCandidateUnavailable'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::ResourceUnavailable)
+            $thrown.TargetObject | Should -Be 'NovaModuleTools'
 
             Assert-MockCalled Invoke-NovaModuleUpdateLookup -Times 1 -ParameterFilter {
                 $AllowPrereleaseNotifications -and $TimeoutMilliseconds -eq 10000

--- a/tests/UpdateNotification.Tests.ps1
+++ b/tests/UpdateNotification.Tests.ps1
@@ -375,7 +375,19 @@ Describe 'Update notification behavior' {
     It 'ConvertFrom-NovaUpdateCliArgument allows no arguments and rejects unsupported usage' {
         InModuleScope $script:moduleName {
             (ConvertFrom-NovaUpdateCliArgument).Count | Should -Be 0
-            {ConvertFrom-NovaUpdateCliArgument -Arguments @('--bogus')} | Should -Throw "Unsupported 'nova update' usage*"
+
+            $unsupportedUsageError = $null
+            try {
+                ConvertFrom-NovaUpdateCliArgument -Arguments @('--bogus')
+            }
+            catch {
+                $unsupportedUsageError = $_
+            }
+
+            $unsupportedUsageError | Should -Not -BeNullOrEmpty
+            $unsupportedUsageError.Exception.Message | Should -BeLike "Unsupported 'nova update' usage*"
+            $unsupportedUsageError.FullyQualifiedErrorId | Should -Be 'Nova.Validation.UnsupportedUpdateCliUsage'
+            $unsupportedUsageError.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidArgument)
         }
     }
 

--- a/tests/UpdateNotification.Tests.ps1
+++ b/tests/UpdateNotification.Tests.ps1
@@ -586,8 +586,23 @@ throw 'offline'
         $result.HostMessages | Should -HaveCount 0
     }
 
-    It 'nova update stops on self-update failure instead of returning a success object' {
-        InModuleScope $script:moduleName {
+    It 'public self-update entrypoints stop on a structured self-update failure for <Name>' -ForEach @(
+        @{
+            Name = 'Update-NovaModuleTool'
+            Invoke = {
+                Update-NovaModuleTool -Confirm:$false
+            }
+        },
+        @{
+            Name = 'nova update'
+            Invoke = {
+                nova update -Confirm:$false
+            }
+        }
+    ) {
+        InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+            param($TestCase)
+
             Mock Read-NovaUpdateNotificationPreference {
                 [pscustomobject]@{PrereleaseNotificationsEnabled = $true}
             }
@@ -610,7 +625,19 @@ throw 'offline'
                 throw "Module 'NovaModuleTools' was not installed by using Install-Module, so it cannot be updated."
             }
 
-            {nova update -Confirm:$false} | Should -Throw '*was not installed by using Install-Module*'
+            $thrown = $null
+            try {
+                & $TestCase.Invoke
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be "Module 'NovaModuleTools' was not installed by using Install-Module, so it cannot be updated."
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Dependency.ModuleSelfUpdateFailed'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidOperation)
+            $thrown.TargetObject | Should -Be 'NovaModuleTools'
             Assert-MockCalled Invoke-NovaModuleSelfUpdate -Times 1
         }
     }


### PR DESCRIPTION
## Summary

- What changed?
  - Completed the final error-model cleanup pass for the central Nova error-model migration.
  - Replaced the remaining non-intentional `Should -Throw` assertions with explicit captured-error checks or structured error assertions.
  - Aligned the public self-update workflow so `Update-NovaModuleTool` and `nova update` now surface a stable structured error contract when self-update fails.
  - Documented the final end state in `plan.md`: the only remaining message-based assertions are the two documented intentional exceptions.
- Why was this change needed?
  - The repo still had a few brittle test assertions that depended on raw thrown text or generic `Should -Throw` behavior.
  - Converting those remaining non-intentional cases improves maintainability, keeps the error-model migration internally consistent, and makes failures easier to validate through stable ids/categories.
  - The two remaining message-based assertions are intentionally preserved because they validate wording owned by PowerShell / `Update-Module`, not Nova-owned error contracts.
- Link the issue, discussion, or follow-up work (for example `Closes #123`).
  - Follow-up to the central error-model migration tracked in `plan.md`.
  - Remaining follow-up idea: review command help/docs only if command failure guidance changes materially.

## Affected area

- [ ] `nova` CLI or command routing
- [x] Public PowerShell cmdlet behavior
- [ ] Scaffolding or `project.json` handling
- [x] Build, test, analyzer, coverage, or CI helper flow
- [ ] Package, raw upload, or package metadata workflow
- [ ] Publish, release, semantic-release, or GitHub Actions automation
- [x] Self-update or notification preference behavior
- [x] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
- [ ] End-user docs (`docs/*.html`)
- [ ] Command help (`docs/NovaModuleTools/en-US/*.md`)
- [ ] `src/resources/example/`
- [ ] Dependency or manifest changes (`package.json`, workflow dependencies, release tooling)
- [ ] Security-sensitive change
- [ ] Documentation-only change
- [x] Other

## Review guidance

- Highlight the main code path or workflow reviewers should start with.
  - Start with `src/private/update/InvokeNovaModuleSelfUpdateWorkflow.ps1` for the public self-update error-alignment change.
  - Then review the final assertion cleanup in `tests/BuildOptions.TestSupport.ps1`, `tests/BuildOptions.Tests.ps1`, and `tests/NovaCommandModel.ReleasePublish.Tests.ps1`.
  - Finish with `plan.md` to see the documented end state and the two intentional remaining message-based exceptions.
- Call out the primary files or folders changed (for example `src/public/`, `src/private/cli/`, `scripts/build/ci/`, `.github/workflows/`, `docs/`, or `src/resources/example/`).
  - `src/private/update/`
  - `tests/`
  - `plan.md`
  - `CHANGELOG.md`
- Call out any trade-offs, follow-up work, or known limitations.
  - Two message-based assertions remain intentionally:
    - `tests/UpdateNotification.Tests.ps1` for low-level `Invoke-NovaModuleSelfUpdate` install-guidance wording
    - `tests/NovaCommandModel.Tests.ps1` for native PowerShell parameter-binding wording on removed `Plaintext` render mode
  - Those should only be converted later if Nova takes ownership of the underlying wording contract.

## Validation

- [x] `Invoke-NovaBuild`
- [x] `Test-NovaBuild`
- [ ] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
- [x] Targeted Nova workflow validated (`nova build`, `nova test`, `nova merge`, `nova deploy`, `nova publish`,
  `nova release`, `nova update`, `nova notification`, or `nova init` as relevant)
- [ ] Docs/example only; executable validation not needed

Validation notes:

```text
Focused validation:
- Invoke-Pester ./tests/UpdateNotification.Tests.ps1 -Output Detailed
- Invoke-Pester ./tests/CiCoverage.Tests.ps1 -Output Detailed
- Invoke-Pester ./tests/BuildOptions.Tests.ps1 -Output Detailed
- Invoke-Pester ./tests/NovaCommandModel.ReleasePublish.Tests.ps1 -Output Detailed

Full validation:
- pwsh -NoLogo -NoProfile -File ./run.ps1
  - Result: Tests Passed: 390, Failed: 0
- git --no-pager diff --check
  - Result: passed

Targeted workflow exercised:
- nova update routing/behavior covered in UpdateNotification-focused validation.

Code Health:
- CodeScene pre-commit safeguard: passed
- CodeScene change-set analysis vs main: passed

Skipped checks:
- ./scripts/build/Invoke-ScriptAnalyzerCI.ps1 was not run as a standalone command in the final PR-summary pass because full repo validation already passed through ./run.ps1.
- ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1 was not run in this final pass because the changed code paths were covered by focused suites plus the normal full-repo validation loop.
```

## Documentation and release follow-up

- [x] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
- [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
- [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [ ] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
- [ ] `docs/*.html` updated if end-user workflows or examples changed
- [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
  changed
- [ ] No documentation, changelog, or example updates were needed

## Maintainability, compatibility, and risk

- [x] Code Health / maintainability impact considered
- [x] No breaking change
- [ ] Breaking change
- [ ] Security-sensitive change
- [ ] CI, workflow, or release-pipeline impact
- [ ] Dependency-review impact

Risk, rollout, or rollback notes:

```text
Compatibility impact is low.

This change mainly tightens error assertions and formalizes the end state of the error-model migration.
The only user-facing behavior change in scope is that public self-update entrypoints now expose a stable structured
error contract while preserving the underlying Update-Module guidance text.

Rollback is straightforward:
- revert the touched test files if the assertion cleanup needs to be backed out
- revert src/private/update/InvokeNovaModuleSelfUpdateWorkflow.ps1 if the structured self-update wrapper needs to be removed
- revert plan.md / CHANGELOG.md if the documentation summary should be withdrawn
```

> [!IMPORTANT]
> Do not use a public pull request to disclose a vulnerability before coordinated handling.
> Use the private reporting path in `SECURITY.md` for new security issues.

