### PR TITLE
Feature/122 add a first class ci mode to the nova workflows

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -103,7 +103,7 @@ jobs:
 
           ./scripts/build/ci/Import-BuiltCiModule.ps1 | Out-Null
 
-          Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API
+          Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API -SkipTests
 
           ./scripts/build/ci/Import-BuiltCiModule.ps1 | Out-Null
 

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -2,6 +2,9 @@ name: Run Tests
 
 on:
   push:
+    branches-ignore:
+      - main
+      - develop
   pull_request:
     branches:
       - main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       `Invoke-NovaRelease -SkipTests`.
     - The `nova` launcher now supports `--skip-tests` / `-s` on `nova package`, `nova publish`, and `nova release`.
     - Skip-tests bypasses `Test-NovaBuild` only; the related build steps still run.
+- Add first-class CI activation switches so Nova can re-import the built `dist/` module at the workflow boundaries where
+  session state matters.
+    - PowerShell now supports `Invoke-NovaBuild -ContinuousIntegration`,
+      `Update-NovaModuleVersion -ContinuousIntegration`,
+      `Publish-NovaModule -ContinuousIntegration`, and `Invoke-NovaRelease -ContinuousIntegration`.
+    - The `nova` launcher now supports `--continuous-integration` / `-i` on `nova build`, `nova bump`, `nova publish`,
+      and `nova release` while keeping `nova version -i` dedicated to the installed-version view.
+    - Build re-activates the freshly built module after the build succeeds, bump re-activates it before the version
+      update starts, and publish/release restore the built module again after publish completes.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,29 @@ PS> Publish-NovaModule -Local
 the active PowerShell session. If your repository workflow needs to switch back to the built `dist/` output afterward,
 re-import `./dist/NovaModuleTools` explicitly.
 
+When the same CI/self-hosting session must stay aligned with the built `dist/` output automatically, use the new
+continuous-integration activation switches instead of handling re-imports manually:
+
+```powershell
+PS> Invoke-NovaBuild -ContinuousIntegration
+PS> Update-NovaModuleVersion -ContinuousIntegration
+PS> Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API -ContinuousIntegration
+PS> Invoke-NovaRelease -PublishOption @{Repository = 'PSGallery'; ApiKey = $env:PSGALLERY_API} -ContinuousIntegration
+
+% nova build --continuous-integration
+% nova bump --continuous-integration
+% nova publish --repository PSGallery --api-key $env:PSGALLERY_API --continuous-integration
+% nova release --repository PSGallery --api-key $env:PSGALLERY_API --continuous-integration
+```
+
+These switches keep the behavior explicit and opt-in:
+
+- `Invoke-NovaBuild -ContinuousIntegration` re-imports the freshly built module after the build succeeds
+- `Update-NovaModuleVersion -ContinuousIntegration` re-imports the built module before the bump workflow starts
+- `Publish-NovaModule -ContinuousIntegration` restores the built module after publish completes
+- `Invoke-NovaRelease -ContinuousIntegration` forwards that CI intent through the nested build/bump boundaries and then
+  restores the built module again after publish
+
 Useful local helper:
 
 ```powershell
@@ -344,6 +367,10 @@ PS> Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $env
 
 These forms skip `Test-NovaBuild` only. `Publish-NovaModule` still builds before publishing, and `Invoke-NovaRelease`
 still runs both build steps around the version bump.
+
+When your pipeline continues in the same PowerShell session after build, bump, publish, or release, add
+`-ContinuousIntegration` / `--continuous-integration` / `-i` to the supported commands so Nova re-activates the built
+`dist/` module at the workflow boundaries where session state matters.
 
 ### Run code quality checks
 

--- a/docs/NovaModuleTools/en-US/Invoke-NovaBuild.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaBuild.md
@@ -20,7 +20,7 @@ Builds the current NovaModuleTools project into a ready-to-import PowerShell mod
 ### __AllParameterSets
 
 ```text
-PS> Invoke-NovaBuild [-WhatIf] [-Confirm] [<CommonParameters>]
+PS> Invoke-NovaBuild [-ContinuousIntegration] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -29,6 +29,9 @@ PS> Invoke-NovaBuild [-WhatIf] [-Confirm] [<CommonParameters>]
 
 This command supports `-WhatIf` and `-Confirm` through PowerShell `SupportsShouldProcess`. Use `-WhatIf` to preview the
 build target without clearing `dist/` or generating new build output.
+
+Use `-ContinuousIntegration` when the same PowerShell session needs to keep using the freshly built `dist/` module after
+the build completes. In CI/self-hosting flows, that re-activates the built module before the command returns.
 
 The command:
 
@@ -88,7 +91,40 @@ PS> Invoke-NovaBuild -Confirm
 
 Prompts before the build workflow runs when confirmation is required.
 
+### EXAMPLE 5
+
+```text
+PS> Invoke-NovaBuild -ContinuousIntegration
+```
+
+Builds the project and then re-imports the freshly built `dist/<ProjectName>/<ProjectName>.psd1` so later CI steps in
+the same session use the updated build output.
+
 ## PARAMETERS
+
+### -ContinuousIntegration
+
+Re-import the freshly built module from `dist/` before the command returns.
+
+Use this in CI/self-hosting flows when later commands in the same PowerShell session must run against the freshly built
+module state instead of the previously loaded copy.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: [ ]
+ParameterSets:
+  - Name: (All)
+    Position: Named
+    IsRequired: false
+    ValueFromPipeline: false
+    ValueFromPipelineByPropertyName: false
+    ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: [ ]
+HelpMessage: ''
+```
 
 ### CommonParameters
 
@@ -115,6 +151,9 @@ Run this command from the project root so `project.json`, `src/`, `docs/`, and `
 
 `Invoke-NovaBuild` uses `SupportsShouldProcess`, so `Get-Help Invoke-NovaBuild -Full` shows the native `-WhatIf` and
 `-Confirm` behavior.
+
+When `-ContinuousIntegration` is used together with a real build, the command re-imports the freshly built module after
+the build succeeds. `-WhatIf` previews remain side-effect free and do not change the loaded module state.
 
 ## RELATED LINKS
 

--- a/docs/NovaModuleTools/en-US/Invoke-NovaRelease.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaRelease.md
@@ -20,7 +20,7 @@ Runs the Nova release pipeline (build, test, version bump, rebuild, publish).
 ### __AllParameterSets
 
 ```text
-PS> Invoke-NovaRelease [[-PublishOption] <hashtable>] [-SkipTests] [[-Path] <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+PS> Invoke-NovaRelease [[-PublishOption] <hashtable>] [-SkipTests] [-ContinuousIntegration] [[-Path] <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -37,6 +37,10 @@ Use `-SkipTests` when tests already ran earlier in your pipeline and you only wa
 `Test-NovaBuild` step. Both build steps still run.
 
 The command changes location to `-Path` for execution and always restores the previous location.
+
+Use `-ContinuousIntegration` when the same CI/self-hosting session should re-activate the built `dist/` module at the
+release workflow boundaries where session state matters. Nova forwards that CI intent into the nested build and version
+bump steps and restores the built module again after publish.
 
 When local release mode is selected, the resolved local publish target is previewed consistently with
 `Publish-NovaModule -Local`. Unlike `Publish-NovaModule -Local`, `Invoke-NovaRelease` does not import the published
@@ -87,6 +91,15 @@ PS> Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $env
 ```
 
 Runs the release workflow without re-running the pre-release `Test-NovaBuild` step.
+
+### EXAMPLE 6
+
+```text
+PS> Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $env:PSGALLERY_API } -ContinuousIntegration
+```
+
+Runs the release workflow and re-activates the built `dist/<ProjectName>/<ProjectName>.psd1` at the CI-sensitive
+workflow boundaries so later commands in the same session keep using the built module state.
 
 ## PARAMETERS
 
@@ -165,6 +178,29 @@ AcceptedValues: [ ]
 HelpMessage: ''
 ```
 
+### -ContinuousIntegration
+
+Re-activate the built module from `dist/` at the release workflow boundaries where the active module state matters.
+
+Use this for CI/self-hosting flows that continue in the same session after build, version bump, or publish.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: [ ]
+ParameterSets:
+  - Name: (All)
+    Position: Named
+    IsRequired: false
+    ValueFromPipeline: false
+    ValueFromPipelineByPropertyName: false
+    ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: [ ]
+HelpMessage: ''
+```
+
 ### CommonParameters
 
 This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`,
@@ -192,6 +228,10 @@ When `-SkipTests` is used, only the pre-release `Test-NovaBuild` step is skipped
 
 Use `Publish-NovaModule -Local` when you want a successful local publish to reload the published module into the active
 PowerShell session.
+
+When `-ContinuousIntegration` is used, the release workflow restores the built `dist/` module after CI-sensitive
+boundaries so later steps in the same session keep using the built module state instead of a stale or publish-modified
+copy.
 
 `Invoke-NovaRelease` uses `SupportsShouldProcess`, so `Get-Help Invoke-NovaRelease -Full` surfaces native `-WhatIf`
 and `-Confirm` support.

--- a/docs/NovaModuleTools/en-US/Publish-NovaModule.md
+++ b/docs/NovaModuleTools/en-US/Publish-NovaModule.md
@@ -20,13 +20,13 @@ Builds, tests, and publishes the current project either locally or to a PowerShe
 ### Local
 
 ```text
-PS> Publish-NovaModule [-Local] [[-ModuleDirectoryPath] <string>] [[-ApiKey] <string>] [-SkipTests] [-WhatIf] [-Confirm] [<CommonParameters>]
+PS> Publish-NovaModule [-Local] [[-ModuleDirectoryPath] <string>] [[-ApiKey] <string>] [-SkipTests] [-ContinuousIntegration] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Repository
 
 ```text
-PS> Publish-NovaModule [-Repository] <string> [[-ModuleDirectoryPath] <string>] [[-ApiKey] <string>] [-SkipTests] [-WhatIf] [-Confirm] [<CommonParameters>]
+PS> Publish-NovaModule [-Repository] <string> [[-ModuleDirectoryPath] <string>] [[-ApiKey] <string>] [-SkipTests] [-ContinuousIntegration] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -42,6 +42,10 @@ PowerShell session so the newly published module is ready to use immediately.
 
 Use repository mode when you want to publish the built module to a registered PowerShell repository such as
 `PSGallery`.
+
+Use `-ContinuousIntegration` when the same CI/self-hosting session should switch back to the built `dist/` module after
+publish completes. This keeps later commands aligned with the built module state instead of whatever publish imported or
+left loaded.
 
 This command supports `-WhatIf` and `-Confirm` through PowerShell `SupportsShouldProcess`. Use `-WhatIf` to preview the
 resolved publish target and workflow without building, testing, or publishing.
@@ -100,6 +104,15 @@ PS> Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API -SkipTes
 ```
 
 Builds and publishes the module to `PSGallery` without re-running `Test-NovaBuild`.
+
+### EXAMPLE 7
+
+```text
+PS> Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API -ContinuousIntegration
+```
+
+Publishes the module and then re-imports the built `dist/<ProjectName>/<ProjectName>.psd1` so later CI steps in the
+same session continue from the built module state.
 
 ## PARAMETERS
 
@@ -216,6 +229,32 @@ AcceptedValues: [ ]
 HelpMessage: ''
 ```
 
+### -ContinuousIntegration
+
+Re-import the built module from `dist/` after publish completes.
+
+Use this when your CI/self-hosting workflow continues in the same session after publish and must keep using the built
+module state for later commands.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: [ ]
+ParameterSets:
+  - Name: Local
+    Position: Named
+  - Name: Repository
+    Position: Named
+    IsRequired: false
+    ValueFromPipeline: false
+    ValueFromPipelineByPropertyName: false
+    ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: [ ]
+HelpMessage: ''
+```
+
 ### CommonParameters
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
@@ -246,6 +285,9 @@ step is skipped.
 Local publish imports the published module from the resolved local install directory. It does not import directly from
 the
 source project or from `dist/`.
+
+When `-ContinuousIntegration` is used, Nova restores the built `dist/` module after publish so later commands in the
+same session keep using the built module state.
 
 `Publish-NovaModule` uses `SupportsShouldProcess`, so `Get-Help Publish-NovaModule -Full` should surface native
 `-WhatIf` and `-Confirm` support.

--- a/docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md
+++ b/docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md
@@ -20,7 +20,7 @@ Updates the project version in `project.json` based on git commit history.
 ### __AllParameterSets
 
 ```text
-PS> Update-NovaModuleVersion [[-Path] <string>] [-Preview] [-WhatIf] [-Confirm] [<CommonParameters>]
+PS> Update-NovaModuleVersion [[-Path] <string>] [-Preview] [-ContinuousIntegration] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -50,6 +50,9 @@ has no commits yet. Create an initial commit first.`
 
 This command supports `-WhatIf` and `-Confirm` through PowerShell `SupportsShouldProcess`. Use `-WhatIf` to preview the
 calculated release label and the exact next version without changing the stored version.
+
+Use `-ContinuousIntegration` when the same session should first re-activate the built `dist/` module before the version
+bump workflow starts. This is useful in CI/self-hosting flows where an earlier command changed the active module state.
 
 When the current version is already a prerelease for the selected release line, Nova finalizes that same semantic
 version instead of incrementing again. For example, a `Major` bump from `2.0.0-preview7` resolves to `2.0.0`, not
@@ -151,6 +154,14 @@ CommitCount: 3
 
 Shows how `-Preview` starts any bare non-preview prerelease stem at `01` instead of jumping directly to `1`.
 
+### EXAMPLE 8
+
+```text
+PS> Update-NovaModuleVersion -ContinuousIntegration
+```
+
+Re-imports the built `dist/<ProjectName>/<ProjectName>.psd1` first and then runs the normal version bump workflow.
+
 ## PARAMETERS
 
 ### -Path
@@ -200,6 +211,30 @@ AcceptedValues: [ ]
 HelpMessage: ''
 ```
 
+### -ContinuousIntegration
+
+Re-import the built module from `dist/` before the version bump workflow starts.
+
+Use this when later steps in the same CI/self-hosting session must stay aligned with the built module state that Nova
+just produced earlier in the workflow.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: [ ]
+ParameterSets:
+  - Name: (All)
+    Position: Named
+    IsRequired: false
+    ValueFromPipeline: false
+    ValueFromPipelineByPropertyName: false
+    ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: [ ]
+HelpMessage: ''
+```
+
 ### CommonParameters
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
@@ -228,6 +263,9 @@ reflect the new version.
 
 `Update-NovaModuleVersion` uses `SupportsShouldProcess`, so `Get-Help Update-NovaModuleVersion -Full` surfaces native
 `-WhatIf` and `-Confirm` support.
