### PR TITLE
Feature/119 add an explicit skip test option to the package publish and release workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     generic headers/auth settings.
   - Package upload now discovers all matching artifacts for the selected package types, including versioned and
     `latest` files in the configured package output directory.
+- Add opt-in skip-test support to the package, publish, and release workflows for CI/CD-oriented delivery paths where
+  tests already ran earlier in the pipeline.
+    - PowerShell now supports `New-NovaModulePackage -SkipTests`, `Publish-NovaModule -SkipTests`, and
+      `Invoke-NovaRelease -SkipTests`.
+    - The `nova` launcher now supports `--skip-tests` / `-s` on `nova package`, `nova publish`, and `nova release`.
+    - Skip-tests bypasses `Test-NovaBuild` only; the related build steps still run.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,16 @@ When `Manifest.Tags`, `Manifest.ProjectUri`, `Manifest.ReleaseNotes`, or `Manife
 copies them into the generated package metadata; when they are omitted, packaging still succeeds and the matching
 package metadata fields are simply left out.
 
+When tests already ran earlier in CI/CD, you can skip only the test step while still rebuilding before packaging:
+
+```powershell
+PS> New-NovaModulePackage -SkipTests
+% nova package --skip-tests
+% nova package -s
+```
+
+`-SkipTests` / `--skip-tests` skips `Test-NovaBuild` only. `Invoke-NovaBuild` still runs.
+
 Use this `project.json` shape when you want to control the package types and output directory:
 
 ```json
@@ -321,6 +331,19 @@ Use this `project.json` shape when you want Nova to resolve upload targets from 
 - `Package.Headers`, `Package.Auth`, `Package.RepositoryUrl`, and repository-specific overrides remain generic so the
   workflow works with raw endpoints such as Nexus or Artifactory without turning `Publish-NovaModule` into a vendor-
   specific upload command.
+
+For module publishing and release flows, the same opt-in skip-tests behavior is available when tests already ran earlier
+in the pipeline:
+
+```powershell
+PS> Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API -SkipTests
+PS> Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $env:PSGALLERY_API } -SkipTests
+% nova publish --repository PSGallery --api-key $env:PSGALLERY_API --skip-tests
+% nova release --repository PSGallery --api-key $env:PSGALLERY_API -s
+```
+
+These forms skip `Test-NovaBuild` only. `Publish-NovaModule` still builds before publishing, and `Invoke-NovaRelease`
+still runs both build steps around the version bump.
 
 ### Run code quality checks
 

--- a/docs/NovaModuleTools/en-US/Invoke-NovaRelease.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaRelease.md
@@ -4,7 +4,7 @@ external help file: NovaModuleTools-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: NovaModuleTools
-ms.date: 04/25/2026
+  ms.date: 04/26/2026
 PlatyPS schema version: 2024-05-01
 title: Invoke-NovaRelease
 ---
@@ -20,7 +20,7 @@ Runs the Nova release pipeline (build, test, version bump, rebuild, publish).
 ### __AllParameterSets
 
 ```text
-PS> Invoke-NovaRelease [[-PublishOption] <hashtable>] [[-Path] <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+PS> Invoke-NovaRelease [[-PublishOption] <hashtable>] [-SkipTests] [[-Path] <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -32,6 +32,9 @@ PS> Invoke-NovaRelease [[-PublishOption] <hashtable>] [[-Path] <string>] [-WhatI
 3. Bump version (`Update-NovaModuleVersion`)
 4. Build again to include the updated version
 5. Publish through the resolved local-directory or repository publish action
+
+Use `-SkipTests` when tests already ran earlier in your pipeline and you only want to skip the pre-release
+`Test-NovaBuild` step. Both build steps still run.
 
 The command changes location to `-Path` for execution and always restores the previous location.
 
@@ -76,6 +79,14 @@ PS> Invoke-NovaRelease -PublishOption @{Repository = 'PSGallery'; ApiKey = $env:
 ```
 
 Previews the release workflow and repository target without making changes.
+
+### EXAMPLE 5
+
+```text
+PS> Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $env:PSGALLERY_API } -SkipTests
+```
+
+Runs the release workflow without re-running the pre-release `Test-NovaBuild` step.
 
 ## PARAMETERS
 
@@ -130,6 +141,30 @@ AcceptedValues: [ ]
 HelpMessage: ''
 ```
 
+### -SkipTests
+
+Skip the pre-release `Test-NovaBuild` step. `Invoke-NovaBuild` still runs before the version bump and again after the
+bump so the published output reflects the updated version.
+
+This option is mainly intended for CI/CD flows where tests already passed earlier in the pipeline.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: [ ]
+ParameterSets:
+  - Name: (All)
+    Position: Named
+    IsRequired: false
+    ValueFromPipeline: false
+    ValueFromPipelineByPropertyName: false
+    ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: [ ]
+HelpMessage: ''
+```
+
 ### CommonParameters
 
 This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`,
@@ -152,6 +187,8 @@ selected release label, and commit count.
 ## NOTES
 
 If build or tests fail, version bump and publish are not completed.
+
+When `-SkipTests` is used, only the pre-release `Test-NovaBuild` step is skipped. Both build steps still run.
 
 Use `Publish-NovaModule -Local` when you want a successful local publish to reload the published module into the active
 PowerShell session.

--- a/docs/NovaModuleTools/en-US/New-NovaModulePackage.md
+++ b/docs/NovaModuleTools/en-US/New-NovaModulePackage.md
@@ -4,7 +4,7 @@ external help file: NovaModuleTools-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: NovaModuleTools
-ms.date: 04/25/2026
+  ms.date: 04/26/2026
 PlatyPS schema version: 2024-05-01
 title: New-NovaModulePackage
 ---
@@ -20,13 +20,16 @@ Builds, tests, and packages the current project as one or more configured packag
 ### __AllParameterSets
 
 ```text
-PS> New-NovaModulePackage [-WhatIf] [-Confirm] [<CommonParameters>]
+PS> New-NovaModulePackage [-SkipTests] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
 `New-NovaModulePackage` runs the normal NovaModuleTools build and test flow, then packages the built module output from
 `dist/<ProjectName>/` into the package formats requested by `Package.Types`.
+
+Use `-SkipTests` when tests already ran earlier in your pipeline and you only want to skip `Test-NovaBuild` for this
+packaging run. `Invoke-NovaBuild` still runs so the package is created from fresh built output.
 
 The package is written to `artifacts/packages/` by default. You can override generic package metadata through the
 optional `Package` section in `project.json`.
@@ -135,7 +138,39 @@ PS> New-NovaModulePackage -Confirm
 
 Prompts before the package artifact is created.
 
+### EXAMPLE 8
+
+```text
+PS> New-NovaModulePackage -SkipTests
+```
+
+Builds the project and creates the package artifact without re-running `Test-NovaBuild`.
+
 ## PARAMETERS
+
+### -SkipTests
+
+Skip `Test-NovaBuild` for this packaging run. `Invoke-NovaBuild` still runs before packaging so the artifact is created
+from fresh built output.
+
+This option is mainly intended for CI/CD flows where tests already passed earlier in the pipeline.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: [ ]
+ParameterSets:
+  - Name: (All)
+    Position: Named
+    IsRequired: false
+    ValueFromPipeline: false
+    ValueFromPipelineByPropertyName: false
+    ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: [ ]
+HelpMessage: ''
+```
 
 ### -WhatIf
 
@@ -221,6 +256,8 @@ Use the top-level `Package` section only for generic packaging overrides such as
 directory, or package file name. `New-NovaModulePackage` always allows packaging when you invoke it; there is no
 separate
 `Package.Enabled` switch.
+
+When `-SkipTests` is used, only `Test-NovaBuild` is skipped. Build still runs.
 
 ## RELATED LINKS
 

--- a/docs/NovaModuleTools/en-US/Publish-NovaModule.md
+++ b/docs/NovaModuleTools/en-US/Publish-NovaModule.md
@@ -4,7 +4,7 @@ external help file: NovaModuleTools-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: NovaModuleTools
-ms.date: 04/25/2026
+  ms.date: 04/26/2026
 PlatyPS schema version: 2024-05-01
 title: Publish-NovaModule
 ---
@@ -20,18 +20,21 @@ Builds, tests, and publishes the current project either locally or to a PowerShe
 ### Local
 
 ```text
