### PR TITLE
feat(#112): clean up PowerShell help content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       easier to scan and less visually cramped.
   - The getting started and core workflows guides now let readers switch between PowerShell and command-line
     examples, including the local-publish-plus-`pwsh` handoff for `Get-ExampleGreeting` and fresh-process `pwsh`
+
+- Clean the generated PowerShell cmdlet help so `Get-Help` pages no longer mix in `nova` launcher syntax or GNU-style
+  CLI options.
     import/reload validation from the command-line path.
   - The command reference, working-with-modules, packaging-and-delivery, versioning-and-updates, and troubleshooting
     guides now use the same centered command-surface header and PowerShell/command-line example switching model.

--- a/docs/NovaModuleTools/en-US/Deploy-NovaPackage.md
+++ b/docs/NovaModuleTools/en-US/Deploy-NovaPackage.md
@@ -63,10 +63,10 @@ raw repository named `LocalNexus` from `Package.Repositories`.
 ### EXAMPLE 2
 
 ```powershell
-% nova deploy --repository LocalNexus
+PS> Deploy-NovaPackage -Repository LocalNexus -WhatIf
 ```
 
-Runs the same raw package upload flow through the Nova CLI.
+Previews the raw package upload flow and the resolved destination URLs without uploading artifacts.
 
 ### EXAMPLE 3
 

--- a/docs/NovaModuleTools/en-US/Get-NovaUpdateNotificationPreference.md
+++ b/docs/NovaModuleTools/en-US/Get-NovaUpdateNotificationPreference.md
@@ -26,15 +26,12 @@ PS> Get-NovaUpdateNotificationPreference [<CommonParameters>]
 ## DESCRIPTION
 
 `Get-NovaUpdateNotificationPreference` returns the current user preference that controls whether
-`Update-NovaModuleTool` / `Update-NovaModuleTools` and `% nova update` may select prerelease versions of
-`NovaModuleTools`.
+`Update-NovaModuleTool` / `Update-NovaModuleTools` may select prerelease versions of `NovaModuleTools`.
 
-The same stored preference is also used by `Update-NovaModuleTool` (alias: `Update-NovaModuleTools`) and `% nova update`
-when they decide whether a prerelease self-update is eligible.
+The same stored preference is also used by `Update-NovaModuleTool` (alias: `Update-NovaModuleTools`) when it decides
+whether a prerelease self-update is eligible.
 
 Stable self-updates remain available and do not require prerelease eligibility.
-
-If you prefer the Nova CLI surface, run `% nova notification` to view the same preference.
 
 ## EXAMPLES
 
@@ -50,10 +47,11 @@ preference is stored.
 ### EXAMPLE 2
 
 ```text
-% nova notification
+PS> Set-NovaUpdateNotificationPreference -DisablePrereleaseNotifications
+PS> Get-NovaUpdateNotificationPreference
 ```
 
-Shows the same prerelease self-update state from the Nova CLI entrypoint.
+Shows the stored preference after prerelease self-updates have been disabled.
 
 ## PARAMETERS
 
@@ -77,15 +75,13 @@ Returns the prerelease self-update state, the always-available stable-update sta
 
 ## NOTES
 
-Use `PS> Set-NovaUpdateNotificationPreference -DisablePrereleaseNotifications` or `$ nova notification --disable` /
-`$ nova notification -d` to stop prerelease self-updates from being eligible.
+Use `Set-NovaUpdateNotificationPreference -DisablePrereleaseNotifications` to stop prerelease self-updates from being
+eligible.
 
-Use `PS> Set-NovaUpdateNotificationPreference -EnablePrereleaseNotifications` or `$ nova notification --enable` /
-`$ nova notification -e` to allow prerelease self-updates again.
+Use `Set-NovaUpdateNotificationPreference -EnablePrereleaseNotifications` to allow prerelease self-updates again.
 
-When prerelease notifications are enabled again, `Update-NovaModuleTool` / `Update-NovaModuleTools` and `% nova update`
-may again select a prerelease target. Prerelease self-updates still require explicit confirmation before the update
-proceeds.
+When prerelease notifications are enabled again, `Update-NovaModuleTool` / `Update-NovaModuleTools` may again select a
+prerelease target. Prerelease self-updates still require explicit confirmation before the update proceeds.
 
 ## RELATED LINKS
 

--- a/docs/NovaModuleTools/en-US/Initialize-NovaModule.md
+++ b/docs/NovaModuleTools/en-US/Initialize-NovaModule.md
@@ -74,10 +74,10 @@ prompt flow to the copied `project.json`.
 ### EXAMPLE 4
 
 ```text
-% nova init --example --path ~/Work
+PS> Initialize-NovaModule -Example -Path ~/Work -WhatIf
 ```
 
-Runs the same example-based scaffold flow through the `nova` CLI.
+Shows what the example-based scaffold flow would create without writing files.
 
 ## PARAMETERS
 

--- a/docs/NovaModuleTools/en-US/Invoke-NovaBuild.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaBuild.md
@@ -40,10 +40,10 @@ The command:
 6. copies project resources into the built module output
 
 To update the installed `NovaModuleTools` module itself, use `Update-NovaModuleTool` (alias:
-`Update-NovaModuleTools`) or `% nova update`.
+`Update-NovaModuleTools`).
 