+
+When `-ContinuousIntegration` is used with a real update, the command re-activates the built `dist/` module first. When
+combined with `-WhatIf`, Nova still previews the bump without changing the loaded module state.
 
 ## RELATED LINKS
 

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -225,10 +225,13 @@ PS&gt; Get-NovaProjectInfo -Version</code></pre>
                                 package, or publish
                             </li>
                             <li><strong>Key switches:</strong> <code>-WhatIf</code>, <code>-Confirm</code>, or the CLI
-                                forms <code>--what-if</code> / <code>-w</code> and <code>--confirm</code> /
-                                <code>-c</code></li>
+                                forms <code>--what-if</code> / <code>-w</code>, <code>--confirm</code> /
+                                <code>-c</code>, and <code>--continuous-integration</code> / <code>-i</code></li>
                             <li><strong>Notable behavior:</strong> respects <code>SetSourcePath</code>,
                                 <code>Preamble</code>, and duplicate function validation
+                            </li>
+                            <li><strong>CI note:</strong> <code>-ContinuousIntegration</code> restores the freshly built
+                                <code>dist/</code> module before the command returns
                             </li>
                         </ul>
                         <div class="surface-example" data-command-example>
@@ -239,11 +242,13 @@ PS&gt; Get-NovaProjectInfo -Version</code></pre>
                             </div>
                             <div class="surface-example__surface" data-command-surface="powershell">
                                 <pre><code>PS&gt; Invoke-NovaBuild
-PS&gt; Invoke-NovaBuild -WhatIf</code></pre>
+PS&gt; Invoke-NovaBuild -WhatIf
+PS&gt; Invoke-NovaBuild -ContinuousIntegration</code></pre>
                             </div>
                             <div class="surface-example__surface" data-command-surface="command-line" hidden>
                                 <pre><code>% nova build
-% nova build --what-if</code></pre>
+% nova build --what-if
+% nova build --continuous-integration</code></pre>
                             </div>
                         </div>
                         <p><a class="text-link" href="./core-workflows.html#build">See the build workflow</a></p>
@@ -366,13 +371,16 @@ PS&gt; Deploy-NovaPackage -Url 'https://packages.example/raw/' -Token $env:NOVA_
                         <h3><code>Publish-NovaModule</code> / <code>% nova publish</code></h3>
                         <p>Build, test, and publish the module either locally or to a registered PowerShell
                             repository. Use <code>-SkipTests</code> / <code>--skip-tests</code> when tests already ran
-                            earlier in CI/CD.</p>
+                            earlier in CI/CD, or <code>-ContinuousIntegration</code> /
+                            <code>--continuous-integration</code>
+                            when later commands in the same session must switch back to the built <code>dist/</code>
+                            module.</p>
                         <ul class="plain-list">
                             <li><strong>Best for:</strong> PowerShell repository publishing or validating a local
                                 publish/install cycle
                             </li>
                             <li><strong>Key parameters:</strong> <code>-Local</code>, <code>-Repository</code>, <code>-ModuleDirectoryPath</code>,
-                                <code>-ApiKey</code>, <code>-SkipTests</code></li>
+                                <code>-ApiKey</code>, <code>-SkipTests</code>, <code>-ContinuousIntegration</code></li>
                             <li><strong>Notable behavior:</strong> local publish reloads the published module into the
                                 current PowerShell session
                             </li>
@@ -386,12 +394,14 @@ PS&gt; Deploy-NovaPackage -Url 'https://packages.example/raw/' -Token $env:NOVA_
                             <div class="surface-example__surface" data-command-surface="powershell">
                                 <pre><code>PS&gt; Publish-NovaModule -Local
 PS&gt; Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API
-PS&gt; Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API -SkipTests</code></pre>
+PS&gt; Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API -SkipTests
+PS&gt; Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API -ContinuousIntegration</code></pre>
                             </div>
                             <div class="surface-example__surface" data-command-surface="command-line" hidden>
                                 <pre><code>% nova publish --local
 % nova publish --repository PSGallery --api-key $env:PSGALLERY_API
-% nova publish --repository PSGallery --api-key $env:PSGALLERY_API --skip-tests</code></pre>
+% nova publish --repository PSGallery --api-key $env:PSGALLERY_API --skip-tests
+% nova publish --repository PSGallery --api-key $env:PSGALLERY_API --continuous-integration</code></pre>
                             </div>
                         </div>
                         <p><a class="text-link" href="./packaging-and-delivery.html#publish">See publish details</a></p>
@@ -401,13 +411,16 @@ PS&gt; Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API -Skip
                         <h3><code>Invoke-NovaRelease</code> / <code>% nova release</code></h3>
                         <p>Run the full release flow: build, test, bump version, build again, and then publish. Use
                             <code>-SkipTests</code> / <code>--skip-tests</code> when tests already ran earlier in CI/CD
-                            and you only want to skip the pre-release test step.</p>
+                            and you only want to skip the pre-release test step. Use <code>-ContinuousIntegration</code>
+                            / <code>--continuous-integration</code> when Nova should restore the built
+                            <code>dist/</code>
+                            module at the CI-sensitive workflow boundaries.</p>
                         <ul class="plain-list">
                             <li><strong>Best for:</strong> an orchestrated release command when you want one workflow
                                 instead of separate steps
                             </li>
                             <li><strong>Key parameters:</strong> <code>-PublishOption</code>, <code>-Path</code>,
-                                <code>-SkipTests</code></li>
+                                <code>-SkipTests</code>, <code>-ContinuousIntegration</code></li>
                             <li><strong>Important difference:</strong> local release does not reload the published
                                 module into the session after publishing
                             </li>
@@ -421,11 +434,13 @@ PS&gt; Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API -Skip
                             <div class="surface-example__surface" data-command-surface="powershell">
                                 <pre><code>PS&gt; Invoke-NovaRelease -PublishOption @{ Local = $true }
 PS&gt; Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $env:PSGALLERY_API }
-PS&gt; Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $env:PSGALLERY_API } -SkipTests</code></pre>
+PS&gt; Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $env:PSGALLERY_API } -SkipTests
+PS&gt; Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $env:PSGALLERY_API } -ContinuousIntegration</code></pre>
                             </div>
                             <div class="surface-example__surface" data-command-surface="command-line" hidden>
                                 <pre><code>% nova release --repository PSGallery --api-key $env:PSGALLERY_API
-% nova release --repository PSGallery --api-key $env:PSGALLERY_API --skip-tests</code></pre>
+% nova release --repository PSGallery --api-key $env:PSGALLERY_API --skip-tests
+% nova release --repository PSGallery --api-key $env:PSGALLERY_API --continuous-integration</code></pre>
                             </div>
                         </div>
                         <div class="surface-note" data-command-visibility="command-line" hidden>
@@ -447,8 +462,9 @@ PS&gt; Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $
                         </p>
                         <ul class="plain-list">
                             <li><strong>Best for:</strong> Git-driven semantic version updates</li>
-                            <li><strong>Key parameters:</strong> <code>-Path</code>, <code>-Preview</code>, or the CLI
-                                form <code>--preview</code> / <code>-p</code></li>
+                            <li><strong>Key parameters:</strong> <code>-Path</code>, <code>-Preview</code>,
+                                <code>-ContinuousIntegration</code>, or the CLI form <code>--preview</code> /
+                                <code>-p</code> and <code>--continuous-integration</code> / <code>-i</code></li>
                             <li><strong>Notable behavior:</strong> falls back to a patch bump when the folder is not a
                                 Git repository, but throws when the repository exists and has no commits yet
                             </li>
@@ -470,10 +486,12 @@ PS&gt; Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $
                                         data-command-surface-label>PowerShell</span></p>
                             </div>
                             <div class="surface-example__surface" data-command-surface="powershell">
-                                <pre><code>PS&gt; Update-NovaModuleVersion -Preview -WhatIf</code></pre>
+                                <pre><code>PS&gt; Update-NovaModuleVersion -Preview -WhatIf
+PS&gt; Update-NovaModuleVersion -ContinuousIntegration</code></pre>
                             </div>
                             <div class="surface-example__surface" data-command-surface="command-line" hidden>
                                 <pre><code>% nova bump --preview --what-if
+% nova bump --continuous-integration
 % nova bump --preview --confirm</code></pre>
                             </div>
                         </div>

--- a/docs/core-workflows.html
+++ b/docs/core-workflows.html
@@ -137,14 +137,20 @@ PS&gt; Initialize-NovaModule -Example -Path ~/Work</code></pre>
                         </p>
                     </div>
                     <div class="surface-example__surface" data-command-surface="powershell">
-                        <pre><code>PS&gt; Invoke-NovaBuild</code></pre>
+                        <pre><code>PS&gt; Invoke-NovaBuild
+PS&gt; Invoke-NovaBuild -ContinuousIntegration</code></pre>
                     </div>
                     <div class="surface-example__surface" data-command-surface="command-line" hidden>
-                        <pre><code>% nova build</code></pre>
+                        <pre><code>% nova build
+% nova build --continuous-integration</code></pre>
                     </div>
                 </div>
                 <p>The build step turns your project into a real PowerShell module under
                     <code>dist/&lt;ProjectName&gt;</code>.</p>
+                <p>Use the continuous-integration form when the same CI/self-hosting session must keep using the freshly
+                    built module after the build completes. Nova then re-imports the new <code>dist/</code> output
+                    before
+                    returning.</p>
                 <h3>What build includes</h3>
                 <ul class="plain-list">
                     <li>generated <code>.psm1</code> output</li>
@@ -257,6 +263,13 @@ pwsh -NoLogo -Command 'Import-Module (Get-NovaProjectInfo).OutputModuleDir -Forc
                         published
                         module from the local install path after a successful publish. That is different from the normal
                         build/import loop, which works from <code>dist/</code>.</p>
+                </div>
+                <div class="notice">
+                    <strong>CI/self-hosting note.</strong>
+                    <p>When a later command in the same session must switch back to the built <code>dist/</code> module,
+                        use <code>Invoke-NovaBuild -ContinuousIntegration</code> or <code>% nova build
+                            --continuous-integration</code>
+                        so Nova restores the built module state automatically.</p>
                 </div>
             </section>
 

--- a/docs/packaging-and-delivery.html
+++ b/docs/packaging-and-delivery.html
@@ -373,11 +373,13 @@ MyModule.latest.zip</code></pre>
                     </div>
                     <div class="surface-example__surface" data-command-surface="powershell">
                         <pre><code>PS&gt; Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API
-PS&gt; Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API -SkipTests</code></pre>
+PS&gt; Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API -SkipTests
+PS&gt; Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API -ContinuousIntegration</code></pre>
                     </div>
                     <div class="surface-example__surface" data-command-surface="command-line" hidden>
                         <pre><code>% nova publish --repository PSGallery --api-key $env:PSGALLERY_API
-% nova publish --repository PSGallery --api-key $env:PSGALLERY_API --skip-tests</code></pre>
+% nova publish --repository PSGallery --api-key $env:PSGALLERY_API --skip-tests
+% nova publish --repository PSGallery --api-key $env:PSGALLERY_API --continuous-integration</code></pre>
                     </div>
                 </div>
                 <p>Repository mode is for registered PowerShell repositories such as PowerShell Gallery.</p>
@@ -404,6 +406,13 @@ PS&gt; Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API -Skip
                     <strong>CI/CD shortcut:</strong>
                     <p>Use <code>-SkipTests</code>, <code>--skip-tests</code>, or <code>-s</code> when tests already ran
                         earlier in the pipeline. Publish still rebuilds before copying or repository publishing.</p>
+                </div>
+                <div class="notice">
+                    <strong>CI/self-hosting activation:</strong>
+                    <p>Use <code>-ContinuousIntegration</code>, <code>--continuous-integration</code>, or
+                        <code>-i</code>
+                        when later commands in the same session must switch back to the built <code>dist/</code> module
+                        after publish completes.</p>
                 </div>
                 <h3>What <code>-WhatIf</code> means here</h3>
                 <p>When you preview local publish, Nova does not build, test, copy, or import the module. The preview is
@@ -438,11 +447,13 @@ PS&gt; Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API -Skip
                     <div class="surface-example__surface" data-command-surface="powershell">
                         <pre><code>PS&gt; Invoke-NovaRelease -PublishOption @{ Local = $true }
 PS&gt; Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $env:PSGALLERY_API }
-PS&gt; Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $env:PSGALLERY_API } -SkipTests</code></pre>
+PS&gt; Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $env:PSGALLERY_API } -SkipTests
+PS&gt; Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $env:PSGALLERY_API } -ContinuousIntegration</code></pre>
                     </div>
                     <div class="surface-example__surface" data-command-surface="command-line" hidden>
                         <pre><code>% nova release --repository PSGallery --api-key $env:PSGALLERY_API
-% nova release --repository PSGallery --api-key $env:PSGALLERY_API --skip-tests</code></pre>
+% nova release --repository PSGallery --api-key $env:PSGALLERY_API --skip-tests
+% nova release --repository PSGallery --api-key $env:PSGALLERY_API --continuous-integration</code></pre>
                     </div>
                 </div>
                 <div class="surface-note" data-command-visibility="command-line" hidden>
@@ -454,6 +465,9 @@ PS&gt; Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $
                 <h3>Important difference from local publish</h3>
                 <p>Local release does <strong>not</strong> import the published module into your current session
                     afterward. That behavior is specific to <code>Publish-NovaModule -Local</code>.</p>
+                <p>When you use the continuous-integration form, Nova still restores the built <code>dist/</code> module
+                    after the CI-sensitive release boundaries so later commands in the same session keep using the built
+                    module state.</p>
                 <h3>When to prefer release over separate steps</h3>
                 <ul class="plain-list">
                     <li>Use release when your version bump and publish should happen together.</li>

--- a/docs/versioning-and-updates.html
+++ b/docs/versioning-and-updates.html
@@ -202,14 +202,19 @@
                     </div>
                     <div class="surface-example__surface" data-command-surface="powershell">
                         <pre><code>PS&gt; Update-NovaModuleVersion -WhatIf