-PS> Publish-NovaModule [-Local] [[-ModuleDirectoryPath] <string>] [[-ApiKey] <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+PS> Publish-NovaModule [-Local] [[-ModuleDirectoryPath] <string>] [[-ApiKey] <string>] [-SkipTests] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Repository
 
 ```text
-PS> Publish-NovaModule [-Repository] <string> [[-ModuleDirectoryPath] <string>] [[-ApiKey] <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+PS> Publish-NovaModule [-Repository] <string> [[-ModuleDirectoryPath] <string>] [[-ApiKey] <string>] [-SkipTests] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
 `Publish-NovaModule` runs the normal NovaModuleTools build and test flow, then publishes the built module.
+
+Use `-SkipTests` when tests already ran earlier in your pipeline and you only want to skip `Test-NovaBuild` for this
+publish run. `Invoke-NovaBuild` still runs before the publish step.
 
 Use local mode when you want to copy the built module into a module directory on the current machine.
 After a successful local publish, the command reloads the published module from that local install path into the active
@@ -89,6 +92,14 @@ PS> Publish-NovaModule -Local -WhatIf
 
 Previews the local publish workflow and target directory without making changes.
 No module copy or import happens when `-WhatIf` is used.
+
+### EXAMPLE 6
+
+```text
+PS> Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API -SkipTests
+```
+
+Builds and publishes the module to `PSGallery` without re-running `Test-NovaBuild`.
 
 ## PARAMETERS
 
@@ -180,6 +191,31 @@ AcceptedValues: []
 HelpMessage: ''
 ```
 
+### -SkipTests
+
+Skip `Test-NovaBuild` for this publish run. `Invoke-NovaBuild` still runs before the publish step.
+
+This option is mainly intended for CI/CD flows where tests already passed earlier in the pipeline.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: [ ]
+ParameterSets:
+  - Name: Local
+    Position: Named
+  - Name: Repository
+    Position: Named
+    IsRequired: false
+    ValueFromPipeline: false
+    ValueFromPipelineByPropertyName: false
+    ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: [ ]
+HelpMessage: ''
+```
+
 ### CommonParameters
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
@@ -202,7 +238,10 @@ published module from the local install path.
 
 ## NOTES
 
-The command always builds and tests before publishing.
+The command always builds before publishing.
+
+When `-SkipTests` is omitted, `Publish-NovaModule` also runs `Test-NovaBuild`. When `-SkipTests` is used, only the test
+step is skipped.
 
 Local publish imports the published module from the resolved local install directory. It does not import directly from
 the

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -298,12 +298,17 @@ PS&gt; Test-NovaBuild -TagFilter unit,fast</code></pre>
                     <article class="command-card">
                         <h3><code>New-NovaModulePackage</code> / <code>% nova package</code></h3>
                         <p>Build, test, and package the module. By default it creates a <code>.nupkg</code> in <code>artifacts/packages/</code>.
-                            Use <code>Package.Types</code> and related settings to customize the output.</p>
+                            Use <code>Package.Types</code> and related settings to customize the output, or use
+                            <code>-SkipTests</code> / <code>--skip-tests</code> when tests already ran earlier in CI/CD.
+                        </p>
                         <ul class="plain-list">
                             <li><strong>Best for:</strong> creating package artifacts from the built module output</li>
                             <li><strong>Key settings:</strong> <code>Package.Types</code>, <code>Package.Latest</code>,
                                 <code>Package.OutputDirectory</code></li>
                             <li><strong>Output:</strong> one object per generated artifact</li>
+                            <li><strong>Optional fast path:</strong> <code>-SkipTests</code> / <code>--skip-tests</code>
+                                skips <code>Test-NovaBuild</code> only; build still runs
+                            </li>
                         </ul>
                         <div class="surface-example" data-command-example>
                             <div class="surface-example__meta">
@@ -312,10 +317,12 @@ PS&gt; Test-NovaBuild -TagFilter unit,fast</code></pre>
                                         data-command-surface-label>PowerShell</span></p>
                             </div>
                             <div class="surface-example__surface" data-command-surface="powershell">
-                                <pre><code>PS&gt; New-NovaModulePackage</code></pre>
+                                <pre><code>PS&gt; New-NovaModulePackage
+PS&gt; New-NovaModulePackage -SkipTests</code></pre>
                             </div>
                             <div class="surface-example__surface" data-command-surface="command-line" hidden>
-                                <pre><code>% nova package</code></pre>
+                                <pre><code>% nova package
+% nova package --skip-tests</code></pre>
                             </div>
                         </div>
                         <p><a class="text-link" href="./packaging-and-delivery.html#pack">See packaging details</a></p>
@@ -358,13 +365,14 @@ PS&gt; Deploy-NovaPackage -Url 'https://packages.example/raw/' -Token $env:NOVA_
                     <article class="command-card">
                         <h3><code>Publish-NovaModule</code> / <code>% nova publish</code></h3>
                         <p>Build, test, and publish the module either locally or to a registered PowerShell
-                            repository.</p>
+                            repository. Use <code>-SkipTests</code> / <code>--skip-tests</code> when tests already ran
+                            earlier in CI/CD.</p>
                         <ul class="plain-list">
                             <li><strong>Best for:</strong> PowerShell repository publishing or validating a local
                                 publish/install cycle
                             </li>
                             <li><strong>Key parameters:</strong> <code>-Local</code>, <code>-Repository</code>, <code>-ModuleDirectoryPath</code>,
-                                <code>-ApiKey</code></li>
+                                <code>-ApiKey</code>, <code>-SkipTests</code></li>
                             <li><strong>Notable behavior:</strong> local publish reloads the published module into the
                                 current PowerShell session
                             </li>
@@ -377,11 +385,13 @@ PS&gt; Deploy-NovaPackage -Url 'https://packages.example/raw/' -Token $env:NOVA_
                             </div>
                             <div class="surface-example__surface" data-command-surface="powershell">
                                 <pre><code>PS&gt; Publish-NovaModule -Local
-PS&gt; Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API</code></pre>
+PS&gt; Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API
+PS&gt; Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API -SkipTests</code></pre>
                             </div>
                             <div class="surface-example__surface" data-command-surface="command-line" hidden>
                                 <pre><code>% nova publish --local
-% nova publish --repository PSGallery --api-key $env:PSGALLERY_API</code></pre>
+% nova publish --repository PSGallery --api-key $env:PSGALLERY_API
+% nova publish --repository PSGallery --api-key $env:PSGALLERY_API --skip-tests</code></pre>
                             </div>
                         </div>
                         <p><a class="text-link" href="./packaging-and-delivery.html#publish">See publish details</a></p>
@@ -389,12 +399,15 @@ PS&gt; Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API</code
 
                     <article class="command-card">
                         <h3><code>Invoke-NovaRelease</code> / <code>% nova release</code></h3>
-                        <p>Run the full release flow: build, test, bump version, build again, and then publish.</p>
+                        <p>Run the full release flow: build, test, bump version, build again, and then publish. Use
+                            <code>-SkipTests</code> / <code>--skip-tests</code> when tests already ran earlier in CI/CD
+                            and you only want to skip the pre-release test step.</p>
                         <ul class="plain-list">
                             <li><strong>Best for:</strong> an orchestrated release command when you want one workflow
                                 instead of separate steps
                             </li>
-                            <li><strong>Key parameters:</strong> <code>-PublishOption</code>, <code>-Path</code></li>
+                            <li><strong>Key parameters:</strong> <code>-PublishOption</code>, <code>-Path</code>,
+                                <code>-SkipTests</code></li>
                             <li><strong>Important difference:</strong> local release does not reload the published
                                 module into the session after publishing
                             </li>
@@ -407,10 +420,12 @@ PS&gt; Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API</code
                             </div>
                             <div class="surface-example__surface" data-command-surface="powershell">
                                 <pre><code>PS&gt; Invoke-NovaRelease -PublishOption @{ Local = $true }
-PS&gt; Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $env:PSGALLERY_API }</code></pre>
+PS&gt; Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $env:PSGALLERY_API }
+PS&gt; Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $env:PSGALLERY_API } -SkipTests</code></pre>
                             </div>
                             <div class="surface-example__surface" data-command-surface="command-line" hidden>
-                                <pre><code>% nova release --repository PSGallery --api-key $env:PSGALLERY_API</code></pre>
+                                <pre><code>% nova release --repository PSGallery --api-key $env:PSGALLERY_API
+% nova release --repository PSGallery --api-key $env:PSGALLERY_API --skip-tests</code></pre>
                             </div>
                         </div>
                         <div class="surface-note" data-command-visibility="command-line" hidden>

--- a/docs/packaging-and-delivery.html
+++ b/docs/packaging-and-delivery.html
@@ -165,6 +165,12 @@
                         which defaults to <code>artifacts/packages/</code>.
                     </li>
                 </ol>
+                <div class="notice">
+                    <strong>CI/CD shortcut:</strong>
+                    <p>Use <code>-SkipTests</code>, <code>--skip-tests</code>, or <code>-s</code> when tests already
+                        ran earlier in your pipeline. Nova still rebuilds before packaging; it only skips
+                        <code>Test-NovaBuild</code>.</p>
+                </div>
                 <h3>Common examples</h3>
                 <div class="surface-example" data-command-example>
                     <div class="surface-example__meta">
@@ -173,10 +179,13 @@
                         </p>
                     </div>
                     <div class="surface-example__surface" data-command-surface="powershell">
-                        <pre><code>PS&gt; New-NovaModulePackage</code></pre>
+                        <pre><code>PS&gt; New-NovaModulePackage
+PS&gt; New-NovaModulePackage -SkipTests</code></pre>
                     </div>
                     <div class="surface-example__surface" data-command-surface="command-line" hidden>
-                        <pre><code>% nova package</code></pre>
+                        <pre><code>% nova package
+% nova package --skip-tests
+% nova package -s</code></pre>
                     </div>
                 </div>
                 <p>This creates a <code>.nupkg</code> by default when <code>Package.Types</code> is omitted.</p>
@@ -363,10 +372,12 @@ MyModule.latest.zip</code></pre>
                         </p>
                     </div>
                     <div class="surface-example__surface" data-command-surface="powershell">
-                        <pre><code>PS&gt; Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API</code></pre>
+                        <pre><code>PS&gt; Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API
+PS&gt; Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API -SkipTests</code></pre>
                     </div>
                     <div class="surface-example__surface" data-command-surface="command-line" hidden>
-                        <pre><code>% nova publish --repository PSGallery --api-key $env:PSGALLERY_API</code></pre>
+                        <pre><code>% nova publish --repository PSGallery --api-key $env:PSGALLERY_API
+% nova publish --repository PSGallery --api-key $env:PSGALLERY_API --skip-tests</code></pre>
                     </div>
                 </div>
                 <p>Repository mode is for registered PowerShell repositories such as PowerShell Gallery.</p>
@@ -389,6 +400,11 @@ MyModule.latest.zip</code></pre>
                         the custom module directory target in this flow.</p>
                 </div>
                 <p>Use this when you want local publishing to target a custom module directory.</p>
+                <div class="notice">
+                    <strong>CI/CD shortcut:</strong>
+                    <p>Use <code>-SkipTests</code>, <code>--skip-tests</code>, or <code>-s</code> when tests already ran
+                        earlier in the pipeline. Publish still rebuilds before copying or repository publishing.</p>
+                </div>
                 <h3>What <code>-WhatIf</code> means here</h3>
                 <p>When you preview local publish, Nova does not build, test, copy, or import the module. The preview is
                     safe and side-effect free.</p>
@@ -406,6 +422,12 @@ MyModule.latest.zip</code></pre>
                     <li>Build again so the output reflects the new version.</li>
                     <li>Publish locally or to a repository.</li>
                 </ol>
+                <div class="notice">
+                    <strong>CI/CD shortcut:</strong>
+                    <p>Use <code>-SkipTests</code>, <code>--skip-tests</code>, or <code>-s</code> when tests already ran
+                        earlier in your pipeline. Release still runs both build steps; it only skips the pre-release
+                        <code>Test-NovaBuild</code> step.</p>
+                </div>
                 <h3>Examples</h3>
                 <div class="surface-example" data-command-example>
                     <div class="surface-example__meta">
@@ -415,10 +437,12 @@ MyModule.latest.zip</code></pre>
                     </div>
                     <div class="surface-example__surface" data-command-surface="powershell">
                         <pre><code>PS&gt; Invoke-NovaRelease -PublishOption @{ Local = $true }
-PS&gt; Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $env:PSGALLERY_API }</code></pre>
+PS&gt; Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $env:PSGALLERY_API }
+PS&gt; Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $env:PSGALLERY_API } -SkipTests</code></pre>
                     </div>
                     <div class="surface-example__surface" data-command-surface="command-line" hidden>
-                        <pre><code>% nova release --repository PSGallery --api-key $env:PSGALLERY_API</code></pre>
+                        <pre><code>% nova release --repository PSGallery --api-key $env:PSGALLERY_API
+% nova release --repository PSGallery --api-key $env:PSGALLERY_API --skip-tests</code></pre>
                     </div>
                 </div>
                 <div class="surface-note" data-command-visibility="command-line" hidden>

--- a/src/private/cli/ConvertFromNovaCliArgument.ps1
+++ b/src/private/cli/ConvertFromNovaCliArgument.ps1
@@ -1,7 +1,24 @@
+function Set-NovaCliDeliveryOption {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][hashtable]$Options,
+        [Parameter(Mandatory)][string[]]$AllowedOptionNameList,
+        [Parameter(Mandatory)][pscustomobject]$Option,
+        [Parameter(Mandatory)][string]$Token
+    )
+
+    if ($Option.Name -notin $AllowedOptionNameList) {
+        Stop-NovaOperation -Message "Unknown argument: $Token" -ErrorId 'Nova.Validation.UnknownCliArgument' -Category InvalidArgument -TargetObject $token
+    }
+
+    $Options[$Option.Name] = $Option.Value
+}
+
 function ConvertFrom-NovaCliArgument {
     [CmdletBinding()]
     param(
-        [string[]]$Arguments
+        [string[]]$Arguments,
+        [string[]]$AllowedOptionNameList = @('Local', 'Repository', 'ModuleDirectoryPath', 'ApiKey', 'SkipTests')
     )
 
     $Arguments = ConvertTo-NovaCliArgumentArray -BoundParameters $PSBoundParameters -Arguments $Arguments
@@ -13,16 +30,22 @@ function ConvertFrom-NovaCliArgument {
 
         switch -Regex ($token) {
             '^(--local|-l)$' {
-                $options.Local = $true
+                Set-NovaCliDeliveryOption -Options $options -AllowedOptionNameList $AllowedOptionNameList -Option ([pscustomobject]@{Name = 'Local'; Value = $true}) -Token $token
             }
             '^(--repository|-r)$' {
-                $options.Repository = Get-NovaCliRequiredArgumentValue -Arguments $Arguments -Index ([ref]$index) -OptionName '--repository'
+                $value = Get-NovaCliRequiredArgumentValue -Arguments $Arguments -Index ([ref]$index) -OptionName '--repository'
+                Set-NovaCliDeliveryOption -Options $options -AllowedOptionNameList $AllowedOptionNameList -Option ([pscustomobject]@{Name = 'Repository'; Value = $value}) -Token $token
             }
             '^(--path|-p)$' {
-                $options.ModuleDirectoryPath = Get-NovaCliRequiredArgumentValue -Arguments $Arguments -Index ([ref]$index) -OptionName '--path'
+                $value = Get-NovaCliRequiredArgumentValue -Arguments $Arguments -Index ([ref]$index) -OptionName '--path'
+                Set-NovaCliDeliveryOption -Options $options -AllowedOptionNameList $AllowedOptionNameList -Option ([pscustomobject]@{Name = 'ModuleDirectoryPath'; Value = $value}) -Token $token
             }
             '^(--api-key|-k)$' {
-                $options.ApiKey = Get-NovaCliRequiredArgumentValue -Arguments $Arguments -Index ([ref]$index) -OptionName '--api-key'
+                $value = Get-NovaCliRequiredArgumentValue -Arguments $Arguments -Index ([ref]$index) -OptionName '--api-key'
+                Set-NovaCliDeliveryOption -Options $options -AllowedOptionNameList $AllowedOptionNameList -Option ([pscustomobject]@{Name = 'ApiKey'; Value = $value}) -Token $token
+            }
+            '^(--skip-tests|-s)$' {
+                Set-NovaCliDeliveryOption -Options $options -AllowedOptionNameList $AllowedOptionNameList -Option ([pscustomobject]@{Name = 'SkipTests'; Value = $true}) -Token $token
             }
             default {
                 Stop-NovaOperation -Message "Unknown argument: $token" -ErrorId 'Nova.Validation.UnknownCliArgument' -Category InvalidArgument -TargetObject $token
@@ -34,3 +57,13 @@ function ConvertFrom-NovaCliArgument {
 
     return $options
 }
+
+function ConvertFrom-NovaPackageCliArgument {
+    [CmdletBinding()]
+    param(
+        [string[]]$Arguments
+    )
+
+    return ConvertFrom-NovaCliArgument -Arguments $Arguments -AllowedOptionNameList @('SkipTests')
+}
+

--- a/src/private/cli/ConvertFromNovaCliArgument.ps1
+++ b/src/private/cli/ConvertFromNovaCliArgument.ps1
@@ -1,4 +1,4 @@
-function Set-NovaCliDeliveryOption {
+function Add-NovaCliDeliveryOption {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][hashtable]$Options,
@@ -30,22 +30,22 @@ function ConvertFrom-NovaCliArgument {
 
         switch -Regex ($token) {
             '^(--local|-l)$' {
-                Set-NovaCliDeliveryOption -Options $options -AllowedOptionNameList $AllowedOptionNameList -Option ([pscustomobject]@{Name = 'Local'; Value = $true}) -Token $token
+                Add-NovaCliDeliveryOption -Options $options -AllowedOptionNameList $AllowedOptionNameList -Option ([pscustomobject]@{Name = 'Local'; Value = $true}) -Token $token
             }
             '^(--repository|-r)$' {
                 $value = Get-NovaCliRequiredArgumentValue -Arguments $Arguments -Index ([ref]$index) -OptionName '--repository'
-                Set-NovaCliDeliveryOption -Options $options -AllowedOptionNameList $AllowedOptionNameList -Option ([pscustomobject]@{Name = 'Repository'; Value = $value}) -Token $token
+                Add-NovaCliDeliveryOption -Options $options -AllowedOptionNameList $AllowedOptionNameList -Option ([pscustomobject]@{Name = 'Repository'; Value = $value}) -Token $token
             }
             '^(--path|-p)$' {
                 $value = Get-NovaCliRequiredArgumentValue -Arguments $Arguments -Index ([ref]$index) -OptionName '--path'
-                Set-NovaCliDeliveryOption -Options $options -AllowedOptionNameList $AllowedOptionNameList -Option ([pscustomobject]@{Name = 'ModuleDirectoryPath'; Value = $value}) -Token $token
+                Add-NovaCliDeliveryOption -Options $options -AllowedOptionNameList $AllowedOptionNameList -Option ([pscustomobject]@{Name = 'ModuleDirectoryPath'; Value = $value}) -Token $token
             }
             '^(--api-key|-k)$' {
                 $value = Get-NovaCliRequiredArgumentValue -Arguments $Arguments -Index ([ref]$index) -OptionName '--api-key'
-                Set-NovaCliDeliveryOption -Options $options -AllowedOptionNameList $AllowedOptionNameList -Option ([pscustomobject]@{Name = 'ApiKey'; Value = $value}) -Token $token
+                Add-NovaCliDeliveryOption -Options $options -AllowedOptionNameList $AllowedOptionNameList -Option ([pscustomobject]@{Name = 'ApiKey'; Value = $value}) -Token $token
             }
             '^(--skip-tests|-s)$' {
-                Set-NovaCliDeliveryOption -Options $options -AllowedOptionNameList $AllowedOptionNameList -Option ([pscustomobject]@{Name = 'SkipTests'; Value = $true}) -Token $token
+                Add-NovaCliDeliveryOption -Options $options -AllowedOptionNameList $AllowedOptionNameList -Option ([pscustomobject]@{Name = 'SkipTests'; Value = $true}) -Token $token
             }
             default {
                 Stop-NovaOperation -Message "Unknown argument: $token" -ErrorId 'Nova.Validation.UnknownCliArgument' -Category InvalidArgument -TargetObject $token

--- a/src/private/cli/GetNovaCliArgumentRoutingState.ps1
+++ b/src/private/cli/GetNovaCliArgumentRoutingState.ps1
@@ -72,6 +72,7 @@ function Get-NovaCliLegacyOptionReplacement {
         '-path' = "'--path' or '-p'"
         '-preview' = "'--preview' or '-p'"
         '-repository' = "'--repository' or '-r'"
+        '-skiptests' = "'--skip-tests' or '-s'"
         '-token' = "'--token' or '-k'"
         '-tokenenvironmentvariable' = "'--token-env' or '-e'"
         '-type' = "'--type' or '-t'"

--- a/src/private/cli/InvokeNovaCliCommandRoute.ps1
+++ b/src/private/cli/InvokeNovaCliCommandRoute.ps1
@@ -35,6 +35,54 @@ function Confirm-NovaCliRoutedCommand {
     Confirm-NovaCliCommandAction -Command $Command
 }
 
+function Invoke-NovaCliParsedCommand {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$InvocationContext,
+        [Parameter(Mandatory)][string]$ParserCommand,
+        [Parameter(Mandatory)][string]$ActionCommand,
+        [switch]$UsePublishOption
+    )
+
+    $arguments = $InvocationContext.Arguments
+    $mutatingCommonParameters = $InvocationContext.MutatingCommonParameters
+    $options = & $ParserCommand -Arguments $arguments
+    if ($UsePublishOption) {
+        return & $ActionCommand -PublishOption $options @mutatingCommonParameters
+    }
+
+    return & $ActionCommand @options @mutatingCommonParameters
+}
+
+function Invoke-NovaCliUpdateRouteCommand {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$InvocationContext
+    )
+
+    $result = Invoke-NovaCliUpdateCommand -Arguments $InvocationContext.Arguments -ForwardedParameters $InvocationContext.MutatingCommonParameters
+    Format-NovaCliCommandResult -Command $InvocationContext.Command -Result $result
+}
+
+function Invoke-NovaCliNotificationRouteCommand {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$InvocationContext
+    )
+
+    Invoke-NovaCliNotificationCommand -Arguments $InvocationContext.Arguments -CommonParameters $InvocationContext.CommonParameters -MutatingCommonParameters $InvocationContext.MutatingCommonParameters
+}
+
+function Invoke-NovaCliInstalledVersionCommand {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$InvocationContext
+    )
+
+    $moduleVersion = Get-NovaCliInstalledVersion
+    Format-NovaCliVersionString -Name $InvocationContext.ModuleName -Version $moduleVersion
+}
+
 function Invoke-NovaCliCommandRoute {
     [CmdletBinding()]
     param(
@@ -50,63 +98,55 @@ function Invoke-NovaCliCommandRoute {
     }
 
     $command = $InvocationContext.Command
-    $arguments = $InvocationContext.Arguments
     $commonParameters = $InvocationContext.CommonParameters
     $mutatingCommonParameters = $InvocationContext.MutatingCommonParameters
-
-    $commandHandlerMap = @{
-        'info' = {
-            Get-NovaProjectInfo @commonParameters
-        }
-        'version' = {
-            Invoke-NovaCliVersionCommand -Arguments $arguments -ForwardedParameters $commonParameters
-        }
-        'build' = {
-            Invoke-NovaBuild @mutatingCommonParameters
-        }
-        'test' = {
-            $options = ConvertFrom-NovaTestCliArgument -Arguments $arguments
-            Test-NovaBuild @options @mutatingCommonParameters
-        }
-        'package' = {
-            New-NovaModulePackage @mutatingCommonParameters
-        }
-        'deploy' = {
-            Invoke-NovaCliDeployCommand -Arguments $arguments -ForwardedParameters $mutatingCommonParameters
-        }
-        'init' = {
-            Invoke-NovaCliInitCommand -Arguments $arguments -ForwardedParameters $mutatingCommonParameters -WhatIfEnabled:$InvocationContext.WhatIfEnabled
-        }
-        'bump' = {
-            $options = ConvertFrom-NovaBumpCliArgument -Arguments $arguments
-            Update-NovaModuleVersion @options @mutatingCommonParameters
-        }
-        'update' = {
-            $result = Invoke-NovaCliUpdateCommand -Arguments $arguments -ForwardedParameters $mutatingCommonParameters
-            Format-NovaCliCommandResult -Command $command -Result $result
-        }
-        'publish' = {
-            $options = ConvertFrom-NovaCliArgument -Arguments $arguments
-            Publish-NovaModule @options @mutatingCommonParameters
-        }
-        'release' = {
-            $options = ConvertFrom-NovaCliArgument -Arguments $arguments
-            Invoke-NovaRelease -PublishOption $options @mutatingCommonParameters
-        }
-        'notification' = {
-            Invoke-NovaCliNotificationCommand -Arguments $arguments -CommonParameters $commonParameters -MutatingCommonParameters $mutatingCommonParameters
-        }
-        '--version' = {
-            $moduleVersion = Get-NovaCliInstalledVersion
-            Format-NovaCliVersionString -Name $InvocationContext.ModuleName -Version $moduleVersion
-        }
-        '--help' = {
-            Get-NovaCliHelp
-        }
-    }
-
-    $commandHandler = Get-NovaCliCommandHandler -CommandHandlerMap $commandHandlerMap -Command $command
     Confirm-NovaCliRoutedCommand -InvocationContext $InvocationContext -Command $command
 
-    return & $commandHandler
+    switch ($command) {
+        'info' {
+            return Get-NovaProjectInfo @commonParameters
+        }
+        'version' {
+            return Invoke-NovaCliVersionCommand -Arguments $InvocationContext.Arguments -ForwardedParameters $commonParameters
+        }
+        'build' {
+            return Invoke-NovaBuild @mutatingCommonParameters
+        }
+        'test' {
+            return Invoke-NovaCliParsedCommand -InvocationContext $InvocationContext -ParserCommand 'ConvertFrom-NovaTestCliArgument' -ActionCommand 'Test-NovaBuild'
+        }
+        'package' {
+            return Invoke-NovaCliParsedCommand -InvocationContext $InvocationContext -ParserCommand 'ConvertFrom-NovaPackageCliArgument' -ActionCommand 'New-NovaModulePackage'
+        }
+        'deploy' {
+            return Invoke-NovaCliDeployCommand -Arguments $InvocationContext.Arguments -ForwardedParameters $mutatingCommonParameters
+        }
+        'init' {
+            return Invoke-NovaCliInitCommand -Arguments $InvocationContext.Arguments -ForwardedParameters $mutatingCommonParameters -WhatIfEnabled:$InvocationContext.WhatIfEnabled
+        }
+        'bump' {
+            return Invoke-NovaCliParsedCommand -InvocationContext $InvocationContext -ParserCommand 'ConvertFrom-NovaBumpCliArgument' -ActionCommand 'Update-NovaModuleVersion'
+        }
+        'update' {
+            return Invoke-NovaCliUpdateRouteCommand -InvocationContext $InvocationContext
+        }
+        'publish' {
+            return Invoke-NovaCliParsedCommand -InvocationContext $InvocationContext -ParserCommand 'ConvertFrom-NovaCliArgument' -ActionCommand 'Publish-NovaModule'
+        }
+        'release' {
+            return Invoke-NovaCliParsedCommand -InvocationContext $InvocationContext -ParserCommand 'ConvertFrom-NovaCliArgument' -ActionCommand 'Invoke-NovaRelease' -UsePublishOption
+        }
+        'notification' {
+            return Invoke-NovaCliNotificationRouteCommand -InvocationContext $InvocationContext
+        }
+        '--version' {
+            return Invoke-NovaCliInstalledVersionCommand -InvocationContext $InvocationContext
+        }
+        '--help' {
+            return Get-NovaCliHelp
+        }
+        default {
+            return Get-NovaCliCommandHandler -CommandHandlerMap @{} -Command $command
+        }
+    }
 }

--- a/src/private/package/GetNovaPackageWorkflowContext.ps1
+++ b/src/private/package/GetNovaPackageWorkflowContext.ps1
@@ -3,6 +3,7 @@ function Get-NovaPackageWorkflowContext {
     param(
         [pscustomobject]$ProjectInfo,
         [hashtable]$WorkflowParams = @{},
+        [switch]$SkipTestsRequested,
         [string]$ModulePath = $ExecutionContext.SessionState.Module.Path
     )
 
@@ -15,10 +16,11 @@ function Get-NovaPackageWorkflowContext {
     return [pscustomobject]@{
         ProjectInfo = $projectInfo
         WorkflowParams = $WorkflowParams
+        SkipTestsRequested = $SkipTestsRequested.IsPresent
         PackageMetadataList = $packageMetadataList
         ModulePath = $ModulePath
         Target = Get-NovaPackageWorkflowTarget -PackageMetadataList $packageMetadataList
-        Operation = Get-NovaPackageWorkflowOperation -PackageMetadataList $packageMetadataList
+        Operation = Get-NovaPackageWorkflowOperation -PackageMetadataList $packageMetadataList -SkipTestsRequested:$SkipTestsRequested
     }
 }
 
@@ -47,12 +49,20 @@ function Get-NovaPackageWorkflowTarget {
 function Get-NovaPackageWorkflowOperation {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][object[]]$PackageMetadataList
+        [Parameter(Mandatory)][object[]]$PackageMetadataList,
+        [switch]$SkipTestsRequested
     )
 
-    if (@($PackageMetadataList).Count -eq 1) {
-        return "Create $( $PackageMetadataList[0].Type ) package from built module output"
+    $validationText = if ($SkipTestsRequested) {
+        'built module output with tests skipped'
+    }
+    else {
+        'built and tested module output'
     }
 
-    return 'Create package artifacts from built module output'
+    if (@($PackageMetadataList).Count -eq 1) {
+        return "Create $( $PackageMetadataList[0].Type ) package from $validationText"
+    }
+
+    return "Create package artifacts from $validationText"
 }

--- a/src/private/package/InvokeNovaPackageWorkflow.ps1
+++ b/src/private/package/InvokeNovaPackageWorkflow.ps1
@@ -5,10 +5,7 @@ function Invoke-NovaPackageWorkflow {
         [switch]$ShouldRun
     )
 
-    $workflowParams = $WorkflowContext.WorkflowParams
-
-    Invoke-NovaBuild @workflowParams
-    Test-NovaBuild @workflowParams
+    Invoke-NovaBuildValidation -WorkflowContext $WorkflowContext
 
     if (-not $ShouldRun) {
         return

--- a/src/private/release/GetNovaPublishWorkflowContext.ps1
+++ b/src/private/release/GetNovaPublishWorkflowContext.ps1
@@ -10,6 +10,7 @@ function Get-NovaPublishWorkflowContext {
     $repository = Get-NovaPublishOptionValue -PublishOption $PublishOption -Name Repository
     $moduleDirectoryPath = Get-NovaPublishOptionValue -PublishOption $PublishOption -Name ModuleDirectoryPath
     $apiKey = Get-NovaPublishOptionValue -PublishOption $PublishOption -Name ApiKey
+    $skipTestsRequested = [bool](Get-NovaPublishOptionValue -PublishOption $PublishOption -Name SkipTests)
     $includeLocalPublishActivation = $WorkflowSettings.ContainsKey('IncludeLocalPublishActivation') -and $WorkflowSettings.IncludeLocalPublishActivation
     $release = $WorkflowSettings.ContainsKey('Release') -and $WorkflowSettings.Release
     $publishInvocation = Resolve-NovaPublishInvocation -ProjectInfo $ProjectInfo -Repository $repository -ModuleDirectoryPath $moduleDirectoryPath -ApiKey $apiKey
@@ -23,10 +24,11 @@ function Get-NovaPublishWorkflowContext {
         WorkflowName = $WorkflowSettings.WorkflowName
         LocalRequested = [bool]($PublishOption.ContainsKey('Local') -and $PublishOption.Local)
         WorkflowParams = $WorkflowParams
+        SkipTestsRequested = $skipTestsRequested
         PublishInvocation = $publishInvocation
         PublishParams = Get-NovaResolvedPublishParameterMap -PublishInvocation $publishInvocation -WorkflowParams $WorkflowParams
         LocalPublishActivation = $localPublishActivation
         Target = $publishInvocation.Target
-        Operation = Get-NovaPublishWorkflowOperation -IsLocal:$publishInvocation.IsLocal -Release:$release
+        Operation = Get-NovaPublishWorkflowOperation -IsLocal:$publishInvocation.IsLocal -Release:$release -SkipTestsRequested:$skipTestsRequested
     }
 }

--- a/src/private/release/GetNovaPublishWorkflowOperation.ps1
+++ b/src/private/release/GetNovaPublishWorkflowOperation.ps1
@@ -2,14 +2,22 @@ function Get-NovaPublishWorkflowOperation {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][bool]$IsLocal,
-        [switch]$Release
+        [switch]$Release,
+        [switch]$SkipTestsRequested
     )
 
-    $workflowText = if ($Release) {
-        'Run Nova release workflow and publish'
+    $validationText = if ($SkipTestsRequested) {
+        'build and publish'
     }
     else {
-        'Build, test, and publish Nova module'
+        'build, test, and publish'
+    }
+
+    $workflowText = if ($Release) {
+        "Run Nova release workflow ($validationText)"
+    }
+    else {
+        "Build, $( $SkipTestsRequested ? 'skip tests, and publish' : 'test, and publish' ) Nova module"
     }
 
     $destinationText = if ($IsLocal) {

--- a/src/private/release/InvokeNovaPublishWorkflow.ps1
+++ b/src/private/release/InvokeNovaPublishWorkflow.ps1
@@ -5,11 +5,9 @@ function Invoke-NovaPublishWorkflow {
         [switch]$ShouldRun
     )
 
-    $workflowParams = $WorkflowContext.WorkflowParams
     $publishParams = $WorkflowContext.PublishParams
 
-    Invoke-NovaBuild @workflowParams
-    Test-NovaBuild @workflowParams
+    Invoke-NovaBuildValidation -WorkflowContext $WorkflowContext
 
     & $WorkflowContext.PublishInvocation.Action @publishParams
 

--- a/src/private/release/InvokeNovaReleaseWorkflow.ps1
+++ b/src/private/release/InvokeNovaReleaseWorkflow.ps1
@@ -7,8 +7,7 @@ function Invoke-NovaReleaseWorkflow {
     $workflowParams = $WorkflowContext.WorkflowParams
     $publishParams = $WorkflowContext.PublishParams
 
-    Invoke-NovaBuild @workflowParams
-    Test-NovaBuild @workflowParams
+    Invoke-NovaBuildValidation -WorkflowContext $WorkflowContext
     $versionResult = Update-NovaModuleVersion @workflowParams
     Invoke-NovaBuild @workflowParams
 

--- a/src/private/shared/InvokeNovaBuildValidation.ps1
+++ b/src/private/shared/InvokeNovaBuildValidation.ps1
@@ -1,0 +1,18 @@
+function Invoke-NovaBuildValidation {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext
+    )
+
+    $workflowParams = $WorkflowContext.WorkflowParams
+    $skipTestsRequested = ($WorkflowContext.PSObject.Properties.Name -contains 'SkipTestsRequested') -and $WorkflowContext.SkipTestsRequested
+    Invoke-NovaBuild @workflowParams
+    if (-not $skipTestsRequested) {
+        Test-NovaBuild @workflowParams
+        return
+    }
+
+    Write-Verbose 'Skipping Test-NovaBuild because SkipTests was requested for this workflow.'
+}
+
+

--- a/src/private/shared/NewNovaDynamicSkipTestsParameterDictionary.ps1
+++ b/src/private/shared/NewNovaDynamicSkipTestsParameterDictionary.ps1
@@ -1,4 +1,4 @@
-function New-NovaDynamicSkipTestsParameterDictionary {
+function Get-NovaDynamicSkipTestsParameterDictionary {
     [CmdletBinding()]
     param()
 

--- a/src/private/shared/NewNovaDynamicSkipTestsParameterDictionary.ps1
+++ b/src/private/shared/NewNovaDynamicSkipTestsParameterDictionary.ps1
@@ -1,0 +1,12 @@
+function New-NovaDynamicSkipTestsParameterDictionary {
+    [CmdletBinding()]
+    param()
+
+    $attributeCollection = [System.Collections.ObjectModel.Collection[System.Attribute]]::new()
+    $attributeCollection.Add([System.Management.Automation.ParameterAttribute]::new())
+    $runtimeParameter = [System.Management.Automation.RuntimeDefinedParameter]::new('SkipTests', [switch],$attributeCollection)
+    $parameterDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+    $parameterDictionary.Add('SkipTests', $runtimeParameter)
+    return $parameterDictionary
+}
+

--- a/src/public/InvokeNovaRelease.ps1
+++ b/src/public/InvokeNovaRelease.ps1
@@ -2,12 +2,19 @@ function Invoke-NovaRelease {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(
         [hashtable]$PublishOption = @{},
+        [switch]$SkipTests,
         [string]$Path = (Get-Location).Path
     )
 
     Push-Location -LiteralPath $Path
     try {
-        $workflowContext = Get-NovaPublishWorkflowContext -ProjectInfo (Get-NovaProjectInfo) -PublishOption $PublishOption -WorkflowParams (Get-NovaShouldProcessForwardingParameter -WhatIfEnabled:$WhatIfPreference) -WorkflowSettings @{
+        $releasePublishOption = @{}
+        foreach ($optionName in $PublishOption.Keys) {
+            $releasePublishOption[$optionName] = $PublishOption[$optionName]
+        }
+
+        $releasePublishOption.SkipTests = [bool]$SkipTests
+        $workflowContext = Get-NovaPublishWorkflowContext -ProjectInfo (Get-NovaProjectInfo) -PublishOption $releasePublishOption -WorkflowParams (Get-NovaShouldProcessForwardingParameter -WhatIfEnabled:$WhatIfPreference) -WorkflowSettings @{
             WorkflowName = 'release'
             Release = $true
         }

--- a/src/public/NewNovaModulePackage.ps1
+++ b/src/public/NewNovaModulePackage.ps1
@@ -1,8 +1,10 @@
 function New-NovaModulePackage {
     [CmdletBinding(SupportsShouldProcess = $true)]
-    param()
+    param(
+        [switch]$SkipTests
+    )
 
-    $workflowContext = Get-NovaPackageWorkflowContext -WorkflowParams (Get-NovaShouldProcessForwardingParameter -WhatIfEnabled:$WhatIfPreference)
+    $workflowContext = Get-NovaPackageWorkflowContext -WorkflowParams (Get-NovaShouldProcessForwardingParameter -WhatIfEnabled:$WhatIfPreference) -SkipTestsRequested:$SkipTests
     $shouldRun = $PSCmdlet.ShouldProcess($workflowContext.Target, $workflowContext.Operation)
 
     return Invoke-NovaPackageWorkflow -WorkflowContext $workflowContext -ShouldRun:$shouldRun

--- a/src/public/PublishNovaModule.ps1
+++ b/src/public/PublishNovaModule.ps1
@@ -12,7 +12,7 @@ function Publish-NovaModule {
     )
 
     dynamicparam {
-        return New-NovaDynamicSkipTestsParameterDictionary
+        return Get-NovaDynamicSkipTestsParameterDictionary
     }
 
     begin {

--- a/src/public/PublishNovaModule.ps1
+++ b/src/public/PublishNovaModule.ps1
@@ -11,22 +11,31 @@ function Publish-NovaModule {
         [string]$ApiKey
     )
 
-    $workflowContext = Get-NovaPublishWorkflowContext -ProjectInfo (Get-NovaProjectInfo) -PublishOption @{
-        Local = [bool]$Local
-        Repository = $Repository
-        ModuleDirectoryPath = $ModuleDirectoryPath
-        ApiKey = $ApiKey
-    } -WorkflowParams (Get-NovaShouldProcessForwardingParameter -WhatIfEnabled:$WhatIfPreference) -WorkflowSettings @{
-        WorkflowName = 'publish'
-        IncludeLocalPublishActivation = $true
+    dynamicparam {
+        return New-NovaDynamicSkipTestsParameterDictionary
     }
 
-    Write-NovaPublishWorkflowContext -WorkflowContext $workflowContext
+    begin {
+        $skipTests = $PSBoundParameters.ContainsKey('SkipTests') -and $PSBoundParameters.SkipTests
 
-    $shouldRun = $PSCmdlet.ShouldProcess($workflowContext.Target, $workflowContext.Operation)
-    if (-not $shouldRun -and -not $WhatIfPreference) {
-        return
+        $workflowContext = Get-NovaPublishWorkflowContext -ProjectInfo (Get-NovaProjectInfo) -PublishOption @{
+            Local = [bool]$Local
+            Repository = $Repository
+            ModuleDirectoryPath = $ModuleDirectoryPath
+            ApiKey = $ApiKey
+            SkipTests = [bool]$skipTests
+        } -WorkflowParams (Get-NovaShouldProcessForwardingParameter -WhatIfEnabled:$WhatIfPreference) -WorkflowSettings @{
+            WorkflowName = 'publish'
+            IncludeLocalPublishActivation = $true
+        }
+
+        Write-NovaPublishWorkflowContext -WorkflowContext $workflowContext
+
+        $shouldRun = $PSCmdlet.ShouldProcess($workflowContext.Target, $workflowContext.Operation)
+        if (-not $shouldRun -and -not $WhatIfPreference) {
+            return
+        }
+
+        Invoke-NovaPublishWorkflow -WorkflowContext $workflowContext -ShouldRun:$shouldRun
     }
-
-    Invoke-NovaPublishWorkflow -WorkflowContext $workflowContext -ShouldRun:$shouldRun
 }

--- a/src/resources/cli/help/package.psd1
+++ b/src/resources/cli/help/package.psd1
@@ -4,6 +4,7 @@
     Usage = 'nova package [<options>]'
     Description = @(
         'Build, test, and package the current project by using the configured package settings.',
+        'Use --skip-tests / -s when tests already ran earlier in CI/CD and you only want to skip Test-NovaBuild for this packaging run.',
         'Use this command when you want package artifact output without publishing to a PowerShell repository.',
         'For more information, documentation, and examples, visit:',
         'https://www.novamoduletools.com/packaging-and-delivery.html#pack'
@@ -26,6 +27,12 @@
             Long = '--confirm'
             Placeholder = ''
             Description = 'Request CLI confirmation before the package workflow runs.'
+        },
+        @{
+            Short = '-s'
+            Long = '--skip-tests'
+            Placeholder = ''
+            Description = 'Skip Test-NovaBuild for this packaging run. Build still runs, which is useful when tests already passed earlier in CI/CD.'
         }
     )
     Examples = @(
@@ -36,6 +43,10 @@
         @{
             Command = 'nova package --what-if'
             Description = 'Preview the package workflow without creating artifacts.'
+        },
+        @{
+            Command = 'nova package --skip-tests'
+            Description = 'Build and package the module without re-running Test-NovaBuild.'
         }
     )
 }

--- a/src/resources/cli/help/publish.psd1
+++ b/src/resources/cli/help/publish.psd1
@@ -4,6 +4,7 @@
     Usage = 'nova publish [<options>]'
     Description = @(
         'Build, test, and publish the current project either locally or to a PowerShell repository.',
+        'Use --skip-tests / -s when tests already ran earlier in CI/CD and you only want to skip Test-NovaBuild for this publish run.',
         'Use --local when you want a local publish workflow, or supply repository credentials when you want a repository publish.',
         'For more information, documentation, and examples, visit:',
         'https://www.novamoduletools.com/packaging-and-delivery.html#publish'
@@ -50,6 +51,12 @@
             Long = '--confirm'
             Placeholder = ''
             Description = 'Request CLI confirmation before the publish workflow runs.'
+        },
+        @{
+            Short = '-s'
+            Long = '--skip-tests'
+            Placeholder = ''
+            Description = 'Skip Test-NovaBuild for this publish run. Build still runs, which is useful when tests already passed earlier in CI/CD.'
         }
     )
     Examples = @(
@@ -60,6 +67,10 @@
         @{
             Command = 'nova publish --repository PSGallery --api-key <key>'
             Description = 'Build, test, and publish the module to a PowerShell repository.'
+        },
+        @{
+            Command = 'nova publish --repository PSGallery --api-key <key> --skip-tests'
+            Description = 'Build and publish the module without re-running Test-NovaBuild.'
         }
     )
 }

--- a/src/resources/cli/help/release.psd1
+++ b/src/resources/cli/help/release.psd1
@@ -4,6 +4,7 @@
     Usage = 'nova release [<options>]'
     Description = @(
         'Run the full release flow: build, test, version bump, rebuild, and publish.',
+        'Use --skip-tests / -s when tests already ran earlier in CI/CD and you only want to skip the pre-release Test-NovaBuild step.',
         'Use the same publish-target options as nova publish when you want the release workflow to publish locally or to a repository.',
         'For more information, documentation, and examples, visit:',
         'https://www.novamoduletools.com/packaging-and-delivery.html#release'
@@ -50,6 +51,12 @@
             Long = '--confirm'
             Placeholder = ''
             Description = 'Request CLI confirmation before the release workflow runs.'
+        },
+        @{
+            Short = '-s'
+            Long = '--skip-tests'
+            Placeholder = ''
+            Description = 'Skip the pre-release Test-NovaBuild step. Both build steps still run, which is useful when tests already passed earlier in CI/CD.'
         }
     )
     Examples = @(
@@ -60,6 +67,10 @@
         @{
             Command = 'nova release --local --what-if'
             Description = 'Preview the full release workflow for a local publish target.'
+        },
+        @{
+            Command = 'nova release --repository PSGallery --api-key <key> --skip-tests'
+            Description = 'Run the release workflow without re-running the pre-release Test-NovaBuild step.'
         }
     )
 }

--- a/tests/CoverageGaps.Cli.Tests.ps1
+++ b/tests/CoverageGaps.Cli.Tests.ps1
@@ -144,6 +144,17 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
         }
     }
 
+    It 'Get-NovaCliCommandHandler returns the mapped handler for a known command' {
+        InModuleScope $script:moduleName {
+            $expectedHandler = [pscustomobject]@{Name = 'publish-handler'}
+            $handlerMap = @{publish = $expectedHandler}
+
+            $result = Get-NovaCliCommandHandler -CommandHandlerMap $handlerMap -Command 'publish'
+
+            $result | Should -Be $expectedHandler
+        }
+    }
+
     It 'Get-NovaCliHelpRequest resolves root short help, command short help, and command long help' {
         InModuleScope $script:moduleName {
             $rootHelp = Get-NovaCliHelpRequest -Command '--help' -Arguments @()

--- a/tests/CoverageGaps.Cli.Tests.ps1
+++ b/tests/CoverageGaps.Cli.Tests.ps1
@@ -563,11 +563,50 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
         }
     }
 
-    It 'Invoke-NovaCliCommandRoute forwards the parsed test build flag to Test-NovaBuild' {
-        InModuleScope $script:moduleName {
+    It 'Invoke-NovaCliCommandRoute forwards parsed mutating options for <Command>' -ForEach @(
+        @{
+            Command = 'test'
+            Arguments = @('--build')
+            ParserCommand = 'ConvertFrom-NovaTestCliArgument'
+            ActionCommand = 'Test-NovaBuild'
+            ParsedOptions = @{Build = $true}
+            ExpectedProperty = 'Build'
+            UsesPublishOption = $false
+        }
+        @{
+            Command = 'package'
+            Arguments = @('--skip-tests')
+            ParserCommand = 'ConvertFrom-NovaPackageCliArgument'
+            ActionCommand = 'New-NovaModulePackage'
+            ParsedOptions = @{SkipTests = $true}
+            ExpectedProperty = 'SkipTests'
+            UsesPublishOption = $false
+        }
+        @{
+            Command = 'publish'
+            Arguments = @('-s')
+            ParserCommand = 'ConvertFrom-NovaCliArgument'
+            ActionCommand = 'Publish-NovaModule'
+            ParsedOptions = @{SkipTests = $true}
+            ExpectedProperty = 'SkipTests'
+            UsesPublishOption = $false
+        }
+        @{
+            Command = 'release'
+            Arguments = @('--skip-tests')
+            ParserCommand = 'ConvertFrom-NovaCliArgument'
+            ActionCommand = 'Invoke-NovaRelease'
+            ParsedOptions = @{SkipTests = $true}
+            ExpectedProperty = 'SkipTests'
+            UsesPublishOption = $true
+        }
+    ) {
+        InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+            param($TestCase)
+
             $invocationContext = [pscustomobject]@{
-                Command = 'test'
-                Arguments = @('--build')
+                Command = $TestCase.Command
+                Arguments = $TestCase.Arguments
                 CommonParameters = @{}
                 MutatingCommonParameters = @{WhatIf = $true}
                 IsHelpRequest = $false
@@ -576,22 +615,40 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
                 WhatIfEnabled = $true
                 CliConfirmEnabled = $false
             }
-            Mock ConvertFrom-NovaTestCliArgument {@{Build = $true}}
-            Mock Test-NovaBuild {
-                param(
-                    [switch]$Build,
-                    [switch]$WhatIf
-                )
 
-                [pscustomobject]@{Build = $Build.IsPresent; WhatIf = $WhatIf.IsPresent}
+            $parserCommand = $TestCase.ParserCommand
+            $actionCommand = $TestCase.ActionCommand
+            $parsedOptions = $TestCase.ParsedOptions
+            $expectedProperty = $TestCase.ExpectedProperty
+
+            Mock $parserCommand {$parsedOptions}
+            if ($TestCase.UsesPublishOption) {
+                Mock $actionCommand {
+                    param([hashtable]$PublishOption, [switch]$WhatIf)
+
+                    [pscustomobject]@{Feature = [bool]$PublishOption.SkipTests; WhatIf = $WhatIf.IsPresent}
+                }
+            }
+            elseif ($expectedProperty -eq 'Build') {
+                Mock $actionCommand {
+                    param([switch]$Build, [switch]$WhatIf)
+
+                    [pscustomobject]@{Feature = $Build.IsPresent; WhatIf = $WhatIf.IsPresent}
+                }
+            }
+            else {
+                Mock $actionCommand {
+                    param([switch]$SkipTests, [switch]$WhatIf)
+
+                    [pscustomobject]@{Feature = $SkipTests.IsPresent; WhatIf = $WhatIf.IsPresent}
+                }
             }
 
             $result = Invoke-NovaCliCommandRoute -InvocationContext $invocationContext
 
-            $result.Build | Should -BeTrue
+            $result.Feature | Should -BeTrue
             $result.WhatIf | Should -BeTrue
-            Assert-MockCalled ConvertFrom-NovaTestCliArgument -Times 1 -ParameterFilter {$Arguments -eq @('--build')}
-            Assert-MockCalled Test-NovaBuild -Times 1 -ParameterFilter {$Build -and $WhatIf}
+            Assert-MockCalled $parserCommand -Times 1 -ParameterFilter {$Arguments -eq $TestCase.Arguments}
         }
     }
 
@@ -698,6 +755,21 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
                 Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
                 TargetObject = '-build'
             })
+
+            $deprecatedSkipTestsError = $null
+            try {
+                Assert-NovaCliArgumentSyntax -Arguments @('-skiptests')
+            }
+            catch {
+                $deprecatedSkipTestsError = $_
+            }
+
+            Assert-TestStructuredCliError -ThrownError $deprecatedSkipTestsError -ExpectedError ([pscustomobject]@{
+                Message = "Unsupported CLI option syntax: -skiptests. Use '--skip-tests' or '-s' instead."
+                ErrorId = 'Nova.Validation.UnsupportedCliOptionSyntax'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                TargetObject = '-skiptests'
+            })
         }
     }
 
@@ -780,13 +852,35 @@ catch {
         }
     }
 
-    It 'ConvertFrom-NovaCliArgument parses local, path, and api key options' {
+    It 'ConvertFrom-NovaCliArgument parses local, path, api key, and skip-tests options' {
         InModuleScope $script:moduleName {
-            $options = ConvertFrom-NovaCliArgument -Arguments @('--local', '--path', '/tmp/modules', '--api-key', 'secret')
+            $options = ConvertFrom-NovaCliArgument -Arguments @('--local', '--path', '/tmp/modules', '--api-key', 'secret', '--skip-tests')
 
             $options.Local | Should -BeTrue
             $options.ModuleDirectoryPath | Should -Be '/tmp/modules'
             $options.ApiKey | Should -Be 'secret'
+            $options.SkipTests | Should -BeTrue
+        }
+    }
+
+    It 'ConvertFrom-NovaPackageCliArgument accepts skip-tests and rejects publish-only options' {
+        InModuleScope $script:moduleName {
+            (ConvertFrom-NovaPackageCliArgument -Arguments @('-s')).SkipTests | Should -BeTrue
+
+            $thrown = $null
+            try {
+                ConvertFrom-NovaPackageCliArgument -Arguments @('--local')
+            }
+            catch {
+                $thrown = $_
+            }
+
+            Assert-TestStructuredCliError -ThrownError $thrown -ExpectedError ([pscustomobject]@{
+                Message = 'Unknown argument: --local'
+                ErrorId = 'Nova.Validation.UnknownCliArgument'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                TargetObject = '--local'
+            })
         }
     }
 

--- a/tests/NovaCommandModel.ReleasePublish.Tests.ps1
+++ b/tests/NovaCommandModel.ReleasePublish.Tests.ps1
@@ -48,18 +48,24 @@ BeforeAll {
 }
 
 Describe 'Nova command model - release and publish behavior' {
-    It 'Invoke-NovaReleaseWorkflow runs build test bump build publish in order' {
-        InModuleScope $script:moduleName {
+    It 'Invoke-NovaReleaseWorkflow preserves the expected step order when <Name>' -ForEach @(
+        @{Name = 'tests run'; SkipTestsRequested = $false; ExpectedStepList = @('build', 'test', 'bump', 'build', 'publish'); ExpectedTestCalls = 1}
+        @{Name = 'tests are skipped'; SkipTestsRequested = $true; ExpectedStepList = @('build', 'bump', 'build', 'publish'); ExpectedTestCalls = 0}
+    ) {
+        InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+            param($TestCase)
+
             $script:steps = @()
 
             Mock Invoke-NovaBuild {$script:steps += 'build'}
             Mock Test-NovaBuild {$script:steps += 'test'}
             Mock Update-NovaModuleVersion {
                 $script:steps += 'bump'
-                return [pscustomobject]@{NewVersion = '1.0.1'}
+                [pscustomobject]@{NewVersion = '1.0.1'}
             }
             $workflowContext = [pscustomobject]@{
                 WorkflowParams = @{}
+                SkipTestsRequested = $TestCase.SkipTestsRequested
                 PublishInvocation = [pscustomobject]@{
                     Action = {$script:steps += 'publish'}
                 }
@@ -68,7 +74,8 @@ Describe 'Nova command model - release and publish behavior' {
 
             Invoke-NovaReleaseWorkflow -WorkflowContext $workflowContext | Out-Null
 
-            $script:steps -join ',' | Should -Be 'build,test,bump,build,publish'
+            $script:steps | Should -Be $TestCase.ExpectedStepList
+            Assert-MockCalled Test-NovaBuild -Times $TestCase.ExpectedTestCalls
         }
     }
 
@@ -171,8 +178,35 @@ Describe 'Nova command model - release and publish behavior' {
             $result.PublishParams.ModuleDirectoryPath | Should -Be '/tmp/modules'
             $result.PublishParams.WhatIf | Should -BeTrue
             $result.PublishInvocation.IsLocal | Should -BeTrue
-            $result.Operation | Should -Be 'Run Nova release workflow and publish to local directory'
+            $result.SkipTestsRequested | Should -BeFalse
+            $result.Operation | Should -Be 'Run Nova release workflow (build, test, and publish) to local directory'
             $result.LocalPublishActivation | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'Get-NovaPublishWorkflowContext composes skip-tests release workflow context when requested' {
+        InModuleScope $script:moduleName {
+            Mock Resolve-NovaPublishInvocation {
+                [pscustomobject]@{
+                    Target = 'PSGallery'
+                    IsLocal = $false
+                    Parameters = @{}
+                    Action = {}
+                }
+            }
+            Mock Get-NovaResolvedPublishParameterMap {{}}
+            $projectInfo = [pscustomobject]@{
+                ProjectName = 'NovaModuleTools'
+                OutputModuleDir = '/tmp/dist/NovaModuleTools'
+            }
+
+            $result = Get-NovaPublishWorkflowContext -ProjectInfo $projectInfo -PublishOption @{Repository = 'PSGallery'; SkipTests = $true} -WorkflowSettings @{
+                WorkflowName = 'release'
+                Release = $true
+            }
+
+            $result.SkipTestsRequested | Should -BeTrue
+            $result.Operation | Should -Be 'Run Nova release workflow (build and publish) to repository'
         }
     }
 
@@ -187,7 +221,7 @@ Describe 'Nova command model - release and publish behavior' {
                     LocalRequested = $true
                     PublishInvocation = [pscustomobject]@{IsLocal = $true}
                     Target = '/tmp/modules'
-                    Operation = 'Run Nova release workflow and publish to local directory'
+                    Operation = 'Run Nova release workflow (build, test, and publish) to local directory'
                 }
             }
             Mock Write-NovaPublishWorkflowContext {}
@@ -201,6 +235,53 @@ Describe 'Nova command model - release and publish behavior' {
             Assert-MockCalled Get-NovaPublishWorkflowContext -Times 1 -ParameterFilter {$WorkflowSettings.WorkflowName -eq 'release' -and $WorkflowSettings.Release}
             Assert-MockCalled Write-NovaPublishWorkflowContext -Times 1
             Assert-MockCalled Invoke-NovaReleaseWorkflow -Times 1
+        }
+    }
+
+    It '<CommandName> forwards SkipTests into its shared workflow context' -ForEach @(
+        @{
+            CommandName = 'Invoke-NovaRelease'
+            WorkflowName = 'release'
+            Operation = 'Run Nova release workflow (build and publish) to repository'
+            Invoke = {
+                Invoke-NovaRelease -PublishOption @{Repository = 'PSGallery'} -SkipTests -Path (Get-Location).Path -Confirm:$false
+            }
+        }
+        @{
+            CommandName = 'Publish-NovaModule'
+            WorkflowName = 'publish'
+            Operation = 'Build, skip tests, and publish Nova module to repository'
+            Invoke = {
+                Publish-NovaModule -Repository PSGallery -ApiKey key123 -SkipTests -Confirm:$false
+            }
+        }
+    ) {
+        InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+            param($TestCase)
+
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{ProjectName = 'NovaModuleTools'}
+            }
+            Mock Get-NovaPublishWorkflowContext {
+                [pscustomobject]@{
+                    WorkflowName = $TestCase.WorkflowName
+                    LocalRequested = $false
+                    PublishInvocation = [pscustomobject]@{IsLocal = $false}
+                    Target = 'PSGallery'
+                    Operation = $TestCase.Operation
+                }
+            }
+            Mock Write-NovaPublishWorkflowContext {}
+            if ($TestCase.WorkflowName -eq 'release') {
+                Mock Invoke-NovaReleaseWorkflow {}
+            }
+            else {
+                Mock Invoke-NovaPublishWorkflow {}
+            }
+
+            & $TestCase.Invoke | Out-Null
+
+            Assert-MockCalled Get-NovaPublishWorkflowContext -Times 1 -ParameterFilter {$PublishOption.SkipTests -and $PublishOption.Repository -eq 'PSGallery'}
         }
     }
 
@@ -228,6 +309,32 @@ Describe 'Nova command model - release and publish behavior' {
             {Invoke-NovaPublishWorkflow -WorkflowContext $workflowContext -ShouldRun} | Should -Not -Throw
 
             $script:steps -join ',' | Should -Be 'build,test,publish,import'
+        }
+    }
+
+    It 'Invoke-NovaPublishWorkflow skips tests when SkipTests is requested' {
+        InModuleScope $script:moduleName {
+            $script:steps = @()
+
+            Mock Invoke-NovaBuild {$script:steps += 'build'}
+            Mock Test-NovaBuild {$script:steps += 'test'}
+            $workflowContext = [pscustomobject]@{
+                WorkflowParams = @{}
+                SkipTestsRequested = $true
+                PublishInvocation = [pscustomobject]@{
+                    Parameters = @{
+                        ProjectInfo = [pscustomobject]@{ProjectName = 'NovaModuleTools'}
+                    }
+                    Action = {$script:steps += 'publish'}
+                }
+                PublishParams = @{}
+                LocalPublishActivation = $null
+            }
+
+            Invoke-NovaPublishWorkflow -WorkflowContext $workflowContext -ShouldRun | Out-Null
+
+            $script:steps -join ',' | Should -Be 'build,publish'
+            Assert-MockCalled Test-NovaBuild -Times 0
         }
     }
 
@@ -332,10 +439,30 @@ Describe 'Nova command model - release and publish behavior' {
             $result.WorkflowParams.WhatIf | Should -BeTrue
             $result.ModulePath | Should -Be '/tmp/NovaModuleTools.psm1'
             $result.Target | Should -Be '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg, /tmp/project/artifacts/packages/NovaModuleTools.1.2.3.zip'
-            $result.Operation | Should -Be 'Create package artifacts from built module output'
+            $result.SkipTestsRequested | Should -BeFalse
+            $result.Operation | Should -Be 'Create package artifacts from built and tested module output'
             $result.PackageMetadataList.Type | Should -Be @('NuGet', 'Zip')
             Assert-MockCalled Get-NovaPackageMetadataList -Times 1 -ParameterFilter {$ProjectInfo.ProjectName -eq 'NovaModuleTools'}
             Assert-MockCalled Assert-NovaPackageMetadata -Times 2
+        }
+    }
+
+    It 'Get-NovaPackageWorkflowContext carries SkipTestsRequested into package operation text' {
+        InModuleScope $script:moduleName {
+            $projectInfo = [pscustomobject]@{
+                ProjectName = 'NovaModuleTools'
+            }
+            $packageMetadataList = @(
+                [pscustomobject]@{Type = 'NuGet'; PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'}
+            )
+
+            Mock Get-NovaPackageMetadataList {$packageMetadataList}
+            Mock Assert-NovaPackageMetadata {}
+
+            $result = Get-NovaPackageWorkflowContext -ProjectInfo $projectInfo -SkipTestsRequested
+
+            $result.SkipTestsRequested | Should -BeTrue
+            $result.Operation | Should -Be 'Create NuGet package from built module output with tests skipped'
         }
     }
 
@@ -353,7 +480,7 @@ Describe 'Nova command model - release and publish behavior' {
 
             $result = Get-NovaPackageWorkflowContext -ProjectInfo $projectInfo
 
-            $result.Operation | Should -Be 'Create NuGet package from built module output'
+            $result.Operation | Should -Be 'Create NuGet package from built and tested module output'
             $result.Target | Should -Be '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'
             Assert-MockCalled Assert-NovaPackageMetadata -Times 1
         }
@@ -397,6 +524,34 @@ Describe 'Nova command model - release and publish behavior' {
                         $WorkflowContext.PackageMetadataList.Count -eq 2 -and
                         $WorkflowContext.ModulePath -eq '/tmp/NovaModuleTools.psm1'
             }
+        }
+    }
+
+    It 'Invoke-NovaPackageWorkflow skips tests when SkipTests is requested' {
+        InModuleScope $script:moduleName {
+            $script:steps = @()
+            $workflowContext = [pscustomobject]@{
+                ProjectInfo = [pscustomobject]@{ProjectName = 'NovaModuleTools'}
+                WorkflowParams = @{}
+                SkipTestsRequested = $true
+                PackageMetadataList = @(
+                    [pscustomobject]@{Type = 'NuGet'; PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'}
+                )
+                ModulePath = '/tmp/NovaModuleTools.psm1'
+            }
+
+            Mock Invoke-NovaBuild {$script:steps += 'build'}
+            Mock Test-NovaBuild {$script:steps += 'test'}
+            Mock Invoke-NovaPackageArtifactCreation {
+                $script:steps += 'pack'
+                @([pscustomobject]@{Type = 'NuGet'; PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'})
+            }
+
+            $result = @(Invoke-NovaPackageWorkflow -WorkflowContext $workflowContext -ShouldRun)
+
+            $script:steps -join ',' | Should -Be 'build,pack'
+            $result.Type | Should -Be @('NuGet')
+            Assert-MockCalled Test-NovaBuild -Times 0
         }
     }
 
@@ -483,7 +638,7 @@ Describe 'Nova command model - release and publish behavior' {
                     )
                     ModulePath = '/tmp/NovaModuleTools.psm1'
                     Target = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'
-                    Operation = 'Create NuGet package from built module output'
+                    Operation = 'Create NuGet package from built and tested module output'
                 }
             }
             Mock Invoke-NovaPackageWorkflow {
@@ -500,8 +655,31 @@ Describe 'Nova command model - release and publish behavior' {
             Assert-MockCalled Invoke-NovaPackageWorkflow -Times 1 -ParameterFilter {
                 $ShouldRun -and
                         $WorkflowContext.Target -eq '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg' -and
-                        $WorkflowContext.Operation -eq 'Create NuGet package from built module output'
+                        $WorkflowContext.Operation -eq 'Create NuGet package from built and tested module output'
             }
+        }
+    }
+
+    It 'New-NovaModulePackage forwards SkipTests into the package workflow context' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaPackageWorkflowContext {
+                [pscustomobject]@{
+                    ProjectInfo = [pscustomobject]@{ProjectName = 'NovaModuleTools'}
+                    WorkflowParams = @{}
+                    SkipTestsRequested = $true
+                    PackageMetadataList = @(
+                        [pscustomobject]@{Type = 'NuGet'; PackagePath = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'}
+                    )
+                    ModulePath = '/tmp/NovaModuleTools.psm1'
+                    Target = '/tmp/project/artifacts/packages/NovaModuleTools.1.2.3.nupkg'
+                    Operation = 'Create NuGet package from built module output with tests skipped'
+                }
+            }
+            Mock Invoke-NovaPackageWorkflow {}
+
+            New-NovaModulePackage -SkipTests -Confirm:$false | Out-Null
+
+            Assert-MockCalled Get-NovaPackageWorkflowContext -Times 1 -ParameterFilter {$SkipTestsRequested}
         }
     }
 

--- a/tests/NovaCommandModel.ReleasePublish.Tests.ps1
+++ b/tests/NovaCommandModel.ReleasePublish.Tests.ps1
@@ -238,6 +238,40 @@ Describe 'Nova command model - release and publish behavior' {
         }
     }
 
+    It 'Invoke-NovaRelease defaults Path to the current location when Path is omitted' {
+        $expectedPath = (Get-Location).Path
+
+        InModuleScope $script:moduleName -Parameters @{ExpectedPath = $expectedPath} {
+            param($ExpectedPath)
+
+            Mock Push-Location {} -ParameterFilter {$LiteralPath -eq $ExpectedPath}
+            Mock Pop-Location {}
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{ProjectName = 'NovaModuleTools'}
+            }
+            Mock Get-NovaPublishWorkflowContext {
+                [pscustomobject]@{
+                    WorkflowName = 'release'
+                    LocalRequested = $true
+                    PublishInvocation = [pscustomobject]@{IsLocal = $true}
+                    Target = '/tmp/modules'
+                    Operation = 'Run Nova release workflow (build, test, and publish) to local directory'
+                }
+            }
+            Mock Write-NovaPublishWorkflowContext {}
+            Mock Invoke-NovaReleaseWorkflow {
+                [pscustomobject]@{NewVersion = '1.0.1'}
+            }
+
+            $result = Invoke-NovaRelease -PublishOption @{Local = $true} -Confirm:$false
+
+            $result.NewVersion | Should -Be '1.0.1'
+            Assert-MockCalled Push-Location -Times 1 -ParameterFilter {$LiteralPath -eq $ExpectedPath}
+            Assert-MockCalled Pop-Location -Times 1
+            Assert-MockCalled Invoke-NovaReleaseWorkflow -Times 1
+        }
+    }
+
     It '<CommandName> forwards SkipTests into its shared workflow context' -ForEach @(
         @{
             CommandName = 'Invoke-NovaRelease'

--- a/tests/NovaCommandModel.StandaloneCli.Tests.ps1
+++ b/tests/NovaCommandModel.StandaloneCli.Tests.ps1
@@ -525,6 +525,22 @@ Describe '$projectName tests' {
         }
     }
 
+    It 'Invoke-NovaCli help for package, publish, and release documents the skip-tests options' -ForEach @(
+        @{CommandName = 'package'}
+        @{CommandName = 'publish'}
+        @{CommandName = 'release'}
+    ) {
+        InModuleScope $script:moduleName -Parameters @{CommandName = $_.CommandName} {
+            param($CommandName)
+
+            $shortHelp = Invoke-NovaCli -Command $CommandName -Arguments @('--help')
+            $longHelp = Invoke-NovaCli -Command '--help' -Arguments @($CommandName)
+
+            $shortHelp | Should -Match '-s, --skip-tests'
+            $longHelp | Should -Match '--skip-tests'
+        }
+    }
+
     It 'Invoke-NovaCli CLI help never delegates to PowerShell Get-Help' {
         InModuleScope $script:moduleName {
             Mock Get-Help {throw 'CLI help should not call Get-Help'}
@@ -548,6 +564,18 @@ Describe '$projectName tests' {
 
             $result.Type | Should -Be @('NuGet')
             $result.PackagePath | Should -Be @('/tmp/artifacts/packages/NovaModuleTools.1.2.3.nupkg')
+        }
+    }
+
+    It 'Invoke-NovaCli package forwards skip-tests to New-NovaModulePackage' {
+        InModuleScope $script:moduleName {
+            Mock New-NovaModulePackage {
+                [pscustomobject]@{SkipTests = $SkipTests.IsPresent}
+            }
+
+            $result = Invoke-NovaCli package --skip-tests
+
+            $result.SkipTests | Should -BeTrue
         }
     }
 
@@ -715,6 +743,18 @@ Describe '$projectName tests' {
         }
     }
 
+    It 'Invoke-NovaCli publish forwards skip-tests' {
+        InModuleScope $script:moduleName {
+            Mock Publish-NovaModule {
+                [pscustomobject]@{SkipTests = $SkipTests.IsPresent}
+            }
+
+            $result = Invoke-NovaCli publish --repository PSGallery --api-key key123 -s
+
+            $result.SkipTests | Should -BeTrue
+        }
+    }
+
     It 'Invoke-NovaCli publish uses the CLI confirmation wrapper for --confirm and -c without forwarding raw Confirm' {
         InModuleScope $script:moduleName {
             Mock Confirm-NovaCliCommandAction {}
@@ -752,6 +792,18 @@ Describe '$projectName tests' {
             $result = Invoke-NovaCli publish --local
 
             $result.Local | Should -BeTrue
+        }
+    }
+
+    It 'Invoke-NovaCli release forwards skip-tests in PublishOption' {
+        InModuleScope $script:moduleName {
+            Mock Invoke-NovaRelease {
+                [pscustomobject]@{SkipTests = [bool]$PublishOption.SkipTests}
+            }
+
+            $result = Invoke-NovaCli release --repository PSGallery --api-key key123 --skip-tests
+
+            $result.SkipTests | Should -BeTrue
         }
     }
 


### PR DESCRIPTION
## Summary

- Added opt-in skip-test support for the package, publish, and release delivery workflows.
- PowerShell now supports `New-NovaModulePackage -SkipTests`, `Publish-NovaModule -SkipTests`, and `Invoke-NovaRelease -SkipTests`.
- The `nova` launcher now supports `--skip-tests` / `-s` on `nova package`, `nova publish`, and `nova release`.
- The workflows still build; they only skip `Test-NovaBuild` when the skip-tests option is explicitly requested.
- This change was needed for CI/CD-oriented delivery paths where tests already ran earlier in the pipeline and a later packaging/publish/release step should not rerun them.
- Follow-up work also cleaned up internal helper naming so `./run.ps1` passes the ScriptAnalyzer gate again.
- Follow-up reference: `plan.md` (`Skip-tests Delivery Workflow Plan`)

## Affected area

- [x] `nova` CLI or command routing
- [x] Public PowerShell cmdlet behavior
- [ ] Scaffolding or `project.json` handling
- [x] Build, test, analyzer, coverage, or CI helper flow
- [x] Package, raw upload, or package metadata workflow
- [x] Publish, release, semantic-release, or GitHub Actions automation
- [ ] Self-update or notification preference behavior
- [x] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
- [x] End-user docs (`docs/*.html`)
- [x] Command help (`docs/NovaModuleTools/en-US/*.md`)
- [ ] `src/resources/example/`
- [ ] Dependency or manifest changes (`package.json`, workflow dependencies, release tooling)
- [ ] Security-sensitive change
- [ ] Documentation-only change
- [ ] Other

## Review guidance

- Start with the shared delivery workflow path:
  - `src/private/shared/InvokeNovaBuildValidation.ps1`
  - `src/private/package/GetNovaPackageWorkflowContext.ps1`
  - `src/private/release/GetNovaPublishWorkflowContext.ps1`
  - `src/private/release/InvokeNovaPublishWorkflow.ps1`
  - `src/private/release/InvokeNovaReleaseWorkflow.ps1`
- Then review the public entrypoints:
  - `src/public/NewNovaModulePackage.ps1`
  - `src/public/PublishNovaModule.ps1`
  - `src/public/InvokeNovaRelease.ps1`
- Then review the CLI parsing/help surface:
  - `src/private/cli/ConvertFromNovaCliArgument.ps1`
  - `src/private/cli/GetNovaCliArgumentRoutingState.ps1`
  - `src/private/cli/InvokeNovaCliCommandRoute.ps1`
  - `src/resources/cli/help/package.psd1`
  - `src/resources/cli/help/publish.psd1`
  - `src/resources/cli/help/release.psd1`
- Test coverage is mainly in:
  - `tests/NovaCommandModel.ReleasePublish.Tests.ps1`
  - `tests/CoverageGaps.Cli.Tests.ps1`
  - `tests/NovaCommandModel.StandaloneCli.Tests.ps1`
  - `tests/NovaCommandModel.Tests.ps1`
- Trade-offs / notes:
  - Skip-tests is intentionally opt-in and does not change default behavior.
  - Build steps still run; only `Test-NovaBuild` is bypassed.
  - `Publish-NovaModule` exposes `SkipTests` via a dynamic parameter to avoid increasing the static parameter surface.
  - Internal helper names were adjusted afterward to keep ScriptAnalyzer and `run.ps1` green without changing user-facing behavior.

## Validation

- [x] `Invoke-NovaBuild`
- [x] `Test-NovaBuild`
- [x] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
- [x] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`,
  `% nova publish`,
  `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
- [ ] Docs/example only; executable validation not needed

Validation notes:

```text
Focused skip-tests validation previously passed with:
- Import-Module './dist/NovaModuleTools/NovaModuleTools.psm1' -Force
- Invoke-Pester -Path './tests/NovaCommandModel.ReleasePublish.Tests.ps1','./tests/CoverageGaps.Cli.Tests.ps1','./tests/NovaCommandModel.StandaloneCli.Tests.ps1','./tests/NovaCommandModel.Tests.ps1' -CI
- Result: Tests Passed: 187, Failed: 0

Follow-up validation after the analyzer-safe helper rename:
- pwsh -NoLogo -NoProfile -File ./run.ps1
- Result: PSScriptAnalyzer: no findings.
- Result: Tests Passed: 486, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 0

Additional safeguard:
- CodeScene pre-commit safeguard rerun
- Result: quality_gates = passed

Exact delivery scenarios covered by tests:
- PowerShell package/publish/release skip-tests forwarding and workflow ordering
- CLI parsing of --skip-tests / -s
- CLI routing for nova package / publish / release skip-tests flows
- CLI help coverage for package / publish / release skip-tests options
```

## Documentation and release follow-up

- [x] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
- [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
- [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [x] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
- [x] `docs/*.html` updated if end-user workflows or examples changed
- [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
- [ ] No documentation, changelog, or example updates were needed

## Maintainability, compatibility, and risk

- [x] Code Health / maintainability impact considered
- [x] No breaking change
- [ ] Breaking change
- [ ] Security-sensitive change
- [x] CI, workflow, or release-pipeline impact
- [ ] Dependency-review impact

Risk, rollout, or rollback notes:

```text
Compatibility impact is low because the new behavior is opt-in.

Default package, publish, and release behavior is unchanged unless callers explicitly pass:
- PowerShell: -SkipTests
- CLI: --skip-tests or -s

Rollback is straightforward:
- Revert the skip-tests workflow/context/CLI/help changes
- Revert the internal helper rename if desired

Operational note:
- This change is intended for pipelines that already ran tests earlier in the flow.
- Because build still runs, artifact generation and publish steps continue to use fresh output.
```

