### PR TITLE
feat(#111): introduce build-before-test option for nova test command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the current project version from `project.json`, while keeping `% nova --version` / `% nova -v` dedicated to the
   installed
   NovaModuleTools version.
+- Add build-before-test support to the test workflow so `Test-NovaBuild -Build`, `% nova test --build`, and `% nova
+  test -b` rebuild the project before running Pester.
 - Add an opt-in `-Preview` mode to `Update-NovaModuleVersion` / GNU-style `% nova bump --preview` / `% nova bump -p` for
   explicit preview iteration.
     - Stable versions still use the normal semantic bump target first, then append `-preview`.
@@ -84,6 +86,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change `nova` help to a dedicated CLI-native help system with both short and long command help forms.
     - `% nova <command> --help` and `% nova <command> -h` now show short CLI help.
     - `% nova --help <command>` and `% nova -h <command>` now show long CLI help.
+  - Long command help now includes the matching public GitHub Pages guide URL for the selected command, while short help
+    stays focused on command syntax and options.
     - CLI help no longer delegates to PowerShell `Get-Help` and now consistently shows CLI option spellings such as
       `--repository` and `-r`.
 - Refactor `tests/NovaCommandModel.TestSupport.ps1` into smaller, focused support scripts so the shared Nova command
@@ -101,6 +105,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix configuration and validation errors so empty `project.json` files and unsupported `Manifest` keys fail fast with
   clear messages.
+- Fix GitHub Pages guide fragment links so section anchors such as `#pack` scroll fully into view instead of hiding the
+  section heading behind the sticky top navigation.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ PS> Invoke-NovaBuild
 
 This creates the built module under `dist/NovaModuleTools/`.
 
+When you want the test workflow to rebuild first, use:
+
+```powershell
+PS> Test-NovaBuild -Build
+% nova test --build
+% nova test -b
+```
+
 NovaModuleTools can self-update the installed module from PowerShell or the `nova` CLI launcher.
 
 - Stable self-updates are always available.
@@ -128,6 +136,8 @@ Use the launcher-oriented help forms when you want CLI syntax instead of PowerSh
 
 - `% nova <command> --help` / `% nova <command> -h` shows short command help
 - `% nova --help <command>` / `% nova -h <command>` shows long command help
+- Long command help now includes the matching public GitHub Pages guide URL for the selected command, while short help
+  stays link-free
 - CLI help is launcher-native and uses CLI option spellings such as `--repository` and `-r`
 - Use PowerShell `Get-Help` when you want cmdlet help such as `Get-Help Publish-NovaModule -Full`
 - Root `% nova -v` means version, while command-level `% nova build -v` means verbose for supported routed commands

--- a/docs/NovaModuleTools/en-US/Test-NovaBuild.md
+++ b/docs/NovaModuleTools/en-US/Test-NovaBuild.md
@@ -4,7 +4,7 @@ external help file: NovaModuleTools-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: NovaModuleTools
-ms.date: 04/25/2026
+ms.date: 04/26/2026
 PlatyPS schema version: 2024-05-01
 title: Test-NovaBuild
 ---
@@ -20,14 +20,16 @@ Runs Pester tests for the current NovaModuleTools project.
 ### __AllParameterSets
 
 ```text
-PS> Test-NovaBuild [[-TagFilter] <string[]>] [[-ExcludeTagFilter] <string[]>] [[-OutputVerbosity] <string>]
-[[-OutputRenderMode] <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+PS> Test-NovaBuild [-Build] [[-TagFilter] <string[]>] [[-ExcludeTagFilter] <string[]>]
+ [[-OutputVerbosity] <string>] [[-OutputRenderMode] <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
 `Test-NovaBuild` reads the Pester configuration from `project.json`, resolves the correct test path, and runs the test
 suite against the current project.
+
+Use `-Build` when you want Nova to rebuild the project output before the Pester run starts.
 
 With the default
 `BuildRecursiveFolders=true`, test files in nested folders under `tests` are discovered and run. Set
@@ -50,12 +52,20 @@ Runs the Pester tests for the current project.
 ### EXAMPLE 2
 
 ```text
+PS> Test-NovaBuild -Build
+```
+
+Builds the project first, then runs the configured Pester test workflow.
+
+### EXAMPLE 3
+
+```text
 PS> Test-NovaBuild -TagFilter unit,fast
 ```
 
 Runs only tests tagged `unit` or `fast`.
 
-### EXAMPLE 3
+### EXAMPLE 4
 
 ```text
 PS> Test-NovaBuild -ExcludeTagFilter slow
@@ -63,7 +73,7 @@ PS> Test-NovaBuild -ExcludeTagFilter slow
 
 Runs the test suite while excluding tests tagged `slow`.
 
-### EXAMPLE 4
+### EXAMPLE 5
 
 ```text
 PS> Test-NovaBuild -OutputVerbosity Normal -OutputRenderMode Ansi
@@ -71,7 +81,7 @@ PS> Test-NovaBuild -OutputVerbosity Normal -OutputRenderMode Ansi
 
 Overrides the console output settings for the current test run while keeping color-capable rendering.
 
-### EXAMPLE 5
+### EXAMPLE 6
 
 ```text
 PS> Test-NovaBuild -WhatIf
@@ -79,7 +89,36 @@ PS> Test-NovaBuild -WhatIf
 
 Previews the planned Pester run without executing tests or writing `artifacts/TestResults.xml`.
 
+### EXAMPLE 7
+
+```text
+PS> Test-NovaBuild -Build -WhatIf
+```
+
+Previews the build-before-test workflow without rebuilding the project or running Pester.
+
 ## PARAMETERS
+
+### -Build
+
+Builds the project before the test workflow starts.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: [ ]
+ParameterSets:
+  - Name: (All)
+    Position: Named
+    IsRequired: false
+    ValueFromPipeline: false
+    ValueFromPipelineByPropertyName: false
+    ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: [ ]
+HelpMessage: ''
+```
 
 ### -ExcludeTagFilter
 

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -11,6 +11,7 @@
     --shadow: 0 20px 60px rgba(0, 0, 0, 0.28);
     --radius: 22px;
     --max-width: 1600px;
+    --anchor-offset: 2.90rem;
 }
 
 * {
@@ -19,6 +20,13 @@
 
 html {
     scroll-behavior: smooth;
+    scroll-padding-top: var(--anchor-offset);
+}
+
+.guide-hero[id],
+.content-section[id],
+.section[id] {
+    scroll-margin-top: var(--anchor-offset);
 }
 
 body {
@@ -891,6 +899,10 @@ td {
 }
 
 @media (max-width: 960px) {
+    :root {
+        --anchor-offset: 9.5rem;
+    }
+
     .site-header__inner,
     .hero,
     .card-grid,
@@ -933,6 +945,10 @@ td {
 }
 
 @media (max-width: 640px) {
+    :root {
+        --anchor-offset: 12rem;
+    }
+
     body {
         font-size: 16px;
     }

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -257,8 +257,9 @@ PS&gt; Invoke-NovaBuild -WhatIf</code></pre>
                             <li><strong>Best for:</strong> validating the project test suite from the normal Nova
                                 workflow
                             </li>
-                            <li><strong>Key parameters:</strong> <code>-TagFilter</code>, <code>-ExcludeTagFilter</code>,
-                                <code>-OutputVerbosity</code>, <code>-OutputRenderMode</code></li>
+                            <li><strong>Key parameters:</strong> <code>-Build</code>, <code>-TagFilter</code>,
+                                <code>-ExcludeTagFilter</code>, <code>-OutputVerbosity</code>,
+                                <code>-OutputRenderMode</code></li>
                             <li><strong>Notable behavior:</strong> uses <code>BuildRecursiveFolders</code> to decide
                                 nested test discovery
                             </li>
@@ -271,17 +272,20 @@ PS&gt; Invoke-NovaBuild -WhatIf</code></pre>
                             </div>
                             <div class="surface-example__surface" data-command-surface="powershell">
                                 <pre><code>PS&gt; Test-NovaBuild
+PS&gt; Test-NovaBuild -Build
 PS&gt; Test-NovaBuild -TagFilter unit,fast</code></pre>
                             </div>
                             <div class="surface-example__surface" data-command-surface="command-line" hidden>
                                 <pre><code>% nova test
+% nova test --build
 % nova test --what-if</code></pre>
                             </div>
                         </div>
                         <div class="surface-note" data-command-visibility="command-line" hidden>
-                            <p><strong>Command-line note:</strong> advanced test filters such as <code>-TagFilter</code>,
-                                <code>-ExcludeTagFilter</code>, and render-mode overrides stay on the PowerShell cmdlet
-                                surface.</p>
+                            <p><strong>Command-line note:</strong> use <code>--build</code> or <code>-b</code> when you
+                                want the routed CLI to rebuild before testing. Advanced test filters such as
+                                <code>-TagFilter</code>, <code>-ExcludeTagFilter</code>, and render-mode overrides stay
+                                on the PowerShell cmdlet surface.</p>
                         </div>
                         <p><a class="text-link" href="./core-workflows.html#test">See the test workflow</a></p>
                     </article>

--- a/docs/core-workflows.html
+++ b/docs/core-workflows.html
@@ -168,23 +168,27 @@ PS&gt; Initialize-NovaModule -Example -Path ~/Work</code></pre>
                     </div>
                     <div class="surface-example__surface" data-command-surface="powershell">
                         <pre><code>PS&gt; Test-NovaBuild
+PS&gt; Test-NovaBuild -Build
 PS&gt; Test-NovaBuild -TagFilter unit,fast
 PS&gt; Test-NovaBuild -ExcludeTagFilter slow
 PS&gt; Test-NovaBuild -OutputVerbosity Detailed -OutputRenderMode Ansi</code></pre>
                     </div>
                     <div class="surface-example__surface" data-command-surface="command-line" hidden>
                         <pre><code>% nova test
+% nova test --build
 % nova test --what-if</code></pre>
                     </div>
                 </div>
                 <p><code>Test-NovaBuild</code> reads the Pester configuration from <code>project.json</code>, resolves
                     the test path, and writes results to <code>artifacts/TestResults.xml</code>.</p>
+                <p>Use <code>-Build</code>, <code>--build</code>, or <code>-b</code> when you want Nova to rebuild the
+                    project before the test workflow starts.</p>
                 <p><strong>Important behavior:</strong> when <code>BuildRecursiveFolders</code> is <code>true</code>,
                     nested test files are discovered. When it is <code>false</code>, Nova stays closer to top-level
                     Pester-style discovery.</p>
                 <div class="surface-note" data-command-visibility="command-line" hidden>
-                    <p><strong>Command-line note:</strong> the routed CLI currently covers the standard test flow and
-                        preview mode. Advanced test overrides such as <code>-TagFilter</code>,
+                    <p><strong>Command-line note:</strong> the routed CLI covers the standard test flow, optional
+                        build-before-test, and preview mode. Advanced test overrides such as <code>-TagFilter</code>,
                         <code>-ExcludeTagFilter</code>, <code>-OutputVerbosity</code>, and
                         <code>-OutputRenderMode</code> are PowerShell cmdlet parameters, so switch to the PowerShell
                         view when you need those controls.</p>

--- a/project.json
+++ b/project.json
@@ -1,13 +1,14 @@
 {
   "ProjectName": "NovaModuleTools",
   "Description": "NovaModuleTools is an enterprise-focused evolution of ModuleTools, designed for large-scale PowerShell projects with a strong emphasis on structure, maintainability, and automated CI/CD pipelines.",
-  "Version": "2.0.0-preview93",
+  "Version": "2.0.0-preview94",
   "Preamble": [
     "Set-StrictMode -Version Latest",
     "$ErrorActionPreference = 'Stop'"
   ],
   "Manifest": {
     "Author": "Stiwi Gabriel Courage",
+    "Copyright": "Copyright (c) 2026 Terra Nova.",
     "PowerShellHostVersion": "7.4",
     "GUID": "6b9202c8-0353-473b-b73c-afab632125a6",
     "RequiredModules": [

--- a/src/private/cli/ConvertFromNovaTestCliArgument.ps1
+++ b/src/private/cli/ConvertFromNovaTestCliArgument.ps1
@@ -1,0 +1,23 @@
+function ConvertFrom-NovaTestCliArgument {
+    [CmdletBinding()]
+    param(
+        [string[]]$Arguments
+    )
+
+    $Arguments = ConvertTo-NovaCliArgumentArray -BoundParameters $PSBoundParameters -Arguments $Arguments
+    $options = @{}
+
+    foreach ($token in $Arguments) {
+        switch -Regex ($token) {
+            '^(--build|-b)$' {
+                $options.Build = $true
+            }
+            default {
+                Stop-NovaOperation -Message "Unknown argument: $token" -ErrorId 'Nova.Validation.UnknownCliArgument' -Category InvalidArgument -TargetObject $token
+            }
+        }
+    }
+
+    return $options
+}
+

--- a/src/private/cli/GetNovaCliArgumentRoutingState.ps1
+++ b/src/private/cli/GetNovaCliArgumentRoutingState.ps1
@@ -58,6 +58,7 @@ function Get-NovaCliLegacyOptionReplacement {
     $replacementMap = @{
         '-apikey' = "'--api-key' or '-k'"
         '-authenticationscheme' = "'--auth-scheme' or '-a'"
+        '-build' = "'--build' or '-b'"
         '-confirm' = "'--confirm' or '-c'"
         '-disable' = "'--disable' or '-d'"
         '-enable' = "'--enable' or '-e'"

--- a/src/private/cli/InvokeNovaCliCommandRoute.ps1
+++ b/src/private/cli/InvokeNovaCliCommandRoute.ps1
@@ -65,7 +65,8 @@ function Invoke-NovaCliCommandRoute {
             Invoke-NovaBuild @mutatingCommonParameters
         }
         'test' = {
-            Test-NovaBuild @mutatingCommonParameters
+            $options = ConvertFrom-NovaTestCliArgument -Arguments $arguments
+            Test-NovaBuild @options @mutatingCommonParameters
         }
         'package' = {
             New-NovaModulePackage @mutatingCommonParameters

--- a/src/private/quality/GetNovaTestWorkflowContext.ps1
+++ b/src/private/quality/GetNovaTestWorkflowContext.ps1
@@ -1,3 +1,16 @@
+function Get-NovaTestWorkflowOperation {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][bool]$BuildRequested
+    )
+
+    if ($BuildRequested) {
+        return 'Build project, run Pester tests, and write test results'
+    }
+
+    return 'Run Pester tests and write test results'
+}
+
 function Get-NovaTestWorkflowContext {
     [CmdletBinding()]
     param(
@@ -18,16 +31,19 @@ function Get-NovaTestWorkflowContext {
     Initialize-NovaPesterExecutionConfiguration -PesterConfig $pesterConfig -BoundParameters $BoundParameters -OutputVerbosity (Get-NovaTestOptionValue -TestOption $TestOption -Name OutputVerbosity) -OutputRenderMode (Get-NovaTestOptionValue -TestOption $TestOption -Name OutputRenderMode)
 
     $testResultPath = Get-NovaPesterTestResultPath -ProjectRoot $projectInfo.ProjectRoot
+    $buildRequested = [bool](Get-NovaTestOptionValue -TestOption $TestOption -Name Build)
 
     return [pscustomobject]@{
+        BuildRequested = $buildRequested
         ProjectInfo = $projectInfo
         PesterConfig = $pesterConfig
         TestResultPath = $testResultPath
         TestResultDirectory = Split-Path -Parent $testResultPath
         TestResultArtifactWriter = Get-Command -Name Write-NovaPesterTestResultArtifact -CommandType Function -ErrorAction Stop
         TestResultReportWriter = Get-Command -Name Write-NovaPesterTestResultReport -CommandType Function -ErrorAction Stop
+        WorkflowParams = Get-NovaShouldProcessForwardingParameter -WhatIfEnabled:($BoundParameters.ContainsKey('WhatIf') -and [bool]$BoundParameters.WhatIf)
         Target = $testResultPath
-        Operation = 'Run Pester tests and write test results'
+        Operation = Get-NovaTestWorkflowOperation -BuildRequested:$buildRequested
     }
 }
 

--- a/src/private/quality/InvokeNovaTestWorkflow.ps1
+++ b/src/private/quality/InvokeNovaTestWorkflow.ps1
@@ -1,8 +1,18 @@
 function Invoke-NovaTestWorkflow {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][pscustomobject]$WorkflowContext
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext,
+        [switch]$ShouldRun
     )
+
+    if (Test-NovaTestWorkflowBuildRequested -WorkflowContext $WorkflowContext) {
+        $workflowParams = $WorkflowContext.WorkflowParams
+        Invoke-NovaBuild @workflowParams
+    }
+
+    if (-not (Test-NovaTestWorkflowShouldRun -WorkflowContext $WorkflowContext -BoundParameters $PSBoundParameters -ShouldRun:$ShouldRun)) {
+        return
+    }
 
     Initialize-NovaPesterArtifactDirectory -WorkflowContext $WorkflowContext
     $WorkflowContext.PesterConfig.TestResult.OutputPath = $WorkflowContext.TestResultPath
@@ -12,6 +22,47 @@ function Invoke-NovaTestWorkflow {
     if ($testResult.Result -ne 'Passed') {
         Stop-NovaOperation -Message 'Tests failed' -ErrorId 'Nova.Workflow.TestRunFailed' -Category InvalidOperation -TargetObject $WorkflowContext.TestResultPath
     }
+}
+
+function Test-NovaTestWorkflowBuildRequested {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext
+    )
+
+    if ($WorkflowContext.PSObject.Properties.Name -notcontains 'BuildRequested') {
+        return $false
+    }
+
+    return [bool]$WorkflowContext.BuildRequested
+}
+
+function Test-NovaTestWorkflowShouldRun {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext,
+        [Parameter(Mandatory)][hashtable]$BoundParameters,
+        [switch]$ShouldRun
+    )
+
+    if ( $BoundParameters.ContainsKey('ShouldRun')) {
+        return $ShouldRun.IsPresent
+    }
+
+    return -not (Test-NovaWhatIfWorkflowContext -WorkflowContext $WorkflowContext)
+}
+
+function Test-NovaWhatIfWorkflowContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext
+    )
+
+    if ($WorkflowContext.PSObject.Properties.Name -notcontains 'WorkflowParams') {
+        return $false
+    }
+
+    return [bool]$WorkflowContext.WorkflowParams.WhatIf
 }
 
 function Initialize-NovaPesterArtifactDirectory {

--- a/src/private/quality/NewNovaTestDynamicParameterDictionary.ps1
+++ b/src/private/quality/NewNovaTestDynamicParameterDictionary.ps1
@@ -1,0 +1,12 @@
+function New-NovaTestDynamicParameterDictionary {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'This helper only returns runtime parameter metadata and does not mutate state.')]
+    [CmdletBinding()]
+    param()
+
+    $attributeCollection = [System.Collections.ObjectModel.Collection[System.Attribute]]::new()
+    $attributeCollection.Add([System.Management.Automation.ParameterAttribute]::new())
+    $dictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+    $dictionary.Add('Build',[System.Management.Automation.RuntimeDefinedParameter]::new('Build', [switch],$attributeCollection))
+    return $dictionary
+}
+

--- a/src/public/TestNovaBuild.ps1
+++ b/src/public/TestNovaBuild.ps1
@@ -8,16 +8,25 @@ function Test-NovaBuild {
         [ValidateSet('Auto', 'Ansi')]
         [string]$OutputRenderMode
     )
-    $workflowContext = Get-NovaTestWorkflowContext -TestOption @{
-        TagFilter = $TagFilter
-        ExcludeTagFilter = $ExcludeTagFilter
-        OutputVerbosity = $OutputVerbosity
-        OutputRenderMode = $OutputRenderMode
-    } -BoundParameters $PSBoundParameters
 
-    if (-not $PSCmdlet.ShouldProcess($workflowContext.Target, $workflowContext.Operation)) {
-        return
+    dynamicparam {
+        return New-NovaTestDynamicParameterDictionary
     }
 
-    Invoke-NovaTestWorkflow -WorkflowContext $workflowContext
+    end {
+        $workflowContext = Get-NovaTestWorkflowContext -TestOption @{
+            Build = $PSBoundParameters.ContainsKey('Build')
+            TagFilter = $TagFilter
+            ExcludeTagFilter = $ExcludeTagFilter
+            OutputVerbosity = $OutputVerbosity
+            OutputRenderMode = $OutputRenderMode
+        } -BoundParameters $PSBoundParameters
+
+        $shouldRun = $PSCmdlet.ShouldProcess($workflowContext.Target, $workflowContext.Operation)
+        if (-not $shouldRun -and -not $WhatIfPreference) {
+            return
+        }
+
+        Invoke-NovaTestWorkflow -WorkflowContext $workflowContext -ShouldRun:$shouldRun
+    }
 }

--- a/src/resources/cli/NovaCliHelp.txt
+++ b/src/resources/cli/NovaCliHelp.txt
@@ -99,5 +99,8 @@ artifacts from the configured package output directory to a raw repository endpo
 Inside PowerShell, 'nova publish --local' also reloads the published module from the
 local install path after a successful publish.
 
+For more information, documentation, and examples, visit:
+   https://www.novamoduletools.com/
+
 Note: 'nova init' is interactive. Use 'nova init --path <path>' or 'nova init -p <path>' for an explicit destination,
 'nova init --example' or 'nova init -e' for the packaged example scaffold, and do not use 'nova init --what-if' or 'nova init -w'.

--- a/src/resources/cli/help/build.psd1
+++ b/src/resources/cli/help/build.psd1
@@ -4,7 +4,9 @@
     Usage = 'nova build [<options>]'
     Description = @(
         'Build the current project into the dist folder.',
-        'Use this command when you want fresh built module output before testing, packaging, or publishing.'
+        'Use this command when you want fresh built module output before testing, packaging, or publishing.',
+        'For more information, documentation, and examples, visit:',
+        'https://www.novamoduletools.com/core-workflows.html#build'
     )
     Options = @(
         @{

--- a/src/resources/cli/help/bump.psd1
+++ b/src/resources/cli/help/bump.psd1
@@ -4,7 +4,9 @@
     Usage = 'nova bump [<options>]'
     Description = @(
         'Update the module version in project.json by using the current repository history.',
-        'Use --preview when you want an explicit prerelease iteration instead of the next stable semantic version.'
+        'Use --preview when you want an explicit prerelease iteration instead of the next stable semantic version.',
+        'For more information, documentation, and examples, visit:',
+        'https://www.novamoduletools.com/versioning-and-updates.html#bump'
     )
     Options = @(
         @{

--- a/src/resources/cli/help/deploy.psd1
+++ b/src/resources/cli/help/deploy.psd1
@@ -4,7 +4,9 @@
     Usage = 'nova deploy [<options>]'
     Description = @(
         'Upload existing package artifact(s) from the current project to a raw HTTP endpoint.',
-        'Use a named repository from project.json or pass an explicit URL when you want a direct upload target.'
+        'Use a named repository from project.json or pass an explicit URL when you want a direct upload target.',
+        'For more information, documentation, and examples, visit:',
+        'https://www.novamoduletools.com/packaging-and-delivery.html#upload'
     )
     Options = @(
         @{

--- a/src/resources/cli/help/info.psd1
+++ b/src/resources/cli/help/info.psd1
@@ -4,7 +4,9 @@
     Usage = 'nova info'
     Description = @(
         'Show project information for the current Nova module project.',
-        'Use this command when you want the resolved project metadata without changing files.'
+        'Use this command when you want the resolved project metadata without changing files.',
+        'For more information, documentation, and examples, visit:',
+        'https://www.novamoduletools.com/project-json-reference.html'
     )
     Options = @()
     Examples = @(

--- a/src/resources/cli/help/init.psd1
+++ b/src/resources/cli/help/init.psd1
@@ -4,7 +4,9 @@
     Usage = 'nova init [<options>]'
     Description = @(
         'Create a new Nova module scaffold.',
-        'Run without options for the interactive flow, or pass an explicit destination path when you want a non-interactive target.'
+        'Run without options for the interactive flow, or pass an explicit destination path when you want a non-interactive target.',
+        'For more information, documentation, and examples, visit:',
+        'https://www.novamoduletools.com/core-workflows.html#scaffold'
     )
     Options = @(
         @{

--- a/src/resources/cli/help/notification.psd1
+++ b/src/resources/cli/help/notification.psd1
@@ -4,7 +4,9 @@
     Usage = 'nova notification [<options>]'
     Description = @(
         'Show or change prerelease self-update eligibility for NovaModuleTools self-updates.',
-        'Run without options to show the current preference, or use --enable/--disable when you want to change it.'
+        'Run without options to show the current preference, or use --enable/--disable when you want to change it.',
+        'For more information, documentation, and examples, visit:',
+        'https://www.novamoduletools.com/versioning-and-updates.html#notification-preferences'
     )
     Options = @(
         @{

--- a/src/resources/cli/help/package.psd1
+++ b/src/resources/cli/help/package.psd1
@@ -4,7 +4,9 @@
     Usage = 'nova package [<options>]'
     Description = @(
         'Build, test, and package the current project by using the configured package settings.',
-        'Use this command when you want package artifact output without publishing to a PowerShell repository.'
+        'Use this command when you want package artifact output without publishing to a PowerShell repository.',
+        'For more information, documentation, and examples, visit:',
+        'https://www.novamoduletools.com/packaging-and-delivery.html#pack'
     )
     Options = @(
         @{

--- a/src/resources/cli/help/publish.psd1
+++ b/src/resources/cli/help/publish.psd1
@@ -4,7 +4,9 @@
     Usage = 'nova publish [<options>]'
     Description = @(
         'Build, test, and publish the current project either locally or to a PowerShell repository.',
-        'Use --local when you want a local publish workflow, or supply repository credentials when you want a repository publish.'
+        'Use --local when you want a local publish workflow, or supply repository credentials when you want a repository publish.',
+        'For more information, documentation, and examples, visit:',
+        'https://www.novamoduletools.com/packaging-and-delivery.html#publish'
     )
     Options = @(
         @{

--- a/src/resources/cli/help/release.psd1
+++ b/src/resources/cli/help/release.psd1
@@ -4,7 +4,9 @@
     Usage = 'nova release [<options>]'
     Description = @(
         'Run the full release flow: build, test, version bump, rebuild, and publish.',
-        'Use the same publish-target options as nova publish when you want the release workflow to publish locally or to a repository.'
+        'Use the same publish-target options as nova publish when you want the release workflow to publish locally or to a repository.',
+        'For more information, documentation, and examples, visit:',
+        'https://www.novamoduletools.com/packaging-and-delivery.html#release'
     )
     Options = @(
         @{

--- a/src/resources/cli/help/test.psd1
+++ b/src/resources/cli/help/test.psd1
@@ -4,9 +4,18 @@
     Usage = 'nova test [<options>]'
     Description = @(
         'Run Pester tests for the current project.',
-        'Use this command when you want Nova to run the configured project test workflow and write the normal test artifacts.'
+        'Use --build when you want Nova to rebuild the project before the test workflow starts.',
+        'Use this command when you want Nova to run the configured project test workflow and write the normal test artifacts.',
+        'For more information, documentation, and examples, visit:',
+        'https://www.novamoduletools.com/core-workflows.html#test'
     )
     Options = @(
+        @{
+            Short = '-b'
+            Long = '--build'
+            Placeholder = ''
+            Description = 'Build the project before running the test workflow.'
+        },
         @{
             Short = '-v'
             Long = '--verbose'
@@ -30,6 +39,10 @@
         @{
             Command = 'nova test'
             Description = 'Run the project test workflow.'
+        },
+        @{
+            Command = 'nova test --build'
+            Description = 'Build the project first, then run the project test workflow.'
         },
         @{
             Command = 'nova test -w'

--- a/src/resources/cli/help/update.psd1
+++ b/src/resources/cli/help/update.psd1
@@ -4,7 +4,9 @@
     Usage = 'nova update [<options>]'
     Description = @(
         'Update the installed NovaModuleTools module by using the stored prerelease-notification preference.',
-        'Stable updates remain available by default, while prerelease targets require explicit confirmation before they run.'
+        'Stable updates remain available by default, while prerelease targets require explicit confirmation before they run.',
+        'For more information, documentation, and examples, visit:',
+        'https://www.novamoduletools.com/versioning-and-updates.html#self-update'
     )
     Options = @(
         @{

--- a/src/resources/cli/help/version.psd1
+++ b/src/resources/cli/help/version.psd1
@@ -4,7 +4,9 @@
     Usage = 'nova version [<options>]'
     Description = @(
         'Show the current project version from project.json.',
-        'Use --installed when you want the locally installed version of the current project module instead of the project.json version.'
+        'Use --installed when you want the locally installed version of the current project module instead of the project.json version.',
+        'For more information, documentation, and examples, visit:',
+        'https://www.novamoduletools.com/versioning-and-updates.html#version-views'
     )
     Options = @(
         @{

--- a/tests/BuildOptions.TestSupport.ps1
+++ b/tests/BuildOptions.TestSupport.ps1
@@ -313,15 +313,24 @@ function Invoke-TestProjectTests {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string]$ProjectRoot,
-        [Parameter(Mandatory)][string]$ModulePath
+        [Parameter(Mandatory)][string]$ModulePath,
+        [switch]$BuildBeforeTest
     )
 
     $scriptPath = Join-Path $ProjectRoot 'Run-TestNovaBuild.ps1'
+    $testCommand = if ($BuildBeforeTest) {
+        'Test-NovaBuild -Build'
+    }
+    else {
+        @(
+            'Invoke-NovaBuild'
+            'Test-NovaBuild'
+        ) -join [Environment]::NewLine
+    }
     $script = @"
 Import-Module '$ModulePath' -Force
 Set-Location -LiteralPath '$ProjectRoot'
-Invoke-NovaBuild
-Test-NovaBuild
+$testCommand
 "@
 
     Set-Content -LiteralPath $scriptPath -Value $script -Encoding utf8

--- a/tests/BuildOptions.Tests.ps1
+++ b/tests/BuildOptions.Tests.ps1
@@ -311,6 +311,18 @@ Describe 'Invoke-NovaBuild options' {
         }
     }
 
+    It 'Test-NovaBuild -Build rebuilds the project before running tests' {
+        $project = New-TestProjectWithMarkerTests -TestDriveRoot $TestDrive -Name 'TestsWithBuildFlag' -BuildRecursiveFolders $true
+        $builtModulePath = Join-Path $project.Root 'dist/TestsWithBuildFlag/TestsWithBuildFlag.psm1'
+
+        $result = Invoke-TestProjectTests -ProjectRoot $project.Root -ModulePath $distModuleDir -BuildBeforeTest
+
+        $result.ExitCode | Should -Be 0 -Because ($result.Output -join [Environment]::NewLine)
+        (Test-Path -LiteralPath $builtModulePath) | Should -BeTrue
+        (Test-Path -LiteralPath $project.TopMarker) | Should -BeTrue
+        (Test-Path -LiteralPath $project.NestedMarker) | Should -BeTrue
+    }
+
     It 'missing FailOnDuplicateFunctionNames defaults to true and fails on duplicate top-level function names' {
         $root = New-TestProjectWithDuplicateFunctions -TestDriveRoot $TestDrive -Name 'DupDefault' -Options @{ ProjectName = 'DupDefault'; BuildRecursiveFolders = $false; SetSourcePath = $false }
         $expectedModulePath = Get-BuiltModuleFilePath -ProjectRoot $root

--- a/tests/CoverageGaps.Cli.TestSupport.ps1
+++ b/tests/CoverageGaps.Cli.TestSupport.ps1
@@ -14,3 +14,52 @@ function Assert-TestStructuredCliError {
     }
 }
 
+function Resolve-TestPublicDocsUrl {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Url,
+        [Parameter(Mandatory)][string]$DocsRoot
+    )
+
+    $publicDocsBaseUrl = 'https://www.novamoduletools.com/'
+    if (-not $Url.StartsWith($publicDocsBaseUrl, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Unsupported docs URL: $Url"
+    }
+
+    $relativeUrl = $Url.Substring($publicDocsBaseUrl.Length)
+    $segments = $relativeUrl -split '#', 2
+    $pageName = $segments[0]
+    if ( [string]::IsNullOrWhiteSpace($pageName)) {
+        $pageName = 'index.html'
+    }
+
+    return [pscustomobject]@{
+        Url = $Url
+        FilePath = Join-Path $DocsRoot $pageName
+        Anchor = if ($segments.Count -gt 1) {
+            $segments[1]
+        } else {
+            $null
+        }
+    }
+}
+
+function Assert-TestPublicDocsUrlExists {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Url,
+        [Parameter(Mandatory)][string]$DocsRoot
+    )
+
+    $resolvedUrl = Resolve-TestPublicDocsUrl -Url $Url -DocsRoot $DocsRoot
+    (Test-Path -LiteralPath $resolvedUrl.FilePath) | Should -BeTrue -Because "Expected docs page for $Url at $( $resolvedUrl.FilePath )"
+
+    if (-not [string]::IsNullOrWhiteSpace($resolvedUrl.Anchor)) {
+        $content = Get-Content -LiteralPath $resolvedUrl.FilePath -Raw
+        $anchorPattern = 'id="{0}"' -f [regex]::Escape($resolvedUrl.Anchor)
+        $content | Should -Match $anchorPattern -Because "Expected anchor #$( $resolvedUrl.Anchor ) in $( $resolvedUrl.FilePath ) for $Url"
+    }
+
+    return $resolvedUrl
+}
+

--- a/tests/CoverageGaps.Cli.Tests.ps1
+++ b/tests/CoverageGaps.Cli.Tests.ps1
@@ -120,6 +120,30 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
         }
     }
 
+    It 'Invoke-NovaCliCommandRoute handles the direct root --help command route when help was not pre-normalized' {
+        InModuleScope $script:moduleName {
+            $invocationContext = [pscustomobject]@{
+                Command = '--help'
+                Arguments = @()
+                CommonParameters = @{}
+                MutatingCommonParameters = @{}
+                IsHelpRequest = $false
+                HelpRequest = $null
+                ModuleName = 'NovaModuleTools'
+                WhatIfEnabled = $false
+                CliConfirmEnabled = $false
+            }
+            Mock Get-NovaCliHelp {'root-help'}
+            Mock Get-NovaCliCommandHelp {throw 'command help should not be used'}
+
+            $result = Invoke-NovaCliCommandRoute -InvocationContext $invocationContext
+
+            $result | Should -Be 'root-help'
+            Assert-MockCalled Get-NovaCliHelp -Times 1
+            Assert-MockCalled Get-NovaCliCommandHelp -Times 0
+        }
+    }
+
     It 'Get-NovaCliHelpRequest resolves root short help, command short help, and command long help' {
         InModuleScope $script:moduleName {
             $rootHelp = Get-NovaCliHelpRequest -Command '--help' -Arguments @()

--- a/tests/CoverageGaps.Cli.Tests.ps1
+++ b/tests/CoverageGaps.Cli.Tests.ps1
@@ -7,6 +7,8 @@ $global:gitTestSupportFunctionNameList = @(
 )
 $global:coverageGapsCliTestSupportFunctionNameList = @(
     'Assert-TestStructuredCliError'
+    'Resolve-TestPublicDocsUrl'
+    'Assert-TestPublicDocsUrlExists'
 )
 . $script:gitTestSupportPath
 . $script:coverageGapsCliTestSupportPath
@@ -323,6 +325,28 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
         }
     }
 
+    It 'ConvertFrom-NovaTestCliArgument parses the build switch and rejects unsupported test arguments' {
+        InModuleScope $script:moduleName {
+            (ConvertFrom-NovaTestCliArgument -Arguments @('--build')).Build | Should -BeTrue
+            (ConvertFrom-NovaTestCliArgument -Arguments @('-b')).Build | Should -BeTrue
+
+            $unknownArgumentError = $null
+            try {
+                ConvertFrom-NovaTestCliArgument -Arguments @('--bogus')
+            }
+            catch {
+                $unknownArgumentError = $_
+            }
+
+            Assert-TestStructuredCliError -ThrownError $unknownArgumentError -ExpectedError ([pscustomobject]@{
+                Message = 'Unknown argument: --bogus'
+                ErrorId = 'Nova.Validation.UnknownCliArgument'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                TargetObject = '--bogus'
+            })
+        }
+    }
+
     It 'ConvertFrom-NovaInitCliArgument parses explicit path and example switches' {
         InModuleScope $script:moduleName {
             $options = ConvertFrom-NovaInitCliArgument -Arguments @('--example', '--path', 'tmp/project/root')
@@ -515,6 +539,38 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
         }
     }
 
+    It 'Invoke-NovaCliCommandRoute forwards the parsed test build flag to Test-NovaBuild' {
+        InModuleScope $script:moduleName {
+            $invocationContext = [pscustomobject]@{
+                Command = 'test'
+                Arguments = @('--build')
+                CommonParameters = @{}
+                MutatingCommonParameters = @{WhatIf = $true}
+                IsHelpRequest = $false
+                HelpRequest = $null
+                ModuleName = 'NovaModuleTools'
+                WhatIfEnabled = $true
+                CliConfirmEnabled = $false
+            }
+            Mock ConvertFrom-NovaTestCliArgument {@{Build = $true}}
+            Mock Test-NovaBuild {
+                param(
+                    [switch]$Build,
+                    [switch]$WhatIf
+                )
+
+                [pscustomobject]@{Build = $Build.IsPresent; WhatIf = $WhatIf.IsPresent}
+            }
+
+            $result = Invoke-NovaCliCommandRoute -InvocationContext $invocationContext
+
+            $result.Build | Should -BeTrue
+            $result.WhatIf | Should -BeTrue
+            Assert-MockCalled ConvertFrom-NovaTestCliArgument -Times 1 -ParameterFilter {$Arguments -eq @('--build')}
+            Assert-MockCalled Test-NovaBuild -Times 1 -ParameterFilter {$Build -and $WhatIf}
+        }
+    }
+
     It 'Get-NovaCliCommandHelp renders CLI-native command help without calling Get-Help' {
         InModuleScope $script:moduleName {
             Mock Get-Help {throw 'CLI help should not call Get-Help'}
@@ -527,6 +583,40 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
             }
 
             Assert-MockCalled Get-Help -Times 0
+        }
+    }
+
+    It 'Get-NovaCliCommandHelp includes docs URLs only in long help descriptions' {
+        InModuleScope $script:moduleName -Parameters @{DocsRoot = (Join-Path $script:repoRoot 'docs')} {
+            param($DocsRoot)
+
+            $docsLinkPrefix = 'For more information, documentation, and examples, visit:'
+            $docsUrlMap = @{
+                'init' = 'https://www.novamoduletools.com/core-workflows.html#scaffold'
+                'info' = 'https://www.novamoduletools.com/project-json-reference.html'
+                'version' = 'https://www.novamoduletools.com/versioning-and-updates.html#version-views'
+                'build' = 'https://www.novamoduletools.com/core-workflows.html#build'
+                'test' = 'https://www.novamoduletools.com/core-workflows.html#test'
+                'package' = 'https://www.novamoduletools.com/packaging-and-delivery.html#pack'
+                'deploy' = 'https://www.novamoduletools.com/packaging-and-delivery.html#upload'
+                'bump' = 'https://www.novamoduletools.com/versioning-and-updates.html#bump'
+                'update' = 'https://www.novamoduletools.com/versioning-and-updates.html#self-update'
+                'notification' = 'https://www.novamoduletools.com/versioning-and-updates.html#notification-preferences'
+                'publish' = 'https://www.novamoduletools.com/packaging-and-delivery.html#publish'
+                'release' = 'https://www.novamoduletools.com/packaging-and-delivery.html#release'
+            }
+
+            foreach ($commandName in $docsUrlMap.Keys) {
+                $docsUrl = $docsUrlMap[$commandName]
+                $shortHelp = Get-NovaCliCommandHelp -Command $commandName -View 'Short'
+                $longHelp = Get-NovaCliCommandHelp -Command $commandName -View 'Long'
+
+                $shortHelp | Should -Not -Match ([regex]::Escape($docsLinkPrefix))
+                $shortHelp | Should -Not -Match ([regex]::Escape($docsUrl))
+                $longHelp | Should -Match ([regex]::Escape($docsLinkPrefix))
+                $longHelp | Should -Match ([regex]::Escape($docsUrl))
+                Assert-TestPublicDocsUrlExists -Url $docsUrl -DocsRoot $docsRoot | Out-Null
+            }
         }
     }
 
@@ -568,6 +658,21 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
                 ErrorId = 'Nova.Validation.UnsupportedCliOptionSyntax'
                 Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
                 TargetObject = '--whatif'
+            })
+
+            $deprecatedBuildError = $null
+            try {
+                Assert-NovaCliArgumentSyntax -Arguments @('-build')
+            }
+            catch {
+                $deprecatedBuildError = $_
+            }
+
+            Assert-TestStructuredCliError -ThrownError $deprecatedBuildError -ExpectedError ([pscustomobject]@{
+                Message = "Unsupported CLI option syntax: -build. Use '--build' or '-b' instead."
+                ErrorId = 'Nova.Validation.UnsupportedCliOptionSyntax'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                TargetObject = '-build'
             })
         }
     }

--- a/tests/NovaCommandModel.BumpAndCli.Tests.ps1
+++ b/tests/NovaCommandModel.BumpAndCli.Tests.ps1
@@ -1,97 +1,81 @@
-function global:Get-TestSupportPath {
-    [CmdletBinding()]
-    param()
+$script:testSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'NovaCommandModel.TestSupport.ps1')).Path
 
-    return (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'NovaCommandModel.TestSupport.ps1')).Path
+<#
+# Why we intentionally ignore CodeScene's warnings here
+#
+# This test file contains a large number of small helper functions that are used across multiple test cases to
+# validate the behavior of the nova CLI confirmation and version bump workflows. To avoid unnecessary complexity
+# in the test cases and to promote reuse of common test logic, these helper functions are defined in a separate
+# test support script and imported into this test file.
+#
+# @CodeScene (disable:"Global Conditionals")
+#>
+$global:novaCommandModelBumpAndCliTestSupportFunctionNameList = @(
+    'Publish-TestSupportFunctions'
+    'Get-TestRegexMatchGroup'
+    'ConvertTo-TestNormalizedText'
+    'Assert-TestModuleIsBuilt'
+    'Get-TestModuleDisplayVersion'
+    'Get-TestHelpLocaleFromMarkdownFiles'
+    'Get-CommandHelpActivationTestCase'
+    'Get-CommandHelpActivationTestCases'
+    'Get-TestModuleContextInfo'
+    'Initialize-TestModuleContext'
+    'Initialize-TestNovaCliProjectLayout'
+    'Write-TestNovaCliProjectJson'
+    'Write-TestNovaCliPublicFunction'
+    'Initialize-TestNovaCliGitRepository'
+    'Invoke-TestInstalledNovaCommand'
+    'New-TestPesterConfigStub'
+    'Assert-TestNovaCliConfirmDecisions'
+    'Invoke-ReadNovaCliPromptKeyAssertion'
+    'Invoke-GetNovaCliCommandPromptKeyAssertion'
+    'Invoke-GetNovaCliCommandCancellationInfoAssertion'
+    'Invoke-UpdateNovaModuleVersionDefaultPathAssertion'
+    'Invoke-ConfirmNovaCliCommandActionEnterAssertion'
+    'Invoke-ConfirmNovaCliCommandActionRetryAssertion'
+    'Invoke-ConfirmNovaCliCommandActionCancellationAssertion'
+)
+. $script:testSupportPath
+
+foreach ($functionName in $global:novaCommandModelBumpAndCliTestSupportFunctionNameList) {
+    $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
+    Set-Item -Path "function:global:$functionName" -Value $scriptBlock
 }
-
-function global:Get-TestSupportFunctionNameList {
-    [CmdletBinding()]
-    param()
-
-    return @(
-        'Publish-TestSupportFunctions'
-        'Get-TestRegexMatchGroup'
-        'ConvertTo-TestNormalizedText'
-        'Assert-TestModuleIsBuilt'
-        'Get-TestModuleDisplayVersion'
-        'Get-TestHelpLocaleFromMarkdownFiles'
-        'Get-CommandHelpActivationTestCase'
-        'Get-CommandHelpActivationTestCases'
-        'Get-TestModuleContextInfo'
-        'Initialize-TestModuleContext'
-        'Initialize-TestNovaCliProjectLayout'
-        'Write-TestNovaCliProjectJson'
-        'Write-TestNovaCliPublicFunction'
-        'Initialize-TestNovaCliGitRepository'
-        'Invoke-TestInstalledNovaCommand'
-        'New-TestPesterConfigStub'
-    )
-}
-
-function global:Import-TestSupportFunctions {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)][string]$SupportPath,
-        [Parameter(Mandatory)][string[]]$FunctionNameList
-    )
-
-    . $SupportPath
-    Publish-TestSupportFunctions -FunctionNameList $FunctionNameList
-}
-
-function global:Initialize-TestSupportEnvironment {
-    [CmdletBinding()]
-    param()
-
-    $script:testSupportPath = Get-TestSupportPath
-    $global:novaCommandModelTestSupportFunctionNameList = Get-TestSupportFunctionNameList
-    Import-TestSupportFunctions -SupportPath $script:testSupportPath -FunctionNameList $global:novaCommandModelTestSupportFunctionNameList
-}
-
-Initialize-TestSupportEnvironment
 
 BeforeAll {
     $testSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'NovaCommandModel.TestSupport.ps1')).Path
     . $testSupportPath
-    $script:assertTestNovaCliConfirmDecisions = (Get-Command -Name 'Assert-TestNovaCliConfirmDecisions' -CommandType Function -ErrorAction Stop).ScriptBlock
-    $script:invokeReadNovaCliPromptKeyAssertion = (Get-Command -Name 'Invoke-ReadNovaCliPromptKeyAssertion' -CommandType Function -ErrorAction Stop).ScriptBlock
-    $script:invokeGetNovaCliCommandPromptKeyAssertion = (Get-Command -Name 'Invoke-GetNovaCliCommandPromptKeyAssertion' -CommandType Function -ErrorAction Stop).ScriptBlock
-    $script:invokeGetNovaCliCommandCancellationInfoAssertion = (Get-Command -Name 'Invoke-GetNovaCliCommandCancellationInfoAssertion' -CommandType Function -ErrorAction Stop).ScriptBlock
-    $script:invokeUpdateNovaModuleVersionDefaultPathAssertion = (Get-Command -Name 'Invoke-UpdateNovaModuleVersionDefaultPathAssertion' -CommandType Function -ErrorAction Stop).ScriptBlock
-    $script:invokeConfirmNovaCliCommandActionEnterAssertion = (Get-Command -Name 'Invoke-ConfirmNovaCliCommandActionEnterAssertion' -CommandType Function -ErrorAction Stop).ScriptBlock
-    $script:invokeConfirmNovaCliCommandActionRetryAssertion = (Get-Command -Name 'Invoke-ConfirmNovaCliCommandActionRetryAssertion' -CommandType Function -ErrorAction Stop).ScriptBlock
-    $script:invokeConfirmNovaCliCommandActionCancellationAssertion = (Get-Command -Name 'Invoke-ConfirmNovaCliCommandActionCancellationAssertion' -CommandType Function -ErrorAction Stop).ScriptBlock
-    Publish-TestSupportFunctions -FunctionNameList $global:novaCommandModelTestSupportFunctionNameList
-    $moduleContext = Initialize-TestModuleContext -CommandPath $PSCommandPath -SupportPath $testSupportPath -FunctionNameList $global:novaCommandModelTestSupportFunctionNameList
+    Publish-TestSupportFunctions -FunctionNameList $global:novaCommandModelBumpAndCliTestSupportFunctionNameList
+    $moduleContext = Initialize-TestModuleContext -CommandPath $PSCommandPath -SupportPath $testSupportPath -FunctionNameList $global:novaCommandModelBumpAndCliTestSupportFunctionNameList
     $script:moduleName = $moduleContext.ModuleName
     $script:distModuleDir = $moduleContext.DistModuleDir
 }
 
 Describe 'Nova command model - bump and CLI confirmation behavior' {
     It 'Get-NovaCliConfirmDecision approves Yes and Yes to All, and cancels No, No to All, and Suspend' {
-        & $script:assertTestNovaCliConfirmDecisions -ModuleName $script:moduleName
+        Assert-TestNovaCliConfirmDecisions -ModuleName $script:moduleName
     }
 
     It 'Read-NovaCliPromptKey returns the expected result when console input <Name>' -ForEach @(
         @{Name = 'is available'; Expected = [char]'y'; ConsoleKeyChar = [char]'y'; Throws = $false}
         @{Name = 'fails'; Expected = [char]0; ConsoleKeyChar = [char]0; Throws = $true}
     ) {
-        & $script:invokeReadNovaCliPromptKeyAssertion -ModuleName $script:moduleName -TestCase $_
+        Invoke-ReadNovaCliPromptKeyAssertion -ModuleName $script:moduleName -TestCase $_
     }
 
     It 'Get-NovaCliCommandPromptKey returns the expected key when prompt input <Name>' -ForEach @(
         @{Name = 'uses the NOVA_CLI_CONFIRM_RESPONSE override'; EnvironmentResponse = 'later'; Expected = [char]'l'; PromptReadCount = 0}
         @{Name = 'must be read from the interactive prompt'; EnvironmentResponse = ''; Expected = [char]'n'; PromptReadCount = 1}
     ) {
-        & $script:invokeGetNovaCliCommandPromptKeyAssertion -ModuleName $script:moduleName -TestCase $_
+        Invoke-GetNovaCliCommandPromptKeyAssertion -ModuleName $script:moduleName -TestCase $_
     }
 
     It 'Get-NovaCliCommandCancellationInfo returns the expected cancellation metadata for <Name>' -ForEach @(
         @{Name = 'Suspend'; Key = 'S'; ExpectedMessage = 'Suspend is not supported in nova CLI mode. Operation cancelled.'; ExpectedErrorId = 'Nova.Workflow.CliSuspendNotSupported'}
         @{Name = 'No'; Key = 'N'; ExpectedMessage = 'Operation cancelled.'; ExpectedErrorId = 'Nova.Workflow.CliOperationCancelled'}
     ) {
-        & $script:invokeGetNovaCliCommandCancellationInfoAssertion -ModuleName $script:moduleName -TestCase $_
+        Invoke-GetNovaCliCommandCancellationInfoAssertion -ModuleName $script:moduleName -TestCase $_
     }
 
     It 'Get-NovaVersionUpdateWorkflowContext prepares version bump state from project info and commit history' {
@@ -179,7 +163,7 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
     }
 
     It 'Update-NovaModuleVersion defaults Path to the current location when Path is omitted' {
-        & $script:invokeUpdateNovaModuleVersionDefaultPathAssertion -ModuleName $script:moduleName
+        Invoke-UpdateNovaModuleVersionDefaultPathAssertion -ModuleName $script:moduleName
     }
 
     It 'Update-NovaModuleVersion -WhatIf returns the expected next version without persisting it when <Name>' -ForEach @(
@@ -419,15 +403,15 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
     }
 
     It 'Confirm-NovaCliCommandAction accepts Enter as the default confirmation response' {
-        & $script:invokeConfirmNovaCliCommandActionEnterAssertion -ModuleName $script:moduleName
+        Invoke-ConfirmNovaCliCommandActionEnterAssertion -ModuleName $script:moduleName
     }
 
     It 'Confirm-NovaCliCommandAction retries after invalid input and returns after an accepted response' {
-        & $script:invokeConfirmNovaCliCommandActionRetryAssertion -ModuleName $script:moduleName
+        Invoke-ConfirmNovaCliCommandActionRetryAssertion -ModuleName $script:moduleName
     }
 
     It 'Confirm-NovaCliCommandAction stops the operation with the expected CLI cancellation result for No' {
-        & $script:invokeConfirmNovaCliCommandActionCancellationAssertion -ModuleName $script:moduleName -TestCase @{
+        Invoke-ConfirmNovaCliCommandActionCancellationAssertion -ModuleName $script:moduleName -TestCase @{
             Key = 'N'
             ExpectedMessage = 'Operation cancelled.'
             ExpectedErrorId = 'Nova.Workflow.CliOperationCancelled'
@@ -435,7 +419,7 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
     }
 
     It 'Confirm-NovaCliCommandAction stops the operation with the expected CLI cancellation result for Suspend' {
-        & $script:invokeConfirmNovaCliCommandActionCancellationAssertion -ModuleName $script:moduleName -TestCase @{
+        Invoke-ConfirmNovaCliCommandActionCancellationAssertion -ModuleName $script:moduleName -TestCase @{
             Key = 'S'
             ExpectedMessage = 'Suspend is not supported in nova CLI mode. Operation cancelled.'
             ExpectedErrorId = 'Nova.Workflow.CliSuspendNotSupported'

--- a/tests/NovaCommandModel.StandaloneCli.Tests.ps1
+++ b/tests/NovaCommandModel.StandaloneCli.Tests.ps1
@@ -377,6 +377,51 @@ Describe '$projectName tests' {
         }
     }
 
+    It 'Install-NovaCli rebuilds before testing when nova test uses <Option>' -ForEach @(
+        @{Option = '--build'}
+        @{Option = '-b'}
+    ) {
+        $option = $_.Option
+        $targetDirectory = Join-Path $TestDrive "test-build-bin-$($option.Replace('-', '') )"
+        $installedPath = Join-Path $targetDirectory 'nova'
+        $projectName = "CliTestBuild$($option.Replace('-', '') )"
+        $projectRoot = Join-Path $TestDrive $projectName
+        $topMarker = Join-Path $projectRoot 'top-level-ran.txt'
+        $builtModulePath = Join-Path $projectRoot "dist/$projectName/$projectName.psm1"
+        $originalModulePath = $env:PSModulePath
+        $modulePathSeparator = [string][System.IO.Path]::PathSeparator
+        $distParent = Split-Path -Parent $script:distModuleDir
+
+        $env:PSModulePath = "$distParent$modulePathSeparator$originalModulePath"
+
+        Initialize-TestNovaCliProjectLayout -ProjectRoot $projectRoot
+        Write-TestNovaCliProjectJson -ProjectRoot $projectRoot -ProjectName $projectName -ProjectGuid ([guid]::NewGuid().Guid)
+        Write-TestNovaCliPublicFunction -ProjectRoot $projectRoot -FunctionName "Invoke-$projectName"
+        @"
+Describe '$projectName tests' {
+    It 'imports the built module and writes a marker' {
+        Import-Module '$builtModulePath' -Force
+        Get-Module -Name '$projectName' | Should -Not -BeNullOrEmpty
+        Set-Content -LiteralPath '$topMarker' -Value 'TopLevel' -Encoding utf8 -NoNewline
+    }
+}
+"@ | Set-Content -LiteralPath (Join-Path $projectRoot 'tests/TestBuildFlag.Tests.ps1') -Encoding utf8
+
+        try {
+            Install-NovaCli -DestinationDirectory $targetDirectory -Force | Out-Null
+
+            (Test-Path -LiteralPath $builtModulePath) | Should -BeFalse
+            $result = Invoke-TestInstalledNovaCommand -InstalledPath $installedPath -WorkingDirectory $projectRoot -Arguments @('test', $option)
+
+            $result.ExitCode | Should -Be 0 -Because $result.Text
+            (Test-Path -LiteralPath $builtModulePath) | Should -BeTrue
+            (Test-Path -LiteralPath $topMarker) | Should -BeTrue
+        }
+        finally {
+            $env:PSModulePath = $originalModulePath
+        }
+    }
+
     It 'Invoke-NovaCli version returns the project name and version' {
         InModuleScope $script:moduleName {
             Mock Get-NovaProjectInfo {[pscustomobject]@{ProjectName = 'AzureDevOpsAgentInstaller'; Version = '1.2.3'}}
@@ -428,7 +473,7 @@ Describe '$projectName tests' {
         @{CommandName = 'info'; Usage = 'usage: nova info'; ExpectedPattern = '\(none\)'},
         @{CommandName = 'version'; Usage = 'usage: nova version [<options>]'; ExpectedPattern = '-i, --installed'},
         @{CommandName = 'build'; Usage = 'usage: nova build [<options>]'; ExpectedPattern = '-v, --verbose'},
-        @{CommandName = 'test'; Usage = 'usage: nova test [<options>]'; ExpectedPattern = '-w, --what-if'},
+        @{CommandName = 'test'; Usage = 'usage: nova test [<options>]'; ExpectedPattern = '-b, --build'},
         @{CommandName = 'package'; Usage = 'usage: nova package [<options>]'; ExpectedPattern = '-c, --confirm'},
         @{CommandName = 'deploy'; Usage = 'usage: nova deploy [<options>]'; ExpectedPattern = '-r, --repository <name>'},
         @{CommandName = 'bump'; Usage = 'usage: nova bump [<options>]'; ExpectedPattern = '-p, --preview'},

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -720,9 +720,11 @@ title: Invoke-NovaBuild
         InModuleScope $script:moduleName {
             Mock Get-NovaTestWorkflowContext {
                 [pscustomobject]@{
+                    BuildRequested = $false
                     Target = '/tmp/nova-project/artifacts/TestResults.xml'
                     Operation = 'Run Pester tests and write test results'
                     PesterConfig = [pscustomobject]@{}
+                    WorkflowParams = @{}
                 }
             }
             Mock Invoke-NovaTestWorkflow {}
@@ -736,6 +738,32 @@ title: Invoke-NovaBuild
             Assert-MockCalled Invoke-NovaTestWorkflow -Times 1 -ParameterFilter {
                 $WorkflowContext.Target -eq '/tmp/nova-project/artifacts/TestResults.xml' -and
                         $WorkflowContext.Operation -eq 'Run Pester tests and write test results'
+            }
+        }
+    }
+
+    It 'Test-NovaBuild -Build forwards the build flag into the test workflow context and workflow execution' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaTestWorkflowContext {
+                [pscustomobject]@{
+                    BuildRequested = $true
+                    Target = '/tmp/nova-project/artifacts/TestResults.xml'
+                    Operation = 'Build project, run Pester tests, and write test results'
+                    PesterConfig = [pscustomobject]@{}
+                    WorkflowParams = @{}
+                }
+            }
+            Mock Invoke-NovaTestWorkflow {}
+
+            Test-NovaBuild -Build -Confirm:$false
+
+            Assert-MockCalled Get-NovaTestWorkflowContext -Times 1 -ParameterFilter {
+                $TestOption.Build -and
+                        $BoundParameters.ContainsKey('Build') -and
+                        $BoundParameters.ContainsKey('Confirm')
+            }
+            Assert-MockCalled Invoke-NovaTestWorkflow -Times 1 -ParameterFilter {
+                $WorkflowContext.BuildRequested -and $ShouldRun
             }
         }
     }
@@ -773,5 +801,54 @@ title: Invoke-NovaBuild
         }
     }
 
+    It 'Test-NovaBuild -Build runs Invoke-NovaBuild before the Pester workflow' {
+        InModuleScope $script:moduleName {
+            $steps = [System.Collections.Generic.List[string]]::new()
+            $workflowContext = [pscustomobject]@{
+                BuildRequested = $true
+                WorkflowParams = @{}
+                TestResultDirectory = '/tmp/nova-project/artifacts'
+                TestResultPath = '/tmp/nova-project/artifacts/TestResults.xml'
+                PesterConfig = New-TestPesterConfigStub -IncludeOutput
+                TestResultArtifactWriter = [pscustomobject]@{ScriptBlock = {}}
+                TestResultReportWriter = [pscustomobject]@{ScriptBlock = {}}
+            }
+
+            Mock Invoke-NovaBuild {$steps.Add('build')}
+            Mock Initialize-NovaPesterArtifactDirectory {$steps.Add('artifacts')}
+            Mock Invoke-NovaPester {
+                $steps.Add('pester')
+                [pscustomobject]@{Result = 'Passed'}
+            }
+            Invoke-NovaTestWorkflow -WorkflowContext $workflowContext -ShouldRun
+
+            $steps | Should -Be @('build', 'artifacts', 'pester')
+            $workflowContext.PesterConfig.TestResult.OutputPath | Should -Be '/tmp/nova-project/artifacts/TestResults.xml'
+        }
+    }
+
+    It 'Test-NovaBuild -Build -WhatIf previews the nested build without invoking Pester' {
+        InModuleScope $script:moduleName {
+            $workflowContext = [pscustomobject]@{
+                BuildRequested = $true
+                WorkflowParams = @{WhatIf = $true}
+                TestResultDirectory = '/tmp/nova-project/artifacts'
+                TestResultPath = '/tmp/nova-project/artifacts/TestResults.xml'
+                PesterConfig = New-TestPesterConfigStub -IncludeOutput
+                TestResultArtifactWriter = [pscustomobject]@{ScriptBlock = {}}
+                TestResultReportWriter = [pscustomobject]@{ScriptBlock = {}}
+            }
+
+            Mock Invoke-NovaBuild {}
+            Mock Initialize-NovaPesterArtifactDirectory {throw 'should not create artifacts'}
+            Mock Invoke-NovaPester {throw 'should not run tests'}
+            $result = Invoke-NovaTestWorkflow -WorkflowContext $workflowContext
+
+            $result | Should -BeNullOrEmpty
+            Assert-MockCalled Invoke-NovaBuild -Times 1 -ParameterFilter {$WhatIf}
+            Assert-MockCalled Initialize-NovaPesterArtifactDirectory -Times 0
+            Assert-MockCalled Invoke-NovaPester -Times 0
+        }
+    }
 
 }

--- a/tests/RemainingCommandCoverage.Tests.ps1
+++ b/tests/RemainingCommandCoverage.Tests.ps1
@@ -131,11 +131,14 @@ Describe 'Coverage for remaining command and filesystem branches' {
         }
     }
 
-    It 'Get-NovaTestWorkflowContext prepares the Pester workflow state and resolves the report writers' {
+    It 'Get-NovaTestWorkflowContext prepares the Pester workflow state and resolves the report writers' -ForEach @(
+        @{Build = $false; ExpectedOperation = 'Run Pester tests and write test results'}
+        @{Build = $true; ExpectedOperation = 'Build project, run Pester tests, and write test results'}
+    ) {
         $cfg = Get-TestNovaPesterConfig
 
-        InModuleScope $script:moduleName -Parameters @{Config = $cfg} {
-            param($Config)
+        InModuleScope $script:moduleName -Parameters @{Config = $cfg; TestCase = $_} {
+            param($Config, $TestCase)
 
             $projectRoot = '/tmp/nova-project'
             $artifactWriter = [pscustomobject]@{ScriptBlock = {}}
@@ -154,10 +157,16 @@ Describe 'Coverage for remaining command and filesystem branches' {
             Mock Get-Command {$artifactWriter} -ParameterFilter {$Name -eq 'Write-NovaPesterTestResultArtifact' -and $CommandType -eq 'Function'}
             Mock Get-Command {$reportWriter} -ParameterFilter {$Name -eq 'Write-NovaPesterTestResultReport' -and $CommandType -eq 'Function'}
 
-            $result = Get-NovaTestWorkflowContext -TestOption @{} -BoundParameters @{}
+            $testOption = @{}
+            if ($TestCase.Build) {
+                $testOption.Build = $true
+            }
+
+            $result = Get-NovaTestWorkflowContext -TestOption $testOption -BoundParameters @{}
 
             $result.Target | Should -Be ([System.IO.Path]::Join($projectRoot, 'artifacts', 'TestResults.xml'))
-            $result.Operation | Should -Be 'Run Pester tests and write test results'
+            $result.BuildRequested | Should -Be $TestCase.Build
+            $result.Operation | Should -Be $TestCase.ExpectedOperation
             $Config.Run.Path | Should -Be ([System.IO.Path]::Join('tests', '*.Tests.ps1'))
             $Config.Output.RenderMode | Should -Be 'Auto'
             $result.TestResultArtifactWriter | Should -Be $artifactWriter


### PR DESCRIPTION
## Summary

- Added build-before-test support so `Test-NovaBuild -Build`, `% nova test --build`, and `% nova test -b` rebuild the project before the test workflow runs.
- This change was needed to remove the manual build step before test runs when scenarios depend on fresh build output, while keeping the PowerShell cmdlet, `nova` CLI, help, docs, and tests aligned.
- Follow-up work: a separately reported local `run.ps1` failure still needs end-to-end investigation; this summary covers the implemented feature work and the focused validation completed for it.

## Affected area

- [x] `nova` CLI or command routing
- [x] Public PowerShell cmdlet behavior
- [ ] Scaffolding or `project.json` handling
- [x] Build, test, analyzer, coverage, or CI helper flow
- [ ] Package, raw upload, or package metadata workflow
- [ ] Publish, release, semantic-release, or GitHub Actions automation
- [ ] Self-update or notification preference behavior
- [x] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
- [x] End-user docs (`docs/*.html`)
- [x] Command help (`docs/NovaModuleTools/en-US/*.md`)
- [ ] `src/resources/example/`
- [ ] Dependency or manifest changes (`package.json`, workflow dependencies, release tooling)
- [ ] Security-sensitive change
- [ ] Documentation-only change
- [ ] Other

## Review guidance

- Start with the main workflow entry point in `src/public/TestNovaBuild.ps1`, then review `src/private/quality/GetNovaTestWorkflowContext.ps1` and `src/private/quality/InvokeNovaTestWorkflow.ps1` to see how the optional build-first behavior is carried through the test workflow.
- Review the CLI path in `src/private/cli/ConvertFromNovaTestCliArgument.ps1`, `src/private/cli/InvokeNovaCliCommandRoute.ps1`, and `src/private/cli/GetNovaCliArgumentRoutingState.ps1`, then check `src/resources/cli/help/test.psd1` for the surfaced `--build` / `-b` help text.
- The main tests are in `tests/BuildOptions.Tests.ps1`, `tests/NovaCommandModel.Tests.ps1`, `tests/CoverageGaps.Cli.Tests.ps1`, and `tests/NovaCommandModel.StandaloneCli.Tests.ps1`; reviewer-facing docs/help updates are in `README.md`, `CHANGELOG.md`, `docs/core-workflows.html`, `docs/commands.html`, and `docs/NovaModuleTools/en-US/Test-NovaBuild.md`.
- Trade-off: `Build` was implemented as a dynamic parameter via `src/private/quality/NewNovaTestDynamicParameterDictionary.ps1` to keep `Test-NovaBuild` within the Code Health function-argument threshold and avoid a maintainability regression.
- Known follow-up: the separately reported full `run.ps1` failure was reproduced but not isolated to a specific failing test in this work item because the end-to-end output truncated during repro.

## Validation

- [x] `Invoke-NovaBuild`
- [x] `Test-NovaBuild`
- [ ] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
- [x] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`,
  `% nova publish`,
  `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
- [ ] Docs/example only; executable validation not needed

Validation notes:

```text
Rebuilt the module with Invoke-NovaBuild -Confirm:$false.
Ran focused Pester coverage for the new build-before-test workflow, CLI routing/parser behavior, and standalone CLI scenarios.
Final focused CLI coverage rerun completed with: Tests Passed: 45, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 0.
Verified help output for Invoke-NovaCli test --help includes -b, --build.
Verified Get-Help Test-NovaBuild -Parameter Build shows the new cmdlet parameter documentation.
Re-ran the pre-commit Code Health safeguard after the dynamic-parameter refactor and it passed.
Did not complete ./scripts/build/Invoke-ScriptAnalyzerCI.ps1 or ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1 in this work item.
Local run.ps1 was reproduced for follow-up, but the failing test was not isolated before output truncation.
```

## Documentation and release follow-up

- [x] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
- [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
- [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [x] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
- [x] `docs/*.html` updated if end-user workflows or examples changed
- [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
  changed
- [ ] No documentation, changelog, or example updates were needed

## Maintainability, compatibility, and risk

- [x] Code Health / maintainability impact considered
- [x] No breaking change
- [ ] Breaking change
- [ ] Security-sensitive change
- [x] CI, workflow, or release-pipeline impact
- [ ] Dependency-review impact

Risk, rollout, or rollback notes:

```text
The new behavior is opt-in through -Build / --build / -b, so existing Test-NovaBuild and nova test flows remain unchanged.
The main implementation risk was a Code Health regression from increasing the cmdlet parameter count; that risk was mitigated by moving Build to a dynamic parameter helper and rerunning the safeguard.
If rollback is needed, revert the test workflow context/execution changes together with the CLI parser/route/help updates so the command surfaces stay aligned.
The separately reported full run.ps1 failure remains a follow-up item and should be investigated independently from this feature summary.
```

> [!IMPORTANT]
> Do not use a public pull request to disclose a vulnerability before coordinated handling.
> Use the private reporting path in `SECURITY.md` for new security issues.