-PS&gt; Update-NovaModuleVersion -Preview -WhatIf</code></pre>
+PS&gt; Update-NovaModuleVersion -Preview -WhatIf
+PS&gt; Update-NovaModuleVersion -ContinuousIntegration</code></pre>
                     </div>
                     <div class="surface-example__surface" data-command-surface="command-line" hidden>
                         <pre><code>% nova bump --what-if
 % nova bump --preview --what-if
+% nova bump --continuous-integration
 % nova bump --confirm</code></pre>
                     </div>
                 </div>
+                <p>Use the continuous-integration form when the same CI/self-hosting session must first re-activate the
+                    built <code>dist/</code> module before the version bump runs. This is especially useful after an
+                    earlier command changed the active module state.</p>
                 <div class="notice notice--warning">
                     <strong>Empty repository rule.</strong>
                     <p>If your Git repository exists but has no commits yet, Nova throws: <code>Cannot bump version

--- a/src/private/build/GetNovaBuildWorkflowContext.ps1
+++ b/src/private/build/GetNovaBuildWorkflowContext.ps1
@@ -1,13 +1,15 @@
 function Get-NovaBuildWorkflowContext {
     [CmdletBinding()]
     param(
-        [pscustomobject]$ProjectInfo
+        [pscustomobject]$ProjectInfo,
+        [switch]$ContinuousIntegrationRequested
     )
 
     $projectInfo = Get-NovaBuildProjectInfo -ProjectInfo $ProjectInfo
 
     return [pscustomobject]@{
         ProjectInfo = $projectInfo
+        ContinuousIntegrationRequested = [bool]$ContinuousIntegrationRequested
         Target = $projectInfo.OutputModuleDir
         Operation = 'Build Nova module output'
     }

--- a/src/private/build/InvokeNovaBuildWorkflow.ps1
+++ b/src/private/build/InvokeNovaBuildWorkflow.ps1
@@ -5,6 +5,7 @@ function Invoke-NovaBuildWorkflow {
     )
 
     $projectInfo = $WorkflowContext.ProjectInfo
+    $continuousIntegrationRequested = ($WorkflowContext.PSObject.Properties.Name -contains 'ContinuousIntegrationRequested') -and $WorkflowContext.ContinuousIntegrationRequested
 
     Reset-ProjectDist -ProjectInfo $projectInfo -Confirm:$false
     Build-Module -ProjectInfo $projectInfo
@@ -13,6 +14,10 @@ function Invoke-NovaBuildWorkflow {
     Build-Help -ProjectInfo $projectInfo
     Copy-ProjectResource -ProjectInfo $projectInfo
     Invoke-NovaBuildUpdateNotificationSafely
+
+    if ($continuousIntegrationRequested) {
+        $null = Import-NovaBuiltModuleForCi -ProjectInfo $projectInfo
+    }
 }
 
 function Invoke-NovaBuildDuplicateValidation {

--- a/src/private/cli/ConvertFromNovaBuildCliArgument.ps1
+++ b/src/private/cli/ConvertFromNovaBuildCliArgument.ps1
@@ -1,4 +1,4 @@
-function ConvertFrom-NovaBumpCliArgument {
+function ConvertFrom-NovaBuildCliArgument {
     [CmdletBinding()]
     param(
         [string[]]$Arguments
@@ -9,9 +9,6 @@ function ConvertFrom-NovaBumpCliArgument {
 
     foreach ($token in $Arguments) {
         switch -Regex ($token) {
-            '^(--preview|-p)$' {
-                $options.Preview = $true
-            }
             '^(--continuous-integration|-i)$' {
                 $options.ContinuousIntegration = $true
             }

--- a/src/private/cli/ConvertFromNovaCliArgument.ps1
+++ b/src/private/cli/ConvertFromNovaCliArgument.ps1
@@ -18,10 +18,14 @@ function ConvertFrom-NovaCliArgument {
     [CmdletBinding()]
     param(
         [string[]]$Arguments,
-        [string[]]$AllowedOptionNameList = @('Local', 'Repository', 'ModuleDirectoryPath', 'ApiKey', 'SkipTests')
+        [string[]]$AllowedOptionNameList
     )
 
     $Arguments = ConvertTo-NovaCliArgumentArray -BoundParameters $PSBoundParameters -Arguments $Arguments
+    if ($null -eq $AllowedOptionNameList) {
+        $AllowedOptionNameList = @('Local', 'Repository', 'ModuleDirectoryPath', 'ApiKey', 'SkipTests', 'ContinuousIntegration')
+    }
+
     $options = @{}
     $index = 0
 
@@ -46,6 +50,9 @@ function ConvertFrom-NovaCliArgument {
             }
             '^(--skip-tests|-s)$' {
                 Add-NovaCliDeliveryOption -Options $options -AllowedOptionNameList $AllowedOptionNameList -Option ([pscustomobject]@{Name = 'SkipTests'; Value = $true}) -Token $token
+            }
+            '^(--continuous-integration|-i)$' {
+                Add-NovaCliDeliveryOption -Options $options -AllowedOptionNameList $AllowedOptionNameList -Option ([pscustomobject]@{Name = 'ContinuousIntegration'; Value = $true}) -Token $token
             }
             default {
                 Stop-NovaOperation -Message "Unknown argument: $token" -ErrorId 'Nova.Validation.UnknownCliArgument' -Category InvalidArgument -TargetObject $token

--- a/src/private/cli/GetNovaCliArgumentRoutingState.ps1
+++ b/src/private/cli/GetNovaCliArgumentRoutingState.ps1
@@ -60,6 +60,7 @@ function Get-NovaCliLegacyOptionReplacement {
         '-authenticationscheme' = "'--auth-scheme' or '-a'"
         '-build' = "'--build' or '-b'"
         '-confirm' = "'--confirm' or '-c'"
+        '-continuousintegration' = "'--continuous-integration' or '-i'"
         '-disable' = "'--disable' or '-d'"
         '-enable' = "'--enable' or '-e'"
         '-example' = "'--example' or '-e'"

--- a/src/private/cli/InvokeNovaCliCommandRoute.ps1
+++ b/src/private/cli/InvokeNovaCliCommandRoute.ps1
@@ -110,7 +110,7 @@ function Invoke-NovaCliCommandRoute {
             return Invoke-NovaCliVersionCommand -Arguments $InvocationContext.Arguments -ForwardedParameters $commonParameters
         }
         'build' {
-            return Invoke-NovaBuild @mutatingCommonParameters
+            return Invoke-NovaCliParsedCommand -InvocationContext $InvocationContext -ParserCommand 'ConvertFrom-NovaBuildCliArgument' -ActionCommand 'Invoke-NovaBuild'
         }
         'test' {
             return Invoke-NovaCliParsedCommand -InvocationContext $InvocationContext -ParserCommand 'ConvertFrom-NovaTestCliArgument' -ActionCommand 'Test-NovaBuild'

--- a/src/private/release/GetNovaPublishWorkflowContext.ps1
+++ b/src/private/release/GetNovaPublishWorkflowContext.ps1
@@ -11,6 +11,7 @@ function Get-NovaPublishWorkflowContext {
     $moduleDirectoryPath = Get-NovaPublishOptionValue -PublishOption $PublishOption -Name ModuleDirectoryPath
     $apiKey = Get-NovaPublishOptionValue -PublishOption $PublishOption -Name ApiKey
     $skipTestsRequested = [bool](Get-NovaPublishOptionValue -PublishOption $PublishOption -Name SkipTests)
+    $continuousIntegrationRequested = [bool](Get-NovaPublishOptionValue -PublishOption $PublishOption -Name ContinuousIntegration)
     $includeLocalPublishActivation = $WorkflowSettings.ContainsKey('IncludeLocalPublishActivation') -and $WorkflowSettings.IncludeLocalPublishActivation
     $release = $WorkflowSettings.ContainsKey('Release') -and $WorkflowSettings.Release
     $publishInvocation = Resolve-NovaPublishInvocation -ProjectInfo $ProjectInfo -Repository $repository -ModuleDirectoryPath $moduleDirectoryPath -ApiKey $apiKey
@@ -21,10 +22,12 @@ function Get-NovaPublishWorkflowContext {
     }
 
     return [pscustomobject]@{
+        ProjectInfo = $ProjectInfo
         WorkflowName = $WorkflowSettings.WorkflowName
         LocalRequested = [bool]($PublishOption.ContainsKey('Local') -and $PublishOption.Local)
         WorkflowParams = $WorkflowParams
         SkipTestsRequested = $skipTestsRequested
+        ContinuousIntegrationRequested = $continuousIntegrationRequested
         PublishInvocation = $publishInvocation
         PublishParams = Get-NovaResolvedPublishParameterMap -PublishInvocation $publishInvocation -WorkflowParams $WorkflowParams
         LocalPublishActivation = $localPublishActivation

--- a/src/private/release/GetNovaVersionUpdateWorkflowContext.ps1
+++ b/src/private/release/GetNovaVersionUpdateWorkflowContext.ps1
@@ -2,7 +2,8 @@ function Get-NovaVersionUpdateWorkflowContext {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string]$ProjectRoot,
-        [switch]$PreviewRelease
+        [switch]$PreviewRelease,
+        [switch]$ContinuousIntegrationRequested
     )
 
     $projectInfo = Get-NovaProjectInfo -Path $ProjectRoot
@@ -10,7 +11,7 @@ function Get-NovaVersionUpdateWorkflowContext {
     $label = Get-NovaVersionLabelForBump -ProjectRoot $ProjectRoot -CommitMessages $commitMessages
     $versionUpdatePlan = Get-NovaVersionUpdatePlan -ProjectInfo $projectInfo -Label $label -PreviewRelease:$PreviewRelease
 
-    return Get-NovaVersionUpdateWorkflowContextObject -ProjectRoot $ProjectRoot -ProjectInfo $projectInfo -CommitMessages $commitMessages -Label $label -VersionUpdatePlan $versionUpdatePlan -PreviewRelease:$PreviewRelease
+    return Get-NovaVersionUpdateWorkflowContextObject -ProjectRoot $ProjectRoot -ProjectInfo $projectInfo -CommitMessages $commitMessages -Label $label -VersionUpdatePlan $versionUpdatePlan -PreviewRelease:$PreviewRelease -ContinuousIntegrationRequested:$ContinuousIntegrationRequested
 }
 
 function Get-NovaVersionUpdateWorkflowContextObject {
@@ -21,7 +22,8 @@ function Get-NovaVersionUpdateWorkflowContextObject {
         [AllowEmptyCollection()][string[]]$CommitMessages = @(),
         [Parameter(Mandatory)][string]$Label,
         [Parameter(Mandatory)][pscustomobject]$VersionUpdatePlan,
-        [switch]$PreviewRelease
+        [switch]$PreviewRelease,
+        [switch]$ContinuousIntegrationRequested
     )
 
     return [pscustomobject]@{
@@ -31,6 +33,7 @@ function Get-NovaVersionUpdateWorkflowContextObject {
         CommitCount = $CommitMessages.Count
         Label = $Label
         PreviewRelease = [bool]$PreviewRelease
+        ContinuousIntegrationRequested = [bool]$ContinuousIntegrationRequested
         Target = [System.IO.Path]::GetFileName($ProjectInfo.ProjectJSON)
         Action = "Update module version using $Label release label"
         PreviousVersion = $ProjectInfo.Version

--- a/src/private/release/InvokeNovaPublishWorkflow.ps1
+++ b/src/private/release/InvokeNovaPublishWorkflow.ps1
@@ -1,3 +1,26 @@
+function Test-NovaPublishWorkflowShouldImportLocalModule {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext,
+        [switch]$ShouldRun
+    )
+
+    return $ShouldRun -and $null -ne $WorkflowContext.LocalPublishActivation
+}
+
+function Invoke-NovaPublishWorkflowCiRestore {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext,
+        [switch]$ShouldRun,
+        [switch]$ContinuousIntegrationRequested
+    )
+
+    if ($ShouldRun -and $ContinuousIntegrationRequested) {
+        $null = Import-NovaBuiltModuleForCi -ProjectInfo $WorkflowContext.ProjectInfo
+    }
+}
+
 function Invoke-NovaPublishWorkflow {
     [CmdletBinding()]
     param(
@@ -6,15 +29,20 @@ function Invoke-NovaPublishWorkflow {
     )
 
     $publishParams = $WorkflowContext.PublishParams
+    $continuousIntegrationRequested = ($WorkflowContext.PSObject.Properties.Name -contains 'ContinuousIntegrationRequested') -and $WorkflowContext.ContinuousIntegrationRequested
+    $shouldImportPublishedLocalModule = Test-NovaPublishWorkflowShouldImportLocalModule -WorkflowContext $WorkflowContext -ShouldRun:$ShouldRun
 
     Invoke-NovaBuildValidation -WorkflowContext $WorkflowContext
 
     & $WorkflowContext.PublishInvocation.Action @publishParams
 
-    if (-not $ShouldRun -or -not $WorkflowContext.LocalPublishActivation) {
+    if (-not $shouldImportPublishedLocalModule) {
+        Invoke-NovaPublishWorkflowCiRestore -WorkflowContext $WorkflowContext -ShouldRun:$ShouldRun -ContinuousIntegrationRequested:$continuousIntegrationRequested
         return
     }
 
     $null = & $WorkflowContext.LocalPublishActivation.ImportAction -ProjectName $WorkflowContext.PublishInvocation.Parameters.ProjectInfo.ProjectName -ManifestPath $WorkflowContext.LocalPublishActivation.ManifestPath
     Write-Verbose "Module copy to local path complete and imported from $( $WorkflowContext.LocalPublishActivation.ManifestPath )"
+
+    Invoke-NovaPublishWorkflowCiRestore -WorkflowContext $WorkflowContext -ShouldRun:$ShouldRun -ContinuousIntegrationRequested:$continuousIntegrationRequested
 }

--- a/src/private/release/InvokeNovaReleaseWorkflow.ps1
+++ b/src/private/release/InvokeNovaReleaseWorkflow.ps1
@@ -1,17 +1,47 @@
+function Get-NovaReleaseNestedWorkflowParameterMap {
+    [CmdletBinding()]
+    param(
+        [hashtable]$WorkflowParams = @{},
+        [switch]$ContinuousIntegrationRequested
+    )
+
+    $nestedWorkflowParams = @{}
+    foreach ($parameterName in $WorkflowParams.Keys) {
+        $nestedWorkflowParams[$parameterName] = $WorkflowParams[$parameterName]
+    }
+
+    if ($ContinuousIntegrationRequested) {
+        $nestedWorkflowParams.ContinuousIntegration = $true
+    }
+
+    return $nestedWorkflowParams
+}
+
 function Invoke-NovaReleaseWorkflow {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][pscustomobject]$WorkflowContext
     )
 
+    $continuousIntegrationRequested = ($WorkflowContext.PSObject.Properties.Name -contains 'ContinuousIntegrationRequested') -and $WorkflowContext.ContinuousIntegrationRequested
+    $skipTestsRequested = ($WorkflowContext.PSObject.Properties.Name -contains 'SkipTestsRequested') -and $WorkflowContext.SkipTestsRequested
     $workflowParams = $WorkflowContext.WorkflowParams
+    $ciWorkflowParams = Get-NovaReleaseNestedWorkflowParameterMap -WorkflowParams $workflowParams -ContinuousIntegrationRequested:$continuousIntegrationRequested
     $publishParams = $WorkflowContext.PublishParams
 
-    Invoke-NovaBuildValidation -WorkflowContext $WorkflowContext
-    $versionResult = Update-NovaModuleVersion @workflowParams
-    Invoke-NovaBuild @workflowParams
+    Invoke-NovaBuild @ciWorkflowParams
+    if (-not $skipTestsRequested) {
+        Test-NovaBuild @workflowParams
+    }
+
+    $versionResult = Update-NovaModuleVersion @ciWorkflowParams
+    Invoke-NovaBuild @ciWorkflowParams
 
     & $WorkflowContext.PublishInvocation.Action @publishParams
+
+    if ($continuousIntegrationRequested) {
+        $null = Import-NovaBuiltModuleForCi -ProjectInfo $WorkflowContext.ProjectInfo
+    }
 
     return $versionResult
 }

--- a/src/private/shared/ImportNovaBuiltModuleForCi.ps1
+++ b/src/private/shared/ImportNovaBuiltModuleForCi.ps1
@@ -1,0 +1,40 @@
+function Resolve-NovaCiProjectInfo {
+    [CmdletBinding()]
+    param(
+        [string]$ProjectRoot = (Get-Location).Path,
+        [pscustomobject]$ProjectInfo
+    )
+
+    if ($null -ne $ProjectInfo) {
+        return $ProjectInfo
+    }
+
+    return Get-NovaProjectInfo -Path $ProjectRoot
+}
+
+function Get-NovaBuiltModuleManifestPathForCi {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo
+    )
+
+    return Join-Path $ProjectInfo.OutputModuleDir "$( $ProjectInfo.ProjectName ).psd1"
+}
+
+function Import-NovaBuiltModuleForCi {
+    [CmdletBinding()]
+    param(
+        [string]$ProjectRoot = (Get-Location).Path,
+        [pscustomobject]$ProjectInfo
+    )
+
+    $resolvedProjectInfo = Resolve-NovaCiProjectInfo -ProjectRoot $ProjectRoot -ProjectInfo $ProjectInfo
+    $moduleManifestPath = Get-NovaBuiltModuleManifestPathForCi -ProjectInfo $resolvedProjectInfo
+    if (-not (Test-Path -LiteralPath $moduleManifestPath)) {
+        throw "Built module manifest not found: $moduleManifestPath"
+    }
+
+    Get-Module -Name $resolvedProjectInfo.ProjectName -All | Remove-Module -Force -ErrorAction SilentlyContinue
+    return Import-Module -Name $moduleManifestPath -Force -Global -PassThru -ErrorAction Stop
+}
+

--- a/src/private/shared/NewNovaDynamicSkipTestsParameterDictionary.ps1
+++ b/src/private/shared/NewNovaDynamicSkipTestsParameterDictionary.ps1
@@ -1,12 +1,23 @@
-function Get-NovaDynamicSkipTestsParameterDictionary {
+function Add-NovaDynamicSwitchParameter {
     [CmdletBinding()]
-    param()
+    param(
+        [Parameter(Mandatory)][System.Management.Automation.RuntimeDefinedParameterDictionary]$ParameterDictionary,
+        [Parameter(Mandatory)][string]$Name
+    )
 
     $attributeCollection = [System.Collections.ObjectModel.Collection[System.Attribute]]::new()
     $attributeCollection.Add([System.Management.Automation.ParameterAttribute]::new())
-    $runtimeParameter = [System.Management.Automation.RuntimeDefinedParameter]::new('SkipTests', [switch],$attributeCollection)
+    $runtimeParameter = [System.Management.Automation.RuntimeDefinedParameter]::new($Name, [switch],$attributeCollection)
+    $ParameterDictionary.Add($Name, $runtimeParameter)
+}
+
+function Get-NovaDynamicDeliveryParameterDictionary {
+    [CmdletBinding()]
+    param()
+
     $parameterDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
-    $parameterDictionary.Add('SkipTests', $runtimeParameter)
+    Add-NovaDynamicSwitchParameter -ParameterDictionary $parameterDictionary -Name 'SkipTests'
+    Add-NovaDynamicSwitchParameter -ParameterDictionary $parameterDictionary -Name 'ContinuousIntegration'
     return $parameterDictionary
 }
 

--- a/src/private/update/WriteNovaAvailableModuleUpdateWarning.ps1
+++ b/src/private/update/WriteNovaAvailableModuleUpdateWarning.ps1
@@ -44,7 +44,7 @@ function Write-NovaAvailableModuleUpdateWarning {
             ''
             'To stop prerelease update notifications:'
             'PS> Set-NovaUpdateNotificationPreference -DisablePrereleaseNotifications'
-            'nova notification --disable'
+            '% nova notification --disable'
             'Stable release notifications remain enabled.'
         )
     }

--- a/src/public/InvokeNovaBuild.ps1
+++ b/src/public/InvokeNovaBuild.ps1
@@ -1,8 +1,10 @@
 function Invoke-NovaBuild {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param (
+        [switch]$ContinuousIntegration
     )
-    $workflowContext = Get-NovaBuildWorkflowContext
+
+    $workflowContext = Get-NovaBuildWorkflowContext -ContinuousIntegrationRequested:$ContinuousIntegration
 
     if (-not $PSCmdlet.ShouldProcess($workflowContext.Target, $workflowContext.Operation)) {
         return

--- a/src/public/InvokeNovaRelease.ps1
+++ b/src/public/InvokeNovaRelease.ps1
@@ -3,6 +3,7 @@ function Invoke-NovaRelease {
     param(
         [hashtable]$PublishOption = @{},
         [switch]$SkipTests,
+        [switch]$ContinuousIntegration,
         [string]$Path = (Get-Location).Path
     )
 
@@ -14,6 +15,7 @@ function Invoke-NovaRelease {
         }
 
         $releasePublishOption.SkipTests = [bool]$SkipTests
+        $releasePublishOption['ContinuousIntegration'] = [bool]$ContinuousIntegration
         $workflowContext = Get-NovaPublishWorkflowContext -ProjectInfo (Get-NovaProjectInfo) -PublishOption $releasePublishOption -WorkflowParams (Get-NovaShouldProcessForwardingParameter -WhatIfEnabled:$WhatIfPreference) -WorkflowSettings @{
             WorkflowName = 'release'
             Release = $true

--- a/src/public/PublishNovaModule.ps1
+++ b/src/public/PublishNovaModule.ps1
@@ -12,11 +12,12 @@ function Publish-NovaModule {
     )
 
     dynamicparam {
-        return Get-NovaDynamicSkipTestsParameterDictionary
+        return Get-NovaDynamicDeliveryParameterDictionary
     }
 
     begin {
         $skipTests = $PSBoundParameters.ContainsKey('SkipTests') -and $PSBoundParameters.SkipTests
+        $continuousIntegration = $PSBoundParameters.ContainsKey('ContinuousIntegration') -and $PSBoundParameters.ContinuousIntegration
 
         $workflowContext = Get-NovaPublishWorkflowContext -ProjectInfo (Get-NovaProjectInfo) -PublishOption @{
             Local = [bool]$Local
@@ -24,6 +25,7 @@ function Publish-NovaModule {
             ModuleDirectoryPath = $ModuleDirectoryPath
             ApiKey = $ApiKey
             SkipTests = [bool]$skipTests
+            'ContinuousIntegration' = [bool]$continuousIntegration
         } -WorkflowParams (Get-NovaShouldProcessForwardingParameter -WhatIfEnabled:$WhatIfPreference) -WorkflowSettings @{
             WorkflowName = 'publish'
             IncludeLocalPublishActivation = $true

--- a/src/public/UpdateNovaModuleVersion.ps1
+++ b/src/public/UpdateNovaModuleVersion.ps1
@@ -2,11 +2,16 @@ function Update-NovaModuleVersion {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(
         [string]$Path = (Get-Location).Path,
-        [switch]$Preview
+        [switch]$Preview,
+        [switch]$ContinuousIntegration
     )
 
     $projectRoot = (Resolve-Path -LiteralPath $Path).Path
-    $workflowContext = Get-NovaVersionUpdateWorkflowContext -ProjectRoot $projectRoot -PreviewRelease:$Preview
+    if ($ContinuousIntegration -and -not $WhatIfPreference) {
+        $null = Import-NovaBuiltModuleForCi -ProjectRoot $projectRoot
+    }
+
+    $workflowContext = Get-NovaVersionUpdateWorkflowContext -ProjectRoot $projectRoot -PreviewRelease:$Preview -ContinuousIntegrationRequested:$ContinuousIntegration
 
 
     $shouldRun = $PSCmdlet.ShouldProcess($workflowContext.Target, $workflowContext.Action)

--- a/src/resources/cli/help/build.psd1
+++ b/src/resources/cli/help/build.psd1
@@ -26,6 +26,12 @@
             Long = '--confirm'
             Placeholder = ''
             Description = 'Request CLI confirmation before the build workflow runs.'
+        },
+        @{
+            Short = '-i'
+            Long = '--continuous-integration'
+            Placeholder = ''
+            Description = 'Re-import the freshly built dist module before returning so later CI steps in the same session use the updated build output.'
         }
     )
     Examples = @(
@@ -36,6 +42,10 @@
         @{
             Command = 'nova build --what-if'
             Description = 'Preview the build workflow without writing output.'
+        },
+        @{
+            Command = 'nova build --continuous-integration'
+            Description = 'Build the project and re-activate the freshly built dist module for later CI steps in the same session.'
         }
     )
 }

--- a/src/resources/cli/help/bump.psd1
+++ b/src/resources/cli/help/bump.psd1
@@ -32,6 +32,12 @@
             Long = '--confirm'
             Placeholder = ''
             Description = 'Request CLI confirmation before the version update runs.'
+        },
+        @{
+            Short = '-i'
+            Long = '--continuous-integration'
+            Placeholder = ''
+            Description = 'Re-import the built dist module before the version bump workflow starts so later CI steps keep using the correct built module state.'
         }
     )
     Examples = @(
@@ -42,6 +48,10 @@
         @{
             Command = 'nova bump --preview --what-if'
             Description = 'Preview the next prerelease version without updating project.json.'
+        },
+        @{
+            Command = 'nova bump --continuous-integration --what-if'
+            Description = 'Preview the next version by using the CI-safe routed bump entrypoint without changing project.json.'
         }
     )
 }

--- a/src/resources/cli/help/publish.psd1
+++ b/src/resources/cli/help/publish.psd1
@@ -57,6 +57,12 @@
             Long = '--skip-tests'
             Placeholder = ''
             Description = 'Skip Test-NovaBuild for this publish run. Build still runs, which is useful when tests already passed earlier in CI/CD.'
+        },
+        @{
+            Short = '-i'
+            Long = '--continuous-integration'
+            Placeholder = ''
+            Description = 'Re-import the built dist module after publish finishes so later CI steps in the same session keep using the built module state.'
         }
     )
     Examples = @(
@@ -71,6 +77,10 @@
         @{
             Command = 'nova publish --repository PSGallery --api-key <key> --skip-tests'
             Description = 'Build and publish the module without re-running Test-NovaBuild.'
+        },
+        @{
+            Command = 'nova publish --repository PSGallery --api-key <key> --continuous-integration'
+            Description = 'Publish the module and then restore the built dist module state for later CI steps in the same session.'
         }
     )
 }

--- a/src/resources/cli/help/release.psd1
+++ b/src/resources/cli/help/release.psd1
@@ -57,6 +57,12 @@
             Long = '--skip-tests'
             Placeholder = ''
             Description = 'Skip the pre-release Test-NovaBuild step. Both build steps still run, which is useful when tests already passed earlier in CI/CD.'
+        },
+        @{
+            Short = '-i'
+            Long = '--continuous-integration'
+            Placeholder = ''
+            Description = 'Re-activate the built dist module at the release workflow boundaries where session state matters so later CI steps keep using the fresh build output.'
         }
     )
     Examples = @(
@@ -71,6 +77,10 @@
         @{
             Command = 'nova release --repository PSGallery --api-key <key> --skip-tests'
             Description = 'Run the release workflow without re-running the pre-release Test-NovaBuild step.'
+        },
+        @{
+            Command = 'nova release --local --continuous-integration --what-if'
+            Description = 'Preview the release workflow and CI-safe reactivation flow without changing files or publishing output.'
         }
     )
 }

--- a/tests/CoverageGaps.BuildInternals.Tests.ps1
+++ b/tests/CoverageGaps.BuildInternals.Tests.ps1
@@ -67,7 +67,68 @@ Describe 'Coverage gaps for build and duplicate-analysis internals' {
         }
     }
 
-    It 'Import-NovaBuiltModuleForCi resolves the built manifest path and imports it globally' {
+    It 'Resolve-NovaCiProjectInfo uses the current location when ProjectRoot is omitted' {
+        $expectedPath = (Get-Location).Path
+
+        InModuleScope $script:moduleName -Parameters @{ExpectedPath = $expectedPath} {
+            param($ExpectedPath)
+
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    ProjectName = 'NovaModuleTools'
+                    OutputModuleDir = '/tmp/dist/NovaModuleTools'
+                }
+            } -ParameterFilter {$Path -eq $ExpectedPath}
+
+            $result = Resolve-NovaCiProjectInfo
+
+            $result.ProjectName | Should -Be 'NovaModuleTools'
+            Assert-MockCalled Get-NovaProjectInfo -Times 1 -ParameterFilter {$Path -eq $ExpectedPath}
+        }
+    }
+
+    It 'Resolve-NovaCiProjectInfo returns the provided ProjectInfo without resolving it again' {
+        InModuleScope $script:moduleName {
+            $projectInfo = [pscustomobject]@{
+                ProjectName = 'NovaModuleTools'
+                OutputModuleDir = '/tmp/dist/NovaModuleTools'
+            }
+            Mock Get-NovaProjectInfo {throw 'should not resolve project info'}
+
+            $result = Resolve-NovaCiProjectInfo -ProjectInfo $projectInfo
+
+            $result | Should -Be $projectInfo
+            Assert-MockCalled Get-NovaProjectInfo -Times 0
+        }
+    }
+
+    It 'Import-NovaBuiltModuleForCi resolves the built manifest path from the current location and imports it globally' {
+        $expectedPath = (Get-Location).Path
+
+        InModuleScope $script:moduleName -Parameters @{ExpectedPath = $expectedPath} {
+            param($ExpectedPath)
+
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    ProjectName = 'NovaModuleTools'
+                    OutputModuleDir = '/tmp/dist/NovaModuleTools'
+                }
+            } -ParameterFilter {$Path -eq $ExpectedPath}
+            Mock Test-Path {$true} -ParameterFilter {$LiteralPath -eq '/tmp/dist/NovaModuleTools/NovaModuleTools.psd1'}
+            Mock Get-Module {@()}
+            Mock Import-Module {
+                [pscustomobject]@{Path = $Name}
+            } -ParameterFilter {$Name -eq '/tmp/dist/NovaModuleTools/NovaModuleTools.psd1' -and $Force -and $Global -and $PassThru}
+
+            $result = Import-NovaBuiltModuleForCi
+
+            $result.Path | Should -Be '/tmp/dist/NovaModuleTools/NovaModuleTools.psd1'
+            Assert-MockCalled Get-NovaProjectInfo -Times 1 -ParameterFilter {$Path -eq $ExpectedPath}
+            Assert-MockCalled Import-Module -Times 1 -ParameterFilter {$Name -eq '/tmp/dist/NovaModuleTools/NovaModuleTools.psd1' -and $Force -and $Global -and $PassThru}
+        }
+    }
+
+    It 'Import-NovaBuiltModuleForCi throws a stable error when the built manifest is missing' {
         InModuleScope $script:moduleName {
             Mock Get-NovaProjectInfo {
                 [pscustomobject]@{
@@ -75,17 +136,14 @@ Describe 'Coverage gaps for build and duplicate-analysis internals' {
                     OutputModuleDir = '/tmp/dist/NovaModuleTools'
                 }
             }
-            Mock Test-Path {$true} -ParameterFilter {$LiteralPath -eq '/tmp/dist/NovaModuleTools/NovaModuleTools.psd1'}
-            Mock Get-Module {@()}
-            Mock Import-Module {
-                [pscustomobject]@{Path = $Name}
-            } -ParameterFilter {$Name -eq '/tmp/dist/NovaModuleTools/NovaModuleTools.psd1' -and $Force -and $Global -and $PassThru}
+            Mock Test-Path {$false} -ParameterFilter {$LiteralPath -eq '/tmp/dist/NovaModuleTools/NovaModuleTools.psd1'}
+            Mock Get-Module {throw 'should not enumerate modules'}
+            Mock Import-Module {throw 'should not import when manifest is missing'}
 
-            $result = Import-NovaBuiltModuleForCi -ProjectRoot '/tmp/project'
+            {Import-NovaBuiltModuleForCi -ProjectRoot '/tmp/project'} | Should -Throw 'Built module manifest not found: /tmp/dist/NovaModuleTools/NovaModuleTools.psd1'
 
-            $result.Path | Should -Be '/tmp/dist/NovaModuleTools/NovaModuleTools.psd1'
-            Assert-MockCalled Get-NovaProjectInfo -Times 1 -ParameterFilter {$Path -eq '/tmp/project'}
-            Assert-MockCalled Import-Module -Times 1 -ParameterFilter {$Name -eq '/tmp/dist/NovaModuleTools/NovaModuleTools.psd1' -and $Force -and $Global -and $PassThru}
+            Assert-MockCalled Get-Module -Times 0
+            Assert-MockCalled Import-Module -Times 0
         }
     }
 

--- a/tests/CoverageGaps.BuildInternals.Tests.ps1
+++ b/tests/CoverageGaps.BuildInternals.Tests.ps1
@@ -47,7 +47,45 @@ Describe 'Coverage gaps for build and duplicate-analysis internals' {
             $result.ProjectInfo.ProjectName | Should -Be 'NovaModuleTools'
             $result.Target | Should -Be '/tmp/dist/NovaModuleTools'
             $result.Operation | Should -Be 'Build Nova module output'
+            $result.ContinuousIntegrationRequested | Should -BeFalse
             Assert-MockCalled Get-NovaBuildProjectInfo -Times 1 -ParameterFilter {$null -eq $ProjectInfo}
+        }
+    }
+
+    It 'Get-NovaBuildWorkflowContext carries ContinuousIntegrationRequested when requested' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaBuildProjectInfo {
+                [pscustomobject]@{
+                    ProjectName = 'NovaModuleTools'
+                    OutputModuleDir = '/tmp/dist/NovaModuleTools'
+                }
+            }
+
+            $result = Get-NovaBuildWorkflowContext -ContinuousIntegrationRequested
+
+            $result.ContinuousIntegrationRequested | Should -BeTrue
+        }
+    }
+
+    It 'Import-NovaBuiltModuleForCi resolves the built manifest path and imports it globally' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    ProjectName = 'NovaModuleTools'
+                    OutputModuleDir = '/tmp/dist/NovaModuleTools'
+                }
+            }
+            Mock Test-Path {$true} -ParameterFilter {$LiteralPath -eq '/tmp/dist/NovaModuleTools/NovaModuleTools.psd1'}
+            Mock Get-Module {@()}
+            Mock Import-Module {
+                [pscustomobject]@{Path = $Name}
+            } -ParameterFilter {$Name -eq '/tmp/dist/NovaModuleTools/NovaModuleTools.psd1' -and $Force -and $Global -and $PassThru}
+
+            $result = Import-NovaBuiltModuleForCi -ProjectRoot '/tmp/project'
+
+            $result.Path | Should -Be '/tmp/dist/NovaModuleTools/NovaModuleTools.psd1'
+            Assert-MockCalled Get-NovaProjectInfo -Times 1 -ParameterFilter {$Path -eq '/tmp/project'}
+            Assert-MockCalled Import-Module -Times 1 -ParameterFilter {$Name -eq '/tmp/dist/NovaModuleTools/NovaModuleTools.psd1' -and $Force -and $Global -and $PassThru}
         }
     }
 