-Use `Set-NovaUpdateNotificationPreference`, `Get-NovaUpdateNotificationPreference`, or the `% nova notification`
-commands when you want to control whether prerelease self-updates are eligible.
+Use `Set-NovaUpdateNotificationPreference` or `Get-NovaUpdateNotificationPreference` when you want to control whether
+prerelease self-updates are eligible.
 
 If `Invoke-NovaBuild` detects that a newer `NovaModuleTools` release or prerelease is available after the build, the
 warning includes the recommended update command together with the release notes link from the installed module

--- a/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaCli.md
@@ -29,30 +29,16 @@ PS> Invoke-NovaCli [[-Command] <string>] [[-Arguments] <string[]>] [-WhatIf] [-C
 
 Use it when you need scripted routing inside PowerShell, for example in tests, automation, or wrapper functions.
 
-Use the installed `nova` launcher when you want the end-user CLI experience. The module does not export `nova` as a
-PowerShell alias.
+`Invoke-NovaCli` routes the same top-level command names as the bundled command-line launcher, but it keeps the entry
+surface explicit for PowerShell callers.
 
-`Invoke-NovaCli` routes the same top-level commands that the launcher supports, including `% nova info`, `% nova
-version`, `% nova --version`, `% nova --help`, `% nova build`, `% nova test`, `% nova package`, `% nova deploy`, `% nova
-init`, `% nova bump`, `% nova update`, `% nova notification`, `% nova publish`, and `% nova release`.
+Use `-Command` to select the routed command and `-Arguments` when a routed command needs additional raw arguments.
 
-Mutating routed commands forward CLI `--verbose`/`-v` and `--what-if`/`-w` to the underlying cmdlet. Routed CLI
-`--confirm`/`-c` is handled by the shared CLI confirmation flow so the launcher never exposes PowerShell's interactive
-`Suspend` prompt.
-
-Only the supported mutating `nova` commands accept `--confirm`/`-c`. Read-only routes and `% nova init` reject the CLI
-confirm flag with a clear validation error.
+When `-Command` is omitted, `Invoke-NovaCli` routes to the root help view.
 
 Direct PowerShell cmdlets such as `Invoke-NovaBuild`, `Publish-NovaModule`, `Deploy-NovaPackage`,
 `Update-NovaModuleVersion`, and `Invoke-NovaRelease` keep their native `-WhatIf` and `-Confirm` behavior when called
 directly.
-
-Use `% nova <command> --help` or `% nova <command> -h` when you want short CLI help for a specific command.
-
-Use `% nova --help <command>` or `% nova -h <command>` when you want long CLI help for a specific command.
-
-The launcher help is CLI-native and uses CLI option spellings such as `--repository` and `-r`. Use PowerShell
-`Get-Help` when you want cmdlet help instead.
 
 ## EXAMPLES
 
@@ -67,68 +53,44 @@ Routes the build workflow through the explicit PowerShell cmdlet entrypoint.
 ### EXAMPLE 2
 
 ```text
-PS> Invoke-NovaCli -Command publish -Arguments @('--local') -WhatIf
+PS> Invoke-NovaCli -Command version
 ```
 
-Routes the local publish workflow while keeping native PowerShell `-WhatIf` on the outer call.
+Routes the version workflow through the explicit PowerShell cmdlet entrypoint.
 
 ### EXAMPLE 3
 
 ```text
-PS> Invoke-NovaCli -Command init -Arguments @('--example', '--path', '~/Work')
+PS> Invoke-NovaCli -Command update -WhatIf
 ```
 
-Starts the example scaffold flow from the explicit PowerShell cmdlet entrypoint.
+Routes the self-update workflow while previewing the outer PowerShell action.
 
 ### EXAMPLE 4
 
 ```text
-% nova build --confirm
+PS> Invoke-NovaCli -Command notification
 ```
 
-Runs the routed build workflow through the launcher-facing CLI surface and uses the shared CLI confirmation flow.
+Routes the notification-preference status workflow through the explicit PowerShell cmdlet entrypoint.
 
 ### EXAMPLE 5
 
 ```text
-% nova version --installed
+PS> Invoke-NovaCli -Command build -Confirm
 ```
 
-Returns the locally installed version of the current project/module.
-
-### EXAMPLE 6
-
-```text
-% nova --version
-```
-
-Returns the installed `NovaModuleTools` module version.
-
-### EXAMPLE 7
-
-```text
-% nova update
-```
-
-Runs the self-update flow through the launcher-oriented CLI surface.
-
-### EXAMPLE 8
-
-```text
-% nova notification --disable
-```
-
-Disables prerelease self-update eligibility through the launcher-facing CLI surface.
+Prompts before the routed build workflow starts.
 
 ## PARAMETERS
 
 ### -Command
 
-Top-level Nova command to route. Defaults to `--help`.
+Top-level Nova command to route. When omitted, the cmdlet routes to the root help view.
 
 ```yaml
 Type: System.String
-DefaultValue: --help
+DefaultValue: (root help view)
 SupportsWildcards: false
 Aliases: [ ]
 ParameterSets:
@@ -146,6 +108,8 @@ HelpMessage: ''
 ### -Arguments
 
 Raw routed argument list for the selected Nova command.
+
+Use this parameter when a routed command needs additional command-specific arguments.
 
 ```yaml
 Type: System.String[]
@@ -187,10 +151,11 @@ Returns the same output that the selected routed Nova command returns.
 Use `Invoke-NovaCli` directly when you need the underlying PowerShell command in scripts, tests, or command dispatch
 scenarios.
 
-Install the bundled `nova` launcher with `Install-NovaCli` when you want `% nova ...` available from your shell.
+Install the bundled command-line launcher with `Install-NovaCli` when you want the same routed command surface from
+your shell.
 
 `Invoke-NovaCli` uses `SupportsShouldProcess` so the outer PowerShell call still surfaces native `-WhatIf` and
-`-Confirm`, while routed CLI `--confirm`/`-c` stays inside the shared CLI confirmation flow.
+`-Confirm` support.
 
 ## RELATED LINKS
 

--- a/docs/NovaModuleTools/en-US/New-NovaModulePackage.md
+++ b/docs/NovaModuleTools/en-US/New-NovaModulePackage.md
@@ -87,10 +87,10 @@ when `Package.Types` is omitted or resolves to `NuGet`.
 ### EXAMPLE 2
 
 ```text
-% nova package
+PS> New-NovaModulePackage -WhatIf
 ```
 
-Runs the same packaging workflow through the `nova` CLI.
+Previews the build, test, and packaging workflow without writing a package artifact.
 
 ### EXAMPLE 3
 

--- a/docs/NovaModuleTools/en-US/NovaModuleTools.md
+++ b/docs/NovaModuleTools/en-US/NovaModuleTools.md
@@ -32,7 +32,7 @@ Shows whether prerelease update notifications are enabled. Stable release notifi
 
 ### `PS> Install-NovaCli`
 
-Installs the bundled `nova` launcher into a user command directory on macOS or Linux.
+Installs the bundled command-line launcher into a user command directory on macOS or Linux.
 
 ### `PS> Invoke-NovaBuild`
 
@@ -73,7 +73,7 @@ Builds, tests, and publishes the current project either locally or to a reposito
 
 ### `PS> Set-NovaUpdateNotificationPreference`
 
-Enables or disables whether prerelease self-updates are eligible for `Update-NovaModuleTool` and `% nova update`.
+Enables or disables whether prerelease self-updates are eligible for `Update-NovaModuleTool`.
 
 ### `PS> Update-NovaModuleVersion`
 

--- a/docs/NovaModuleTools/en-US/Publish-NovaModule.md
+++ b/docs/NovaModuleTools/en-US/Publish-NovaModule.md
@@ -43,11 +43,7 @@ Use repository mode when you want to publish the built module to a registered Po
 This command supports `-WhatIf` and `-Confirm` through PowerShell `SupportsShouldProcess`. Use `-WhatIf` to preview the
 resolved publish target and workflow without building, testing, or publishing.
 
-When you run the same workflow through `% nova publish --confirm` / `% nova publish -c`, the CLI handles confirmation
-before
-the routed publish starts. `Y` / `Yes` and `A` / `Yes to All` continue, `N` / `No` and `L` / `No to All` cancel the
-publish with a non-zero exit code, and `S` / `Suspend` is treated as cancel because nested PowerShell prompts are not
-supported in CLI mode.
+Use `-Confirm` when you want PowerShell to prompt before the publish workflow starts.
 
 ## EXAMPLES
 
@@ -80,10 +76,10 @@ Builds, tests, and publishes the module to `PSGallery`.
 ### EXAMPLE 4
 
 ```text
-% nova publish --repository PSGallery --api-key $PSGALLERY_API
+PS> Publish-NovaModule -Repository PSGallery -Confirm
 ```
 
-Runs the same publish flow through the `nova` CLI.
+Prompts before the repository publish workflow starts.
 
 ### EXAMPLE 5
 
@@ -215,8 +211,6 @@ source project or from `dist/`.
 `Publish-NovaModule` uses `SupportsShouldProcess`, so `Get-Help Publish-NovaModule -Full` should surface native
 `-WhatIf` and `-Confirm` support.
 
-The CLI-specific `% nova publish --confirm` / `% nova publish -c` prompt is separate from native PowerShell `-Confirm`.
-It never opens a nested PowerShell `Suspend` prompt.
 
 ## RELATED LINKS
 

--- a/docs/NovaModuleTools/en-US/Set-NovaUpdateNotificationPreference.md
+++ b/docs/NovaModuleTools/en-US/Set-NovaUpdateNotificationPreference.md
@@ -32,16 +32,12 @@ PS> Set-NovaUpdateNotificationPreference -DisablePrereleaseNotifications [-WhatI
 ## DESCRIPTION
 
 `Set-NovaUpdateNotificationPreference` manages the user preference that controls whether
-`Update-NovaModuleTool` / `Update-NovaModuleTools` and `% nova update` may select prerelease versions of
-`NovaModuleTools`.
+`Update-NovaModuleTool` / `Update-NovaModuleTools` may select prerelease versions of `NovaModuleTools`.
 
-The same stored preference is also used by `Update-NovaModuleTool` (alias: `Update-NovaModuleTools`) and `% nova update`
-when they decide whether a prerelease self-update can be selected.
+The same stored preference is also used by `Update-NovaModuleTool` (alias: `Update-NovaModuleTools`) when it decides
+whether a prerelease self-update can be selected.
 
 Stable self-updates remain available and do not require prerelease eligibility.
-
-If you prefer the Nova CLI surface, use `% nova notification --disable` / `% nova notification -d` and
-`% nova notification --enable` / `% nova notification -e` for the same stored preference.
 
 ## EXAMPLES
 
@@ -51,8 +47,7 @@ If you prefer the Nova CLI surface, use `% nova notification --disable` / `% nov
 PS> Set-NovaUpdateNotificationPreference -DisablePrereleaseNotifications
 ```
 
-Turns off prerelease self-update eligibility and restricts `Update-NovaModuleTool` / `% nova update` to stable releases
-only.
+Turns off prerelease self-update eligibility and restricts `Update-NovaModuleTool` to stable releases only.
 
 ### EXAMPLE 2
 
@@ -61,23 +56,23 @@ PS> Set-NovaUpdateNotificationPreference -EnablePrereleaseNotifications
 ```
 
 Turns prerelease self-update eligibility back on, which allows `Update-NovaModuleTool` /
-`Update-NovaModuleTools` and `% nova update` to consider a prerelease target again.
+`Update-NovaModuleTools` to consider a prerelease target again.
 
 ### EXAMPLE 3
 
 ```text
-% nova notification --disable
+PS> Set-NovaUpdateNotificationPreference -DisablePrereleaseNotifications -WhatIf
 ```
 
-Uses the Nova CLI entrypoint to disable prerelease self-update eligibility.
+Previews the change that would disable prerelease self-update eligibility.
 
 ### EXAMPLE 4
 
 ```text
-% nova notification --enable
+PS> Set-NovaUpdateNotificationPreference -EnablePrereleaseNotifications -Confirm
 ```
 
-Uses the Nova CLI entrypoint to re-enable prerelease self-update eligibility.
+Prompts before the preference is changed to allow prerelease self-updates again.
 
 ## PARAMETERS
 
@@ -201,7 +196,6 @@ Returns the current prerelease self-update state, the always-available stable-up
 
 Use this command together with `Get-NovaUpdateNotificationPreference` when you want to confirm the stored setting.
 
-Use `% nova notification` when you want to view the same setting through the CLI surface.
 
 ## RELATED LINKS
 

--- a/docs/NovaModuleTools/en-US/Update-NovaModuleTools.md
+++ b/docs/NovaModuleTools/en-US/Update-NovaModuleTools.md
@@ -31,7 +31,7 @@ The cmdlet is also available through the compatibility alias `Update-NovaModuleT
 
 Before it runs `Update-Module`, it resolves the best available update candidate by using the stored prerelease
 preference exposed through `Get-NovaUpdateNotificationPreference`, `Set-NovaUpdateNotificationPreference`, and
-`% nova notification`.
+those PowerShell preference commands.
 
 When prerelease notifications are disabled, `Update-NovaModuleTool` only considers stable releases and never passes
 `-AllowPrerelease` to the update flow.
@@ -41,10 +41,7 @@ prerelease, the command always asks for explicit confirmation before it proceeds
 
 Stable updates do not require prerelease confirmation.
 
-After a successful update, `Update-NovaModuleTool` and `% nova update` print the release notes link from the installed
-module manifest.
-
-Use `% nova update` when you want the same behavior through the Nova CLI entrypoint.
+After a successful update, `Update-NovaModuleTool` prints the release notes link from the installed module manifest.
 
 ## EXAMPLES
 
@@ -69,16 +66,13 @@ Restricts self-update to stable releases only.
 ### EXAMPLE 3
 
 ```text
-% nova update
+PS> Get-NovaUpdateNotificationPreference
+PS> Update-NovaModuleTool
 ```
 
-Runs the same self-update flow from the Nova CLI. If the selected target is a prerelease, the CLI asks for explicit
-confirmation before running the update.
+Reads the current prerelease preference and then runs the self-update flow from PowerShell.
 
 Successful updates print the release notes link from the installed module manifest.
-
-If no newer version is available, the standalone `% nova update` launcher prints `You're up to date!` together with the
-installed `NovaModuleTools` version.
 
 ### EXAMPLE 4
 
@@ -157,10 +151,8 @@ update was available, whether the target was prerelease, and whether the update 
 If the PowerShell Gallery cannot be reached well enough to resolve an update candidate, the command stops before calling
 `Update-Module`.
 
-Use `Get-NovaUpdateNotificationPreference`, `Set-NovaUpdateNotificationPreference`, `% nova notification`,
-`% nova notification --disable` / `% nova notification -d`, and `% nova notification --enable` /
-`% nova notification -e` to
-inspect or change the same stored prerelease setting.
+Use `Get-NovaUpdateNotificationPreference` and `Set-NovaUpdateNotificationPreference` to inspect or change the stored
+prerelease setting.
 
 ## RELATED LINKS
 

--- a/docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md
+++ b/docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md
@@ -55,10 +55,6 @@ When the current version is already a prerelease for the selected release line, 
 version instead of incrementing again. For example, a `Major` bump from `2.0.0-preview7` resolves to `2.0.0`, not
 `3.0.0-preview7`.
 
-From the routed `nova` CLI, `% nova bump --confirm` / `% nova bump -c` uses a CLI-friendly confirmation prompt. `Y` /
-`Yes` and `A` / `Yes to All` continue, while `N` / `No` and `L` / `No to All` cancel without changing `project.json`.
-`S` / `Suspend` is not supported in CLI mode; entering it cancels safely, returns a non-zero exit code, and never opens
-a nested PowerShell prompt.
 
 ## EXAMPLES
 

--- a/project.json
+++ b/project.json
@@ -1,7 +1,7 @@
 {
   "ProjectName": "NovaModuleTools",
   "Description": "NovaModuleTools is an enterprise-focused evolution of ModuleTools, designed for large-scale PowerShell projects with a strong emphasis on structure, maintainability, and automated CI/CD pipelines.",
-  "Version": "2.0.0-preview94",
+  "Version": "2.0.0-preview95",
   "Preamble": [
     "Set-StrictMode -Version Latest",
     "$ErrorActionPreference = 'Stop'"

--- a/tests/NovaCommandModel.TestSupport/TextAndHelp.ps1
+++ b/tests/NovaCommandModel.TestSupport/TextAndHelp.ps1
@@ -95,3 +95,32 @@ function Get-CommandHelpActivationTestCases {
     )
 }
 
+function Assert-TestPowerShellHelpExcludesCliSyntax {
+    [CmdletBinding()]
+    param(
+        [AllowNull()][string]$Text,
+        [Parameter(Mandatory)][string]$Subject
+    )
+
+    if ( [string]::IsNullOrWhiteSpace($Text)) {
+        return
+    }
+
+    foreach ($forbiddenPattern in @(
+        [pscustomobject]@{
+            Pattern = '(?-i)\bnova\s+(?:--help|--version|info|version|build|test|package|deploy|init|bump|update|notification|publish|release)\b'
+            Reason = 'should not mention launcher command syntax'
+        }
+        [pscustomobject]@{
+            Pattern = '(?<![A-Za-z0-9-])--[a-z][a-z-]*'
+            Reason = 'should not expose GNU-style long options'
+        }
+        [pscustomobject]@{
+            Pattern = '(?m)^\s*[%$]\s*nova\b'
+            Reason = 'should not include shell prompt launcher examples'
+        }
+    )) {
+        $Text | Should -Not -Match $forbiddenPattern.Pattern -Because "$Subject $( $forbiddenPattern.Reason )"
+    }
+}
+

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -6,6 +6,7 @@ $global:novaCommandModelTestSupportFunctionNameList = @(
     'Get-TestHelpLocaleFromMarkdownFiles'
     'Get-CommandHelpActivationTestCase'
     'Get-CommandHelpActivationTestCases'
+    'Assert-TestPowerShellHelpExcludesCliSyntax'
     'Initialize-TestNovaCliProjectLayout'
     'Write-TestNovaCliProjectJson'
     'Write-TestNovaCliPublicFunction'
@@ -463,6 +464,19 @@ Describe 'Nova command model - project, help, and build behavior' {
         }
     }
 
+    It 'PowerShell help markdown stays free of launcher syntax and GNU-style options' {
+        $helpMarkdownFiles = Get-ChildItem -LiteralPath $script:projectInfo.DocsDir -Filter '*.md' -Recurse
+
+        foreach ($file in $helpMarkdownFiles) {
+            $content = Get-Content -LiteralPath $file.FullName -Raw
+            if ($content -notmatch '(?m)^document type:\s*(cmdlet|module)\s*$') {
+                continue
+            }
+
+            Assert-TestPowerShellHelpExcludesCliSyntax -Text $content -Subject $file.Name
+        }
+    }
+
     It 'Get-Help supports Detailed, Full, Examples, and Parameter views for every public command' {
         $commonParameterNames = @(
             'Verbose',
@@ -498,10 +512,14 @@ Describe 'Nova command model - project, help, and build behavior' {
             $fullText | Should -Match 'OUTPUTS' -Because "$( $testCase.HelpTarget ) should render an outputs section"
             $fullText | Should -Match 'NOTES' -Because "$( $testCase.HelpTarget ) should render a notes section"
             $examplesText | Should -Match 'PS>' -Because "$( $testCase.HelpTarget ) examples should use PowerShell prompt formatting"
+            Assert-TestPowerShellHelpExcludesCliSyntax -Text $detailedText -Subject "$( $testCase.HelpTarget ) detailed help"
+            Assert-TestPowerShellHelpExcludesCliSyntax -Text $fullText -Subject "$( $testCase.HelpTarget ) full help"
+            Assert-TestPowerShellHelpExcludesCliSyntax -Text $examplesText -Subject "$( $testCase.HelpTarget ) examples help"
 
             foreach ($parameterName in $expectedParameterNames) {
                 $parameterText = Get-Help $testCase.HelpTarget -Parameter $parameterName -ErrorAction Stop | Out-String
                 $parameterText | Should -Match ([regex]::Escape("-$parameterName")) -Because "$( $testCase.HelpTarget ) should document -$parameterName"
+                Assert-TestPowerShellHelpExcludesCliSyntax -Text $parameterText -Subject "$( $testCase.HelpTarget ) parameter help for -$parameterName"
             }
         }
     }

--- a/tests/UpdateNotification.Tests.ps1
+++ b/tests/UpdateNotification.Tests.ps1
@@ -739,7 +739,7 @@ throw 'offline'
             $cliHelp | Should -Match 'prerelease targets require explicit confirmation'
             $commandHelp | Should -Match 'stored prerelease preference'
             $commandHelp | Should -Match 'explicit confirmation'
-            $commandHelp | Should -Match 'nova update'
+            $commandHelp | Should -Not -Match 'nova update'
         }
     }
 


### PR DESCRIPTION
## Summary

- Cleaned the PowerShell cmdlet help so generated `Get-Help` output no longer mixes in `nova` launcher syntax or GNU-style CLI options.
- This change was needed because the PlatyPS help pages had drifted into mixed PowerShell/CLI documentation, which made cmdlet help less clear and undermined the separation between PowerShell automation and the `nova` CLI.
- Follow-up context: this implements the PowerShell help cleanup plan captured in `plan.md` and adds focused regression coverage so launcher syntax leaks fail fast if they return.

## Affected area

- [ ] `nova` CLI or command routing
- [ ] Public PowerShell cmdlet behavior
- [ ] Scaffolding or `project.json` handling
- [x] Build, test, analyzer, coverage, or CI helper flow
- [ ] Package, raw upload, or package metadata workflow
- [ ] Publish, release, semantic-release, or GitHub Actions automation
- [ ] Self-update or notification preference behavior
- [ ] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
- [ ] End-user docs (`docs/*.html`)
- [x] Command help (`docs/NovaModuleTools/en-US/*.md`)
- [ ] `src/resources/example/`
- [ ] Dependency or manifest changes (`package.json`, workflow dependencies, release tooling)
- [ ] Security-sensitive change
- [ ] Documentation-only change
- [ ] Other

## Review guidance

- Start with the rewritten PowerShell help pages under `docs/NovaModuleTools/en-US/`, especially `Invoke-NovaCli.md`, `Publish-NovaModule.md`, `Update-NovaModuleTools.md`, `Update-NovaModuleVersion.md`, `Set-NovaUpdateNotificationPreference.md`, and `Get-NovaUpdateNotificationPreference.md`.
- Then review `tests/NovaCommandModel.TestSupport/TextAndHelp.ps1` for the shared `Assert-TestPowerShellHelpExcludesCliSyntax` guard and `tests/NovaCommandModel.Tests.ps1` for the markdown and rendered `Get-Help` assertions.
- `tests/UpdateNotification.Tests.ps1` contains the focused expectation update that keeps CLI wording on CLI help paths while requiring PowerShell-native wording in cmdlet help.
- Trade-off: `Invoke-NovaCli` still documents the routed PowerShell entrypoint, but the page now avoids acting as the primary CLI manual. The cleanup intentionally prefers cmdlet-oriented wording over launcher-oriented examples.

## Validation

- [x] `Invoke-NovaBuild`
- [ ] `Test-NovaBuild`
- [ ] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
- [ ] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`,
  `% nova publish`,
  `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
- [ ] Docs/example only; executable validation not needed

Validation notes:

```text
Invoke-NovaBuild -Confirm:$false
Invoke-Pester -Path tests/NovaCommandModel.Tests.ps1, tests/UpdateNotification.Tests.ps1

Tests Passed: 70, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 0

Additional checks completed:
- searched docs/NovaModuleTools/en-US/*.md for `% nova`, `$ nova`, and `--long-option` leaks
- spot-checked Get-Help output for Publish-NovaModule, Update-NovaModuleTool, and Invoke-NovaCli
- pre-commit Code Health safeguard passed

Skipped checks:
- Test-NovaBuild was not rerun directly because this work targeted cmdlet help and help-rendering tests
- ScriptAnalyzer CI and full CI helper flows were not rerun in this focused documentation/help change
- No targeted nova launcher workflow was exercised because the cleanup intentionally stayed on PowerShell help surfaces
```

## Documentation and release follow-up

- [ ] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
- [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
- [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [x] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
- [ ] `docs/*.html` updated if end-user workflows or examples changed
- [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
  changed
- [ ] No documentation, changelog, or example updates were needed

## Maintainability, compatibility, and risk

- [x] Code Health / maintainability impact considered
- [x] No breaking change
- [ ] Breaking change
- [ ] Security-sensitive change
- [ ] CI, workflow, or release-pipeline impact
- [ ] Dependency-review impact

Risk, rollout, or rollback notes:

```text
This is a low-risk cleanup of generated PowerShell help and the tests that guard it.

There is no intended behavioral change to nova CLI routing or PowerShell command execution; the main user-visible change is that Get-Help now stays PowerShell-native and no longer shows launcher syntax or GNU-style options.

If rollback is needed, revert the updated docs/NovaModuleTools/en-US/*.md pages together with the help-validation test changes so the generated help and the regression coverage stay aligned.
```

> [!IMPORTANT]
> Do not use a public pull request to disclose a vulnerability before coordinated handling.
> Use the private reporting path in `SECURITY.md` for new security issues.