--- a/tests/CoverageGaps.Cli.TestSupport.ps1
+++ b/tests/CoverageGaps.Cli.TestSupport.ps1
@@ -63,3 +63,65 @@ function Assert-TestPublicDocsUrlExists {
     return $resolvedUrl
 }
 
+function Get-TestNovaCliRoutedParserCaseList {
+    return @(
+        @{
+            ParserCommand = 'ConvertFrom-NovaBuildCliArgument'
+            ValidCases = @(
+                @{Arguments = @('--continuous-integration'); Property = 'ContinuousIntegration'}
+                @{Arguments = @('-i'); Property = 'ContinuousIntegration'}
+            )
+        }
+        @{
+            ParserCommand = 'ConvertFrom-NovaBumpCliArgument'
+            ValidCases = @(
+                @{Arguments = @('--preview'); Property = 'Preview'}
+                @{Arguments = @('-p'); Property = 'Preview'}
+                @{Arguments = @('--continuous-integration'); Property = 'ContinuousIntegration'}
+                @{Arguments = @('-i'); Property = 'ContinuousIntegration'}
+            )
+        }
+        @{
+            ParserCommand = 'ConvertFrom-NovaTestCliArgument'
+            ValidCases = @(
+                @{Arguments = @('--build'); Property = 'Build'}
+                @{Arguments = @('-b'); Property = 'Build'}
+            )
+        }
+    )
+}
+
+function Get-TestNovaCliContinuousIntegrationRouteCaseList {
+    return @(
+        @{Command = 'build'; ParserCommand = 'ConvertFrom-NovaBuildCliArgument'; ActionCommand = 'Invoke-NovaBuild'}
+        @{Command = 'bump'; ParserCommand = 'ConvertFrom-NovaBumpCliArgument'; ActionCommand = 'Update-NovaModuleVersion'}
+    )
+}
+
+function Get-TestNovaCliNormalizedRootCommandCaseList {
+    return @(
+        @{Command = '-h'; Expected = '--help'}
+        @{Command = '-v'; Expected = '--version'}
+        @{Command = 'build'; Expected = 'build'}
+    )
+}
+
+function Get-TestNovaCliOptionClassificationCaseList {
+    return @(
+        @{HelperName = 'Test-NovaCliLegacySingleHyphenOption'; Argument = '-legacy'; Expected = $true}
+        @{HelperName = 'Test-NovaCliLegacySingleHyphenOption'; Argument = '--legacy'; Expected = $false}
+        @{HelperName = 'Test-NovaCliWhatIfOption'; Argument = '--what-if'; Expected = $true}
+        @{HelperName = 'Test-NovaCliConfirmOption'; Argument = '-c'; Expected = $true}
+    )
+}
+
+function Get-TestNovaCliSyntaxGuidanceCaseList {
+    return @(
+        @{Argument = '-legacy'; Message = "Unsupported CLI option syntax: -legacy. Use long options with '--' or single-character short options."}
+        @{Argument = '--whatif'; Message = "Unsupported CLI option syntax: --whatif. Use '--what-if' or '-w' instead."}
+        @{Argument = '-build'; Message = "Unsupported CLI option syntax: -build. Use '--build' or '-b' instead."}
+        @{Argument = '-skiptests'; Message = "Unsupported CLI option syntax: -skiptests. Use '--skip-tests' or '-s' instead."}
+        @{Argument = '-continuousintegration'; Message = "Unsupported CLI option syntax: -continuousintegration. Use '--continuous-integration' or '-i' instead."}
+    )
+}
+

--- a/tests/CoverageGaps.Cli.Tests.ps1
+++ b/tests/CoverageGaps.Cli.Tests.ps1
@@ -9,6 +9,11 @@ $global:coverageGapsCliTestSupportFunctionNameList = @(
     'Assert-TestStructuredCliError'
     'Resolve-TestPublicDocsUrl'
     'Assert-TestPublicDocsUrlExists'
+    'Get-TestNovaCliRoutedParserCaseList'
+    'Get-TestNovaCliContinuousIntegrationRouteCaseList'
+    'Get-TestNovaCliNormalizedRootCommandCaseList'
+    'Get-TestNovaCliOptionClassificationCaseList'
+    'Get-TestNovaCliSyntaxGuidanceCaseList'
 )
 . $script:gitTestSupportPath
 . $script:coverageGapsCliTestSupportPath
@@ -338,47 +343,31 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
         }
     }
 
-    It 'ConvertFrom-NovaBumpCliArgument parses the preview switch and rejects unsupported bump arguments' {
-        InModuleScope $script:moduleName {
-            (ConvertFrom-NovaBumpCliArgument -Arguments @('--preview')).Preview | Should -BeTrue
-            (ConvertFrom-NovaBumpCliArgument -Arguments @('-p')).Preview | Should -BeTrue
+    It 'routed CLI parsers accept supported switches and reject unsupported arguments' {
+        foreach ($testCase in (Get-TestNovaCliRoutedParserCaseList)) {
+            InModuleScope $script:moduleName -Parameters @{TestCase = $testCase} {
+                param($TestCase)
 
-            $unknownArgumentError = $null
-            try {
-                ConvertFrom-NovaBumpCliArgument -Arguments @('--bogus')
+                foreach ($validCase in $TestCase.ValidCases) {
+                    $options = & $TestCase.ParserCommand -Arguments $validCase.Arguments
+                    $options[$validCase.Property] | Should -BeTrue
+                }
+
+                $unknownArgumentError = $null
+                try {
+                    & $TestCase.ParserCommand -Arguments @('--bogus')
+                }
+                catch {
+                    $unknownArgumentError = $_
+                }
+
+                Assert-TestStructuredCliError -ThrownError $unknownArgumentError -ExpectedError ([pscustomobject]@{
+                    Message = 'Unknown argument: --bogus'
+                    ErrorId = 'Nova.Validation.UnknownCliArgument'
+                    Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                    TargetObject = '--bogus'
+                })
             }
-            catch {
-                $unknownArgumentError = $_
-            }
-
-            Assert-TestStructuredCliError -ThrownError $unknownArgumentError -ExpectedError ([pscustomobject]@{
-                Message = 'Unknown argument: --bogus'
-                ErrorId = 'Nova.Validation.UnknownCliArgument'
-                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
-                TargetObject = '--bogus'
-            })
-        }
-    }
-
-    It 'ConvertFrom-NovaTestCliArgument parses the build switch and rejects unsupported test arguments' {
-        InModuleScope $script:moduleName {
-            (ConvertFrom-NovaTestCliArgument -Arguments @('--build')).Build | Should -BeTrue
-            (ConvertFrom-NovaTestCliArgument -Arguments @('-b')).Build | Should -BeTrue
-
-            $unknownArgumentError = $null
-            try {
-                ConvertFrom-NovaTestCliArgument -Arguments @('--bogus')
-            }
-            catch {
-                $unknownArgumentError = $_
-            }
-
-            Assert-TestStructuredCliError -ThrownError $unknownArgumentError -ExpectedError ([pscustomobject]@{
-                Message = 'Unknown argument: --bogus'
-                ErrorId = 'Nova.Validation.UnknownCliArgument'
-                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
-                TargetObject = '--bogus'
-            })
         }
     }
 
@@ -663,6 +652,38 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
         }
     }
 
+    It 'Invoke-NovaCliCommandRoute forwards ContinuousIntegration to build and bump commands' {
+        foreach ($testCase in (Get-TestNovaCliContinuousIntegrationRouteCaseList)) {
+            InModuleScope $script:moduleName -Parameters @{TestCase = $testCase} {
+                param($TestCase)
+
+                $invocationContext = [pscustomobject]@{
+                    Command = $TestCase.Command
+                    Arguments = @('--continuous-integration')
+                    CommonParameters = @{}
+                    MutatingCommonParameters = @{WhatIf = $true}
+                    IsHelpRequest = $false
+                    HelpRequest = $null
+                    ModuleName = 'NovaModuleTools'
+                    WhatIfEnabled = $true
+                    CliConfirmEnabled = $false
+                }
+
+                Mock $TestCase.ParserCommand {@{ContinuousIntegration = $true}}
+                Mock $TestCase.ActionCommand {
+                    param([switch]$ContinuousIntegration, [switch]$WhatIf)
+
+                    [pscustomobject]@{Feature = $ContinuousIntegration.IsPresent; WhatIf = $WhatIf.IsPresent}
+                }
+
+                $result = Invoke-NovaCliCommandRoute -InvocationContext $invocationContext
+
+                $result.Feature | Should -BeTrue
+                $result.WhatIf | Should -BeTrue
+            }
+        }
+    }
+
     It 'Get-NovaCliCommandHelp renders CLI-native command help without calling Get-Help' {
         InModuleScope $script:moduleName {
             Mock Get-Help {throw 'CLI help should not call Get-Help'}
@@ -712,75 +733,46 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
         }
     }
 
-    It 'CLI routing helpers cover normalized root help, option classification, and generic syntax guidance' {
-        InModuleScope $script:moduleName {
-            (Get-NovaCliNormalizedRootCommand -Command '-h') | Should -Be '--help'
-            (Get-NovaCliNormalizedRootCommand -Command '-v') | Should -Be '--version'
-            (Get-NovaCliNormalizedRootCommand -Command 'build') | Should -Be 'build'
-            (Test-NovaCliLegacySingleHyphenOption -Argument '-legacy') | Should -BeTrue
-            (Test-NovaCliLegacySingleHyphenOption -Argument '--legacy') | Should -BeFalse
-            (Test-NovaCliWhatIfOption -Argument '--what-if') | Should -BeTrue
-            (Test-NovaCliConfirmOption -Argument '-c') | Should -BeTrue
+    It 'Get-NovaCliNormalizedRootCommand normalizes root aliases' {
+        foreach ($testCase in (Get-TestNovaCliNormalizedRootCommandCaseList)) {
+            InModuleScope $script:moduleName -Parameters @{TestCase = $testCase} {
+                param($TestCase)
 
-            $genericSyntaxError = $null
-            try {
-                Assert-NovaCliArgumentSyntax -Arguments @('-legacy')
+                (Get-NovaCliNormalizedRootCommand -Command $TestCase.Command) | Should -Be $TestCase.Expected
             }
-            catch {
-                $genericSyntaxError = $_
-            }
+        }
+    }
 
-            Assert-TestStructuredCliError -ThrownError $genericSyntaxError -ExpectedError ([pscustomobject]@{
-                Message = "Unsupported CLI option syntax: -legacy. Use long options with '--' or single-character short options."
-                ErrorId = 'Nova.Validation.UnsupportedCliOptionSyntax'
-                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
-                TargetObject = '-legacy'
-            })
+    It 'CLI routing helpers classify routed options correctly' {
+        foreach ($testCase in (Get-TestNovaCliOptionClassificationCaseList)) {
+            InModuleScope $script:moduleName -Parameters @{TestCase = $testCase} {
+                param($TestCase)
 
-            $deprecatedWhatIfError = $null
-            try {
-                Assert-NovaCliArgumentSyntax -Arguments @('--whatif')
+                (& $TestCase.HelperName -Argument $TestCase.Argument) | Should -Be $TestCase.Expected
             }
-            catch {
-                $deprecatedWhatIfError = $_
-            }
+        }
+    }
 
-            Assert-TestStructuredCliError -ThrownError $deprecatedWhatIfError -ExpectedError ([pscustomobject]@{
-                Message = "Unsupported CLI option syntax: --whatif. Use '--what-if' or '-w' instead."
-                ErrorId = 'Nova.Validation.UnsupportedCliOptionSyntax'
-                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
-                TargetObject = '--whatif'
-            })
+    It 'Assert-NovaCliArgumentSyntax returns migration guidance for unsupported routed options' {
+        foreach ($testCase in (Get-TestNovaCliSyntaxGuidanceCaseList)) {
+            InModuleScope $script:moduleName -Parameters @{TestCase = $testCase} {
+                param($TestCase)
 
-            $deprecatedBuildError = $null
-            try {
-                Assert-NovaCliArgumentSyntax -Arguments @('-build')
-            }
-            catch {
-                $deprecatedBuildError = $_
-            }
+                $syntaxError = $null
+                try {
+                    Assert-NovaCliArgumentSyntax -Arguments @($TestCase.Argument)
+                }
+                catch {
+                    $syntaxError = $_
+                }
 
-            Assert-TestStructuredCliError -ThrownError $deprecatedBuildError -ExpectedError ([pscustomobject]@{
-                Message = "Unsupported CLI option syntax: -build. Use '--build' or '-b' instead."
-                ErrorId = 'Nova.Validation.UnsupportedCliOptionSyntax'
-                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
-                TargetObject = '-build'
-            })
-
-            $deprecatedSkipTestsError = $null
-            try {
-                Assert-NovaCliArgumentSyntax -Arguments @('-skiptests')
+                Assert-TestStructuredCliError -ThrownError $syntaxError -ExpectedError ([pscustomobject]@{
+                    Message = $TestCase.Message
+                    ErrorId = 'Nova.Validation.UnsupportedCliOptionSyntax'
+                    Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                    TargetObject = $TestCase.Argument
+                })
             }
-            catch {
-                $deprecatedSkipTestsError = $_
-            }
-
-            Assert-TestStructuredCliError -ThrownError $deprecatedSkipTestsError -ExpectedError ([pscustomobject]@{
-                Message = "Unsupported CLI option syntax: -skiptests. Use '--skip-tests' or '-s' instead."
-                ErrorId = 'Nova.Validation.UnsupportedCliOptionSyntax'
-                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
-                TargetObject = '-skiptests'
-            })
         }
     }
 
@@ -863,14 +855,15 @@ catch {
         }
     }
 
-    It 'ConvertFrom-NovaCliArgument parses local, path, api key, and skip-tests options' {
+    It 'ConvertFrom-NovaCliArgument parses local, path, api key, skip-tests, and continuous integration options' {
         InModuleScope $script:moduleName {
-            $options = ConvertFrom-NovaCliArgument -Arguments @('--local', '--path', '/tmp/modules', '--api-key', 'secret', '--skip-tests')
+            $options = ConvertFrom-NovaCliArgument -Arguments @('--local', '--path', '/tmp/modules', '--api-key', 'secret', '--skip-tests', '--continuous-integration')
 
             $options.Local | Should -BeTrue
             $options.ModuleDirectoryPath | Should -Be '/tmp/modules'
             $options.ApiKey | Should -Be 'secret'
             $options.SkipTests | Should -BeTrue
+            $options.ContinuousIntegration | Should -BeTrue
         }
     }
 

--- a/tests/NovaCommandModel.BumpAndCli.Tests.ps1
+++ b/tests/NovaCommandModel.BumpAndCli.Tests.ps1
@@ -104,11 +104,35 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
             $result.CommitCount | Should -Be 2
             $result.Target | Should -Be 'project.json'
             $result.Action | Should -Be 'Update module version using Minor release label'
+            $result.'ContinuousIntegrationRequested' | Should -BeFalse
             Assert-MockCalled Get-NovaVersionUpdatePlan -Times 1 -ParameterFilter {
                 $ProjectInfo.ProjectName -eq 'NovaModuleTools' -and
                         $Label -eq 'Minor' -and
                         -not $PreviewRelease
             }
+        }
+    }
+
+    It 'Get-NovaVersionUpdateWorkflowContext carries ContinuousIntegrationRequested when requested' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    ProjectName = 'NovaModuleTools'
+                    Version = '1.0.0'
+                    ProjectJSON = '/tmp/project.json'
+                }
+            }
+            Mock Get-GitCommitMessageForVersionBump {@('feat: add change')}
+            Mock Get-NovaVersionLabelForBump {'Minor'}
+            Mock Get-NovaVersionUpdatePlan {
+                [pscustomobject]@{
+                    NewVersion = [semver]'1.1.0'
+                }
+            }
+
+            $result = Get-NovaVersionUpdateWorkflowContext -ProjectRoot '/tmp/project' -ContinuousIntegrationRequested
+
+            $result.'ContinuousIntegrationRequested' | Should -BeTrue
         }
     }
 
@@ -162,8 +186,61 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
         }
     }
 
+    It 'Update-NovaModuleVersion imports the built module before preparing the workflow in CI mode' {
+        InModuleScope $script:moduleName {
+            $script:steps = @()
+
+            Mock Resolve-Path {[pscustomobject]@{Path = '/tmp/current-project'}} -ParameterFilter {$LiteralPath -eq '/tmp/current-project'}
+            Mock Import-NovaBuiltModuleForCi {$script:steps += 'import'}
+            Mock Get-NovaVersionUpdateWorkflowContext {
+                $script:steps += 'context'
+                [pscustomobject]@{
+                    Target = 'project.json'
+                    Action = 'Update module version using Minor release label'
+                }
+            }
+            Mock Invoke-NovaVersionUpdateWorkflow {
+                $script:steps += 'workflow'
+                [pscustomobject]@{NewVersion = '1.1.0'}
+            }
+
+            $result = Update-NovaModuleVersion -Path '/tmp/current-project' -ContinuousIntegration -Confirm:$false
+
+            $result.NewVersion | Should -Be '1.1.0'
+            $script:steps | Should -Be @('import', 'context', 'workflow')
+            Assert-MockCalled Import-NovaBuiltModuleForCi -Times 1 -ParameterFilter {$ProjectRoot -eq '/tmp/current-project'}
+            Assert-MockCalled Get-NovaVersionUpdateWorkflowContext -Times 1 -ParameterFilter {$ProjectRoot -eq '/tmp/current-project' -and $ContinuousIntegrationRequested}
+        }
+    }
+
     It 'Update-NovaModuleVersion defaults Path to the current location when Path is omitted' {
         Invoke-UpdateNovaModuleVersionDefaultPathAssertion -ModuleName $script:moduleName
+    }
+
+    It 'Update-NovaModuleVersion -WhatIf stays side-effect free in CI mode' {
+        InModuleScope $script:moduleName {
+            Mock Resolve-Path {[pscustomobject]@{Path = '/tmp/current-project'}} -ParameterFilter {$LiteralPath -eq '/tmp/current-project'}
+            Mock Import-NovaBuiltModuleForCi {throw 'should not import during WhatIf'}
+            Mock Get-NovaVersionUpdateWorkflowContext {
+                [pscustomobject]@{
+                    PreviousVersion = '1.0.0'
+                    NewVersion = '1.1.0'
+                    Label = 'Minor'
+                    CommitCount = 1
+                    Target = 'project.json'
+                    Action = 'Update module version using Minor release label'
+                }
+            }
+            Mock Invoke-NovaVersionUpdateWorkflow {
+                [pscustomobject]@{NewVersion = '1.1.0'}
+            }
+
+            $result = Update-NovaModuleVersion -Path '/tmp/current-project' -ContinuousIntegration -WhatIf
+
+            $result.NewVersion | Should -Be '1.1.0'
+            Assert-MockCalled Import-NovaBuiltModuleForCi -Times 0
+            Assert-MockCalled Get-NovaVersionUpdateWorkflowContext -Times 1 -ParameterFilter {$ContinuousIntegrationRequested}
+        }
     }
 
     It 'Update-NovaModuleVersion -WhatIf returns the expected next version without persisting it when <Name>' -ForEach @(

--- a/tests/NovaCommandModel.ReleasePublish.Tests.ps1
+++ b/tests/NovaCommandModel.ReleasePublish.Tests.ps1
@@ -179,13 +179,37 @@ Describe 'Nova command model - release and publish behavior' {
             $result.PublishParams.WhatIf | Should -BeTrue
             $result.PublishInvocation.IsLocal | Should -BeTrue
             $result.SkipTestsRequested | Should -BeFalse
+            $result.'ContinuousIntegrationRequested' | Should -BeFalse
             $result.Operation | Should -Be 'Run Nova release workflow (build, test, and publish) to local directory'
             $result.LocalPublishActivation | Should -BeNullOrEmpty
         }
     }
 
-    It 'Get-NovaPublishWorkflowContext composes skip-tests release workflow context when requested' {
-        InModuleScope $script:moduleName {
+    It 'Get-NovaPublishWorkflowContext carries delivery workflow flags when requested' -ForEach @(
+        @{
+            PublishOption = @{Repository = 'PSGallery'; SkipTests = $true}
+            WorkflowSettings = @{WorkflowName = 'release'; Release = $true}
+            Assert = {
+                param($Result)
+
+                $Result.SkipTestsRequested | Should -BeTrue
+                $Result.Operation | Should -Be 'Run Nova release workflow (build and publish) to repository'
+            }
+        }
+        @{
+            PublishOption = @{Repository = 'PSGallery'; ContinuousIntegration = $true}
+            WorkflowSettings = @{WorkflowName = 'publish'}
+            Assert = {
+                param($Result)
+
+                $Result.'ContinuousIntegrationRequested' | Should -BeTrue
+                $Result.ProjectInfo.ProjectName | Should -Be 'NovaModuleTools'
+            }
+        }
+    ) {
+        InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+            param($TestCase)
+
             Mock Resolve-NovaPublishInvocation {
                 [pscustomobject]@{
                     Target = 'PSGallery'
@@ -200,13 +224,9 @@ Describe 'Nova command model - release and publish behavior' {
                 OutputModuleDir = '/tmp/dist/NovaModuleTools'
             }
 
-            $result = Get-NovaPublishWorkflowContext -ProjectInfo $projectInfo -PublishOption @{Repository = 'PSGallery'; SkipTests = $true} -WorkflowSettings @{
-                WorkflowName = 'release'
-                Release = $true
-            }
+            $result = Get-NovaPublishWorkflowContext -ProjectInfo $projectInfo -PublishOption $TestCase.PublishOption -WorkflowSettings $TestCase.WorkflowSettings
 
-            $result.SkipTestsRequested | Should -BeTrue
-            $result.Operation | Should -Be 'Run Nova release workflow (build and publish) to repository'
+            & $TestCase.Assert $result
         }
     }
 
@@ -235,6 +255,53 @@ Describe 'Nova command model - release and publish behavior' {
             Assert-MockCalled Get-NovaPublishWorkflowContext -Times 1 -ParameterFilter {$WorkflowSettings.WorkflowName -eq 'release' -and $WorkflowSettings.Release}
             Assert-MockCalled Write-NovaPublishWorkflowContext -Times 1
             Assert-MockCalled Invoke-NovaReleaseWorkflow -Times 1
+        }
+    }
+
+    It '<CommandName> forwards ContinuousIntegration into its shared workflow context' -ForEach @(
+        @{
+            CommandName = 'Invoke-NovaRelease'
+            WorkflowName = 'release'
+            Operation = 'Run Nova release workflow (build, test, and publish) to repository'
+            Invoke = {
+                Invoke-NovaRelease -PublishOption @{Repository = 'PSGallery'} -ContinuousIntegration -Path (Get-Location).Path -Confirm:$false
+            }
+        }
+        @{
+            CommandName = 'Publish-NovaModule'
+            WorkflowName = 'publish'
+            Operation = 'Build, test, and publish Nova module to repository'
+            Invoke = {
+                Publish-NovaModule -Repository PSGallery -ApiKey key123 -ContinuousIntegration -Confirm:$false
+            }
+        }
+    ) {
+        InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+            param($TestCase)
+
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{ProjectName = 'NovaModuleTools'}
+            }
+            Mock Get-NovaPublishWorkflowContext {
+                [pscustomobject]@{
+                    WorkflowName = $TestCase.WorkflowName
+                    LocalRequested = $false
+                    PublishInvocation = [pscustomobject]@{IsLocal = $false}
+                    Target = 'PSGallery'
+                    Operation = $TestCase.Operation
+                }
+            }
+            Mock Write-NovaPublishWorkflowContext {}
+            if ($TestCase.WorkflowName -eq 'release') {
+                Mock Invoke-NovaReleaseWorkflow {}
+            }
+            else {
+                Mock Invoke-NovaPublishWorkflow {}
+            }
+
+            & $TestCase.Invoke | Out-Null
+
+            Assert-MockCalled Get-NovaPublishWorkflowContext -Times 1 -ParameterFilter {$PublishOption.ContinuousIntegration -and $PublishOption.Repository -eq 'PSGallery'}
         }
     }
 
@@ -346,6 +413,55 @@ Describe 'Nova command model - release and publish behavior' {
         }
     }
 
+    It 'Invoke-NovaPublishWorkflow restores the built module in CI mode for <Name>' -ForEach @(
+        @{
+            Name = 'repository publish'
+            UseLocalPublishActivation = $false
+            ExpectedSteps = 'build,test,publish,ci'
+        }
+        @{
+            Name = 'local publish'
+            UseLocalPublishActivation = $true
+            ExpectedSteps = 'build,test,publish,import,ci'
+        }
+    ) {
+        InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+            param($TestCase)
+
+            $script:steps = @()
+
+            Mock Invoke-NovaBuild {$script:steps += 'build'}
+            Mock Test-NovaBuild {$script:steps += 'test'}
+            Mock Import-NovaBuiltModuleForCi {$script:steps += 'ci'}
+            $localPublishActivation = $null
+            if ($TestCase.UseLocalPublishActivation) {
+                $localPublishActivation = [pscustomobject]@{
+                    ManifestPath = '/tmp/modules/NovaModuleTools/NovaModuleTools.psd1'
+                    ImportAction = {param($ProjectName, $ManifestPath) $script:steps += 'import'}
+                }
+            }
+
+            $workflowContext = [pscustomobject]@{
+                ProjectInfo = [pscustomobject]@{ProjectName = 'NovaModuleTools'}
+                WorkflowParams = @{}
+                ContinuousIntegrationRequested = $true
+                PublishInvocation = [pscustomobject]@{
+                    Parameters = @{
+                        ProjectInfo = [pscustomobject]@{ProjectName = 'NovaModuleTools'}
+                    }
+                    Action = {$script:steps += 'publish'}
+                }
+                PublishParams = @{}
+                LocalPublishActivation = $localPublishActivation
+            }
+
+            Invoke-NovaPublishWorkflow -WorkflowContext $workflowContext -ShouldRun | Out-Null
+
+            $script:steps -join ',' | Should -Be $TestCase.ExpectedSteps
+            Assert-MockCalled Import-NovaBuiltModuleForCi -Times 1 -ParameterFilter {$ProjectInfo.ProjectName -eq 'NovaModuleTools'}
+        }
+    }
+
     It 'Invoke-NovaPublishWorkflow skips tests when SkipTests is requested' {
         InModuleScope $script:moduleName {
             $script:steps = @()
@@ -417,6 +533,45 @@ Describe 'Nova command model - release and publish behavior' {
 
             $result | Should -BeNullOrEmpty
             $script:steps -join ',' | Should -Be 'build:True,test:True,publish:True'
+        }
+    }
+
+    It 'Invoke-NovaReleaseWorkflow forwards ContinuousIntegration into nested build and bump steps and restores the built module after publish' {
+        InModuleScope $script:moduleName {
+            $script:steps = @()
+
+            Mock Invoke-NovaBuild {
+                param([switch]$ContinuousIntegration)
+
+                $script:steps += "build:$( [bool]$ContinuousIntegration )"
+            }
+            Mock Test-NovaBuild {
+                $script:steps += 'test'
+            }
+            Mock Update-NovaModuleVersion {
+                param([switch]$ContinuousIntegration)
+
+                $script:steps += "bump:$( [bool]$ContinuousIntegration )"
+                [pscustomobject]@{NewVersion = '1.0.1'}
+            }
+            Mock Import-NovaBuiltModuleForCi {
+                $script:steps += 'ci'
+            }
+            $workflowContext = [pscustomobject]@{
+                ProjectInfo = [pscustomobject]@{ProjectName = 'NovaModuleTools'}
+                WorkflowParams = @{}
+                ContinuousIntegrationRequested = $true
+                SkipTestsRequested = $false
+                PublishInvocation = [pscustomobject]@{
+                    Action = {$script:steps += 'publish'}
+                }
+                PublishParams = @{}
+            }
+
+            Invoke-NovaReleaseWorkflow -WorkflowContext $workflowContext | Out-Null
+
+            $script:steps | Should -Be @('build:True', 'test', 'bump:True', 'build:True', 'publish', 'ci')
+            Assert-MockCalled Import-NovaBuiltModuleForCi -Times 1 -ParameterFilter {$ProjectInfo.ProjectName -eq 'NovaModuleTools'}
         }
     }
 

--- a/tests/NovaCommandModel.StandaloneCli.Tests.ps1
+++ b/tests/NovaCommandModel.StandaloneCli.Tests.ps1
@@ -13,6 +13,9 @@ Publish-TestSupportFunctions -FunctionNameList @(
     'Write-TestNovaCliPublicFunction'
     'Initialize-TestNovaCliGitRepository'
     'Invoke-TestInstalledNovaCommand'
+    'Get-TestNovaCliWhatIfResultMap'
+    'Assert-TestNovaCliWhatIfResultMap'
+    'Get-TestNovaCliContinuousIntegrationForwardingCaseList'
     'New-TestPesterConfigStub'
     'Get-TestInstalledNovaCliSnapshot'
     'Assert-TestInstalledNovaCliSnapshot'
@@ -45,6 +48,9 @@ BeforeAll {
         'Write-TestNovaCliPublicFunction'
         'Initialize-TestNovaCliGitRepository'
         'Invoke-TestInstalledNovaCommand'
+        'Get-TestNovaCliWhatIfResultMap'
+        'Assert-TestNovaCliWhatIfResultMap'
+        'Get-TestNovaCliContinuousIntegrationForwardingCaseList'
         'New-TestPesterConfigStub'
         'Get-TestInstalledNovaCliSnapshot'
         'Assert-TestInstalledNovaCliSnapshot'
@@ -153,7 +159,7 @@ function Invoke-TestCliVerbose {
         }
     }
 
-    It 'Install-NovaCli forwards --what-if and -w from the standalone launcher without mutating build, test, bump, or publish state' {
+    It 'Install-NovaCli forwards --what-if, -w, and CI-safe routed options without mutating build, test, bump, publish, or release state' {
         $targetDirectory = Join-Path $TestDrive 'whatif-bin'
         $installedPath = Join-Path $targetDirectory 'nova'
         $projectRoot = Join-Path $TestDrive 'CliWhatIfProject'
@@ -183,35 +189,9 @@ Describe 'CLI WhatIf test project' {
 }
 '@ | Set-Content -LiteralPath (Join-Path $projectRoot 'tests/CliWhatIf.Tests.ps1') -Encoding utf8
 
-            $buildResult = Invoke-TestInstalledNovaCommand -InstalledPath $installedPath -WorkingDirectory $projectRoot -Arguments @('build', '--what-if')
-            $shortTestResult = Invoke-TestInstalledNovaCommand -InstalledPath $installedPath -WorkingDirectory $projectRoot -Arguments @('test', '-w')
-            $longTestResult = Invoke-TestInstalledNovaCommand -InstalledPath $installedPath -WorkingDirectory $projectRoot -Arguments @('test', '--what-if')
-            $publishResult = Invoke-TestInstalledNovaCommand -InstalledPath $installedPath -WorkingDirectory $projectRoot -Arguments @('publish', '--local', '-w')
-            $bumpResult = Invoke-TestInstalledNovaCommand -InstalledPath $installedPath -WorkingDirectory $projectRoot -Arguments @('bump', '-w')
-            $previewBumpResult = Invoke-TestInstalledNovaCommand -InstalledPath $installedPath -WorkingDirectory $projectRoot -Arguments @('bump', '--preview', '--what-if')
-            $versionAfterBump = (Get-Content -LiteralPath $projectJsonPath -Raw | ConvertFrom-Json).Version
+            $resultMap = Get-TestNovaCliWhatIfResultMap -InstalledPath $installedPath -ProjectRoot $projectRoot
 
-            $buildResult.ExitCode | Should -Be 0
-            $shortTestResult.ExitCode | Should -Be 0
-            $longTestResult.ExitCode | Should -Be 0
-            $publishResult.ExitCode | Should -Be 0
-            $bumpResult.ExitCode | Should -Be 0
-            $previewBumpResult.ExitCode | Should -Be 0
-            $buildResult.Text | Should -Match 'What if:'
-            $shortTestResult.Text | Should -Match 'What if:'
-            $longTestResult.Text | Should -Match 'What if:'
-            $publishResult.Text | Should -Match 'What if:'
-            $publishResult.Text | Should -Not -Match 'Unknown argument:'
-            $bumpResult.Text | Should -Match 'What if:'
-            $bumpResult.Text | Should -Match '0\.0\.1\s+0\.1\.0\s+Minor\s+1'
-            $previewBumpResult.Text | Should -Match 'What if:'
-            $previewBumpResult.Text | Should -Match '0\.0\.1\s+0\.1\.0-preview\s+Minor\s+1'
-            $bumpResult.Text | Should -Not -Match 'Version bumped to :'
-            $previewBumpResult.Text | Should -Not -Match 'Unknown argument:'
-            $previewBumpResult.Text | Should -Not -Match 'Version bumped to :'
-            $versionAfterBump | Should -Be '0.0.1'
-            (Test-Path -LiteralPath $builtModulePath) | Should -BeFalse
-            (Test-Path -LiteralPath $testResultPath) | Should -BeFalse
+            Assert-TestNovaCliWhatIfResultMap -ResultMap $resultMap -ProjectJsonPath $projectJsonPath -BuiltModulePath $builtModulePath -TestResultPath $testResultPath
         }
         finally {
             $env:PSModulePath = $originalModulePath
@@ -541,6 +521,23 @@ Describe '$projectName tests' {
         }
     }
 
+    It 'Invoke-NovaCli help for build, bump, publish, and release documents the continuous integration options' -ForEach @(
+        @{CommandName = 'build'}
+        @{CommandName = 'bump'}
+        @{CommandName = 'publish'}
+        @{CommandName = 'release'}
+    ) {
+        InModuleScope $script:moduleName -Parameters @{CommandName = $_.CommandName} {
+            param($CommandName)
+
+            $shortHelp = Invoke-NovaCli -Command $CommandName -Arguments @('--help')
+            $longHelp = Invoke-NovaCli -Command '--help' -Arguments @($CommandName)
+
+            $shortHelp | Should -Match '-i, --continuous-integration'
+            $longHelp | Should -Match '--continuous-integration'
+        }
+    }
+
     It 'Invoke-NovaCli CLI help never delegates to PowerShell Get-Help' {
         InModuleScope $script:moduleName {
             Mock Get-Help {throw 'CLI help should not call Get-Help'}
@@ -576,6 +573,29 @@ Describe '$projectName tests' {
             $result = Invoke-NovaCli package --skip-tests
 
             $result.SkipTests | Should -BeTrue
+        }
+    }
+
+    It 'Invoke-NovaCli forwards continuous integration for routed build, bump, publish, and release commands' {
+        foreach ($testCase in (Get-TestNovaCliContinuousIntegrationForwardingCaseList)) {
+            InModuleScope $script:moduleName -Parameters @{TestCase = $testCase} {
+                param($TestCase)
+
+                if ($TestCase.UsesPublishOption) {
+                    Mock $TestCase.ActionCommand {
+                        [pscustomobject]@{ContinuousIntegration = [bool]$PublishOption.ContinuousIntegration}
+                    }
+                }
+                else {
+                    Mock $TestCase.ActionCommand {
+                        [pscustomobject]@{ContinuousIntegration = $ContinuousIntegration.IsPresent}
+                    }
+                }
+
+                $result = Invoke-NovaCli -Command $TestCase.CommandName -Arguments $TestCase.Arguments
+
+                $result.ContinuousIntegration | Should -BeTrue
+            }
         }
     }
 
@@ -755,6 +775,7 @@ Describe '$projectName tests' {
         }
     }
 
+
     It 'Invoke-NovaCli publish uses the CLI confirmation wrapper for --confirm and -c without forwarding raw Confirm' {
         InModuleScope $script:moduleName {
             Mock Confirm-NovaCliCommandAction {}
@@ -806,6 +827,7 @@ Describe '$projectName tests' {
             $result.SkipTests | Should -BeTrue
         }
     }
+
 
     It 'Invoke-NovaCli forwards WhatIf to mutating routed commands' {
         InModuleScope $script:moduleName {

--- a/tests/NovaCommandModel.TestSupport/CliProjectSupport.ps1
+++ b/tests/NovaCommandModel.TestSupport/CliProjectSupport.ps1
@@ -121,3 +121,67 @@ function Invoke-TestInstalledNovaCommand {
     }
 }
 
+function Get-TestNovaCliWhatIfResultMap {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$InstalledPath,
+        [Parameter(Mandatory)][string]$ProjectRoot
+    )
+
+    return @{
+        Build = Invoke-TestInstalledNovaCommand -InstalledPath $InstalledPath -WorkingDirectory $ProjectRoot -Arguments @('build', '--what-if')
+        BuildCi = Invoke-TestInstalledNovaCommand -InstalledPath $InstalledPath -WorkingDirectory $ProjectRoot -Arguments @('build', '--continuous-integration', '--what-if')
+        TestShort = Invoke-TestInstalledNovaCommand -InstalledPath $InstalledPath -WorkingDirectory $ProjectRoot -Arguments @('test', '-w')
+        TestLong = Invoke-TestInstalledNovaCommand -InstalledPath $InstalledPath -WorkingDirectory $ProjectRoot -Arguments @('test', '--what-if')
+        Publish = Invoke-TestInstalledNovaCommand -InstalledPath $InstalledPath -WorkingDirectory $ProjectRoot -Arguments @('publish', '--local', '-w')
+        PublishCi = Invoke-TestInstalledNovaCommand -InstalledPath $InstalledPath -WorkingDirectory $ProjectRoot -Arguments @('publish', '--local', '-i', '-w')
+        Bump = Invoke-TestInstalledNovaCommand -InstalledPath $InstalledPath -WorkingDirectory $ProjectRoot -Arguments @('bump', '-w')
+        BumpCi = Invoke-TestInstalledNovaCommand -InstalledPath $InstalledPath -WorkingDirectory $ProjectRoot -Arguments @('bump', '-i', '-w')
+        PreviewBump = Invoke-TestInstalledNovaCommand -InstalledPath $InstalledPath -WorkingDirectory $ProjectRoot -Arguments @('bump', '--preview', '--what-if')
+        ReleaseCi = Invoke-TestInstalledNovaCommand -InstalledPath $InstalledPath -WorkingDirectory $ProjectRoot -Arguments @('release', '--local', '-i', '-w')
+    }
+}
+
+function Assert-TestNovaCliWhatIfResultMap {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][hashtable]$ResultMap,
+        [Parameter(Mandatory)][string]$ProjectJsonPath,
+        [Parameter(Mandatory)][string]$BuiltModulePath,
+        [Parameter(Mandatory)][string]$TestResultPath
+    )
+
+    foreach ($resultName in $ResultMap.Keys) {
+        $ResultMap[$resultName].ExitCode | Should -Be 0 -Because "$resultName => $( $ResultMap[$resultName].Text )"
+    }
+
+    foreach ($resultName in @('Build', 'BuildCi', 'TestShort', 'TestLong', 'Publish', 'PublishCi', 'Bump', 'BumpCi', 'PreviewBump', 'ReleaseCi')) {
+        $ResultMap[$resultName].Text | Should -Match 'What if:'
+    }
+
+    foreach ($resultName in @('Publish', 'PublishCi', 'PreviewBump', 'ReleaseCi')) {
+        $ResultMap[$resultName].Text | Should -Not -Match 'Unknown argument:'
+    }
+
+    $ResultMap.Bump.Text | Should -Match '0\.0\.1\s+0\.1\.0\s+Minor\s+1'
+    $ResultMap.BumpCi.Text | Should -Match '0\.0\.1\s+0\.1\.0\s+Minor\s+1'
+    $ResultMap.PreviewBump.Text | Should -Match '0\.0\.1\s+0\.1\.0-preview\s+Minor\s+1'
+    $ResultMap.Bump.Text | Should -Not -Match 'Version bumped to :'
+    $ResultMap.PreviewBump.Text | Should -Not -Match 'Version bumped to :'
+    ((Get-Content -LiteralPath $ProjectJsonPath -Raw | ConvertFrom-Json).Version) | Should -Be '0.0.1'
+    (Test-Path -LiteralPath $BuiltModulePath) | Should -BeFalse
+    (Test-Path -LiteralPath $TestResultPath) | Should -BeFalse
+}
+
+function Get-TestNovaCliContinuousIntegrationForwardingCaseList {
+    [CmdletBinding()]
+    param()
+
+    return @(
+        @{CommandName = 'build'; ActionCommand = 'Invoke-NovaBuild'; UsesPublishOption = $false; Arguments = @('--continuous-integration')}
+        @{CommandName = 'bump'; ActionCommand = 'Update-NovaModuleVersion'; UsesPublishOption = $false; Arguments = @('--continuous-integration')}
+        @{CommandName = 'publish'; ActionCommand = 'Publish-NovaModule'; UsesPublishOption = $false; Arguments = @('--repository', 'PSGallery', '--api-key', 'key123', '--continuous-integration')}
+        @{CommandName = 'release'; ActionCommand = 'Invoke-NovaRelease'; UsesPublishOption = $true; Arguments = @('--repository', 'PSGallery', '--api-key', 'key123', '--continuous-integration')}
+    )
+}
+

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -591,6 +591,35 @@ Describe 'Nova command model - project, help, and build behavior' {
         }
     }
 
+    It 'Invoke-NovaBuildWorkflow re-imports the built module after the build completes in CI mode' {
+        InModuleScope $script:moduleName {
+            $script:steps = @()
+            $projectInfo = [pscustomobject]@{
+                ProjectName = 'NovaModuleTools'
+                OutputModuleDir = '/tmp/dist/NovaModuleTools'
+                FailOnDuplicateFunctionNames = $true
+            }
+            $workflowContext = [pscustomobject]@{
+                ProjectInfo = $projectInfo
+                ContinuousIntegrationRequested = $true
+            }
+
+            Mock Reset-ProjectDist {$script:steps += 'reset'}
+            Mock Build-Module {$script:steps += 'module'}
+            Mock Assert-BuiltModuleHasNoDuplicateFunctionName {$script:steps += 'duplicates'}
+            Mock Build-Manifest {$script:steps += 'manifest'}
+            Mock Build-Help {$script:steps += 'help'}
+            Mock Copy-ProjectResource {$script:steps += 'resources'}
+            Mock Invoke-NovaBuildUpdateNotification {$script:steps += 'notification'}
+            Mock Import-NovaBuiltModuleForCi {$script:steps += 'ci'}
+
+            Invoke-NovaBuildWorkflow -WorkflowContext $workflowContext
+
+            $script:steps -join ',' | Should -Be 'reset,module,duplicates,manifest,help,resources,notification,ci'
+            Assert-MockCalled Import-NovaBuiltModuleForCi -Times 1 -ParameterFilter {$ProjectInfo.ProjectName -eq 'NovaModuleTools'}
+        }
+    }
+
     It 'Invoke-NovaBuild delegates orchestration to the private build workflow helper' {
         InModuleScope $script:moduleName {
             Mock Get-NovaBuildWorkflowContext {
@@ -612,6 +641,22 @@ Describe 'Nova command model - project, help, and build behavior' {
         }
     }
 
+    It 'Invoke-NovaBuild forwards ContinuousIntegration into the build workflow context' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaBuildWorkflowContext {
+                [pscustomobject]@{
+                    Target = '/tmp/dist/NovaModuleTools'
+                    Operation = 'Build Nova module output'
+                }
+            }
+            Mock Invoke-NovaBuildWorkflow {}
+
+            Invoke-NovaBuild -ContinuousIntegration -Confirm:$false
+
+            Assert-MockCalled Get-NovaBuildWorkflowContext -Times 1 -ParameterFilter {$ContinuousIntegrationRequested}
+        }
+    }
+
     It 'Invoke-NovaBuild -WhatIf skips the build pipeline' {
         InModuleScope $script:moduleName {
             Mock Get-NovaProjectInfo {
@@ -626,8 +671,9 @@ Describe 'Nova command model - project, help, and build behavior' {
             Mock Build-Help {throw 'should not build help'}
             Mock Copy-ProjectResource {throw 'should not copy resources'}
             Mock Invoke-NovaBuildUpdateNotification {throw 'should not check for updates'}
+            Mock Import-NovaBuiltModuleForCi {throw 'should not re-import'}
 
-            $result = Invoke-NovaBuild -WhatIf
+            $result = Invoke-NovaBuild -ContinuousIntegration -WhatIf
 
             $result | Should -BeNullOrEmpty
             Assert-MockCalled Reset-ProjectDist -Times 0
@@ -636,6 +682,7 @@ Describe 'Nova command model - project, help, and build behavior' {
             Assert-MockCalled Build-Help -Times 0
             Assert-MockCalled Copy-ProjectResource -Times 0
             Assert-MockCalled Invoke-NovaBuildUpdateNotification -Times 0
+            Assert-MockCalled Import-NovaBuiltModuleForCi -Times 0
         }
     }
 


### PR DESCRIPTION
## Summary

- Add first-class CI activation support to the Nova workflow commands so the active session can re-import the correct built module when workflow state crosses build, bump, publish, and release boundaries.
- Introduce one shared internal activation helper and wire the behavior through the relevant PowerShell commands, workflow contexts, CLI parsers, and command routing instead of duplicating CI-only logic in each workflow.
- Update CLI help, PowerShell help, repository docs, changelog, and regression coverage so `-ContinuousIntegration`, `--continuous-integration`, and `-i` are documented and validated while preserving `nova version -i` for the installed-version view. Closes #122.

## Affected area

- [x] `nova` CLI or command routing
- [x] Public PowerShell cmdlet behavior
- [ ] Scaffolding or `project.json` handling
- [x] Build, test, analyzer, coverage, or CI helper flow
- [ ] Package, raw upload, or package metadata workflow
- [x] Publish, release, semantic-release, or GitHub Actions automation
- [ ] Self-update or notification preference behavior
- [x] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
- [x] End-user docs (`docs/*.html`)
- [x] Command help (`docs/NovaModuleTools/en-US/*.md`)
- [ ] `src/resources/example/`
- [ ] Dependency or manifest changes (`package.json`, workflow dependencies, release tooling)
- [ ] Security-sensitive change
- [ ] Documentation-only change
- [ ] Other

## Review guidance

- Start with `/Users/stiwi.courage/workspace/couragedk/NovaModuleTools/src/private/shared/ImportNovaBuiltModuleForCi.ps1`, then review how CI intent is forwarded through the public entrypoints in `src/public/` and the workflow-boundary hook points in `src/private/build/` and `src/private/release/`.
- Review the CLI surface next in `src/private/cli/` plus the help text updates in `src/resources/cli/help/`, `docs/NovaModuleTools/en-US/`, and `docs/*.html`.
- The largest test changes are in `tests/NovaCommandModel.ReleasePublish.Tests.ps1`, `tests/CoverageGaps.Cli.Tests.ps1`, `tests/NovaCommandModel.StandaloneCli.Tests.ps1`, and the new shared helpers under `tests/CoverageGaps.Cli.TestSupport.ps1` and `tests/NovaCommandModel.TestSupport/CliProjectSupport.ps1`.
- Main trade-offs and compatibility notes:
  - CI mode stays opt-in; local behavior is unchanged unless `-ContinuousIntegration` / `--continuous-integration` is supplied.
  - `nova version -i` keeps its existing installed-version meaning; the short `-i` CI form is command-scoped to `build`, `bump`, `publish`, and `release`.
  - `Test-NovaBuild` was intentionally left out of the first CI-mode wave to keep the new surface area narrow.
  - The test refactors are maintainability-driven and reduce duplication/complexity without changing the intended command behavior.

## Validation

- [x] `Invoke-NovaBuild`
- [ ] `Test-NovaBuild`
- [x] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [x] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
- [x] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`,
  `% nova publish`,
  `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
- [ ] Docs/example only; executable validation not needed

Validation notes:

```text
Import-Module NovaModuleTools -ErrorAction Stop
Invoke-NovaBuild

Import-Module './dist/NovaModuleTools/NovaModuleTools.psm1' -Force
Invoke-Pester -Path './tests/Module.Tests.ps1','./tests/CoverageGaps.BuildInternals.Tests.ps1','./tests/NovaCommandModel.Tests.ps1','./tests/NovaCommandModel.BumpAndCli.Tests.ps1','./tests/NovaCommandModel.ReleasePublish.Tests.ps1','./tests/CoverageGaps.Cli.Tests.ps1','./tests/NovaCommandModel.StandaloneCli.Tests.ps1' -CI
- Tests Passed: 261, Failed: 0

Invoke-Pester -Path './tests/BuildOptions.Tests.ps1','./tests/UpdateNotification.Tests.ps1','./tests/NovaCommandModel.ReleasePublish.Tests.ps1' -CI
- Tests Passed: 100, Failed: 0

pwsh -NoLogo -NoProfile -File './scripts/build/ci/Invoke-NovaModuleToolsCI.ps1' -OutputDirectory './artifacts/ci-check'
- Tests Passed: 512, Failed: 0
- Covered 95,24% / 75%. 2.943 analyzed Commands in 1 File.

Standalone CLI routing/help follow-up:
Invoke-Pester -Path './tests/NovaCommandModel.StandaloneCli.Tests.ps1' -CI
- Tests Passed: 69, Failed: 0

CodeScene safeguard on the final implementation reported quality_gates: passed.

`Test-NovaBuild` was not exercised as a direct public command because CI activation was intentionally limited to build, bump, publish, and release in this first wave.
```

## Documentation and release follow-up

- [x] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
- [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
- [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [x] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
- [x] `docs/*.html` updated if end-user workflows or examples changed
- [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
  changed
- [ ] No documentation, changelog, or example updates were needed

## Maintainability, compatibility, and risk

- [x] Code Health / maintainability impact considered
- [x] No breaking change
- [ ] Breaking change
- [ ] Security-sensitive change
- [x] CI, workflow, or release-pipeline impact
- [ ] Dependency-review impact

Risk, rollout, or rollback notes:

```text
Compatibility impact is intentionally low because the feature is opt-in and existing command behavior is preserved when CI mode is omitted.

The highest-risk areas are workflow-boundary activation after build/publish and the command-scoped `-i` CLI parsing. Those paths are covered by focused PowerShell tests, standalone CLI tests, and the repo-wide CI script.

Rollback is straightforward: revert the CI activation helper and the `ContinuousIntegration` plumbing in the affected commands/workflows, then revert the related CLI/help/docs/test updates in the same change set.

Maintainability follow-up was completed during implementation by extracting shared test support and reducing duplicated/complex conditional test logic so the final CodeScene safeguard passed.
```