### PR TITLE
feat(#96): centralize configuration and secret resolution for NovaMod…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Centralize delivery configuration resolution so raw package upload, update notification settings, and PSGallery
+  publishing now follow one explicit precedence model without surfacing configured secrets in error text.
+    - Raw upload now resolves command overrides before named repository settings, then package defaults.
+    - Secret lookup now resolves explicit values before environment-variable indirection, then configured literal
+      fallbacks.
 - Keep CI-oriented publish and bump workflows bound to the freshly built module so follow-up `publish`, `release`, and
   `bump` steps no longer lose private helpers after module re-imports in the same session.
     - PowerShell now supports `New-NovaModulePackage -SkipTests`, `Publish-NovaModule -SkipTests`, and

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ PS> Update-NovaModuleTools   # alias
 Use `% nova notification` when you want the CLI-oriented workflow and the `Set-` / `Get-` cmdlets when you want the
 PowerShell function form in scripts.
 
+Update notification preferences use one shared settings location:
+
+- Windows: `%APPDATA%/NovaModuleTools/settings.json`
+- macOS/Linux with `XDG_CONFIG_HOME`: `$XDG_CONFIG_HOME/NovaModuleTools/settings.json`
+- macOS/Linux fallback: `~/.config/NovaModuleTools/settings.json`
+
 `Update-NovaModuleTool` (and its `Update-NovaModuleTools` alias), CLI:`% nova update` use that stored prerelease
 preference to decide whether prerelease self-updates are eligible. When prerelease self-updates are disabled,
 self-update stays on stable releases. When they are enabled, self-update may target a prerelease, but it asks for
@@ -339,8 +345,12 @@ Use this `project.json` shape when you want Nova to resolve upload targets from 
 - `Deploy-NovaPackage` uploads existing package files only; it does not build, test, or create packages.
 - `% nova deploy` is the CLI entrypoint for the same raw upload workflow and uses POSIX/GNU-style options such as
   `--repository`, `--url`, and `--token`.
-- `-Url` overrides repository or package-level upload settings and is the simplest CI/CD path for the PowerShell cmdlet
-  form.
+- Upload target precedence is explicit: `-Url` / `--url` and `-UploadPath` / `--upload-path` win first, then matching
+  `Package.Repositories[]` values, then package-level `Package.RepositoryUrl` / `Package.RawRepositoryUrl` and
+  `Package.UploadPath`.
+- Secret precedence is explicit too: `-Token` / `--token` wins first, then `-TokenEnvironmentVariable` /
+  `--token-env`, then merged repository/package `Auth.TokenEnvironmentVariable`, then merged repository/package
+  `Auth.Token`.
 - When `-PackagePath` is omitted, Nova resolves package files from `Package.OutputDirectory.Path`.
 - `Package.FileNamePattern` overrides the default upload discovery pattern. When omitted, Nova falls back to
   `<Package.Id>*` and then applies the selected package type extension.
@@ -354,6 +364,9 @@ Use this `project.json` shape when you want Nova to resolve upload targets from 
 - `Package.Headers`, `Package.Auth`, `Package.RepositoryUrl`, and repository-specific overrides remain generic so the
   workflow works with raw endpoints such as Nexus or Artifactory without turning `Publish-NovaModule` into a vendor-
   specific upload command.
+- `Publish-NovaModule` and `Invoke-NovaRelease` keep a matching secret rule for PowerShell repositories: `-ApiKey` /
+  `--api-key` overrides any fallback, and `PSGallery` still checks `PSGALLERY_API` when no explicit API key was
+  provided.
 
 For module publishing and release flows, the same opt-in skip-tests behavior is available when tests already ran earlier
 in the pipeline:

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -363,6 +363,11 @@ PS&gt; Deploy-NovaPackage -Url 'https://packages.example/raw/' -Token $env:NOVA_
 % nova deploy --url https://packages.example/raw/ --token $env:NOVA_PACKAGE_TOKEN</code></pre>
                             </div>
                         </div>
+                        <p>Resolution order stays explicit: command-line <code>url</code> / <code>upload-path</code>
+                            overrides win first, then the selected <code>Package.Repositories[]</code> entry, then
+                            package-level defaults. Secrets follow the same pattern: explicit <code>token</code>, then
+                            explicit <code>token-env</code>, then configured <code>Auth.TokenEnvironmentVariable</code>,
+                            then configured <code>Auth.Token</code>.</p>
                         <p><a class="text-link" href="./packaging-and-delivery.html#upload">See raw upload details</a>
                         </p>
                     </article>
@@ -404,6 +409,9 @@ PS&gt; Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API -Cont
 % nova publish --repository PSGallery --api-key $env:PSGALLERY_API --continuous-integration</code></pre>
                             </div>
                         </div>
+                        <p>When publishing to <code>PSGallery</code>, an explicit <code>-ApiKey</code> /
+                            <code>--api-key</code> wins first. If it is omitted, Nova still checks
+                            <code>PSGALLERY_API</code> as the repository-specific fallback.</p>
                         <p><a class="text-link" href="./packaging-and-delivery.html#publish">See publish details</a></p>
                     </article>
 
@@ -608,6 +616,9 @@ PS&gt; Set-NovaUpdateNotificationPreference -EnablePrereleaseNotifications</code
 % nova notification --enable</code></pre>
                             </div>
                         </div>
+                        <p>The shared preference file lives under <code>%APPDATA%</code> on Windows, otherwise under
+                            <code>$XDG_CONFIG_HOME</code> when it is set, and finally under
+                            <code>~/.config/NovaModuleTools/settings.json</code>.</p>
                         <p><a class="text-link" href="./versioning-and-updates.html#notification-preferences">See update
                             preference guidance</a></p>
                     </article>

--- a/docs/project-json-reference.html
+++ b/docs/project-json-reference.html
@@ -532,6 +532,15 @@
                         </tbody>
                     </table>
                 </div>
+                <p>Nova resolves raw-upload settings in a fixed order so CI/CD overrides stay predictable. Command
+                    arguments such as <code>-Url</code> / <code>--url</code> and <code>-UploadPath</code> /
+                    <code>--upload-path</code> win first, then the selected <code>Package.Repositories[]</code> entry,
+                    then package-level defaults such as <code>Package.RepositoryUrl</code>,
+                    <code>Package.RawRepositoryUrl</code>, and <code>Package.UploadPath</code>.</p>
+                <p>Secrets follow a matching precedence model. An explicit token value wins first, then an explicit
+                    token-environment-variable name, then the merged repository/package
+                    <code>Auth.TokenEnvironmentVariable</code>, and finally the merged literal
+                    <code>Auth.Token</code>. Prefer environment-variable indirection for real credentials.</p>
 
                 <h3>Authentication examples</h3>
                 <pre><code>{
@@ -677,7 +686,8 @@
   }
 }</code></pre>
                 <p>Use package-level values for the shared default behavior, then override only the repository-specific
-                    parts that need to change.</p>
+                    parts that need to change. Repository-specific <code>Headers</code>, <code>Auth</code>, and
+                    <code>UploadPath</code> override package defaults only for the selected named target.</p>
             </section>
         </div>
     </section>

--- a/project.json
+++ b/project.json
@@ -8,7 +8,7 @@
   ],
   "Manifest": {
     "Author": "Stiwi Gabriel Courage",
-    "Copyright": "Copyright (c) 2026 Terra Nova.",
+    "Copyright": "Copyright (c) 2026 Stiwi Gabriel Courage",
     "PowerShellHostVersion": "7.4",
     "GUID": "6b9202c8-0353-473b-b73c-afab632125a6",
     "RequiredModules": [

--- a/src/private/package/GetNovaPackageUploadPath.ps1
+++ b/src/private/package/GetNovaPackageUploadPath.ps1
@@ -6,16 +6,12 @@ function Get-NovaPackageUploadPath {
         [string]$UploadPath
     )
 
-    if (-not [string]::IsNullOrWhiteSpace($UploadPath)) {
-        return $UploadPath.Trim()
-    }
+    $resolvedUploadPath = Get-NovaFirstConfiguredValue -CandidateList @(
+        $UploadPath
+        (Get-NovaPackageSettingValue -InputObject $RepositorySettings -Name 'UploadPath')
+        (Get-NovaPackageSettingValue -InputObject $PackageSettings -Name 'UploadPath')
+    )
 
-    $repositoryUploadPath = Get-NovaPackageSettingValue -InputObject $RepositorySettings -Name 'UploadPath'
-    if (-not [string]::IsNullOrWhiteSpace("$repositoryUploadPath")) {
-        return "$repositoryUploadPath".Trim()
-    }
-
-    $packageUploadPath = Get-NovaPackageSettingValue -InputObject $PackageSettings -Name 'UploadPath'
-    return "$( $packageUploadPath )".Trim()
+    return "$( $resolvedUploadPath )".Trim()
 }
 

--- a/src/private/package/GetNovaPackageUploadTargetUrl.ps1
+++ b/src/private/package/GetNovaPackageUploadTargetUrl.ps1
@@ -6,17 +6,13 @@ function Get-NovaPackageUploadTargetUrl {
         [string]$Url
     )
 
-    $resolvedUrl = $Url
-    if ( [string]::IsNullOrWhiteSpace($resolvedUrl)) {
-        $resolvedUrl = Get-NovaPackageSettingValue -InputObject $RepositorySettings -Name 'Url'
-    }
-    if ( [string]::IsNullOrWhiteSpace("$resolvedUrl")) {
-        $resolvedUrl = Get-NovaPackageSettingValue -InputObject $PackageSettings -Name 'RepositoryUrl'
-    }
-    if ( [string]::IsNullOrWhiteSpace("$resolvedUrl")) {
-        $resolvedUrl = Get-NovaPackageSettingValue -InputObject $PackageSettings -Name 'RawRepositoryUrl'
-    }
-    if ( [string]::IsNullOrWhiteSpace("$resolvedUrl")) {
+    $resolvedUrl = Get-NovaFirstConfiguredValue -CandidateList @(
+        $Url
+        (Get-NovaPackageSettingValue -InputObject $RepositorySettings -Name 'Url')
+        (Get-NovaPackageSettingValue -InputObject $PackageSettings -Name 'RepositoryUrl')
+        (Get-NovaPackageSettingValue -InputObject $PackageSettings -Name 'RawRepositoryUrl')
+    )
+    if (-not (Test-NovaConfiguredValue -Value $resolvedUrl)) {
         Stop-NovaOperation -Message 'Upload target URL is missing. Provide -Url or configure Package.RepositoryUrl or Package.Repositories[].Url.' -ErrorId 'Nova.Configuration.PackageUploadTargetUrlMissing' -Category InvalidData -TargetObject 'Url'
     }
 

--- a/src/private/package/GetNovaPackageUploadToken.ps1
+++ b/src/private/package/GetNovaPackageUploadToken.ps1
@@ -6,18 +6,11 @@ function Get-NovaPackageUploadToken {
         [string]$TokenEnvironmentVariable
     )
 
-    if (-not [string]::IsNullOrWhiteSpace($Token)) {
-        return $Token
-    }
-
-    $environmentVariableName = $TokenEnvironmentVariable
-    if ( [string]::IsNullOrWhiteSpace($environmentVariableName)) {
-        $environmentVariableName = Get-NovaPackageSettingValue -InputObject $AuthSettings -Name 'TokenEnvironmentVariable'
-    }
-    if (-not [string]::IsNullOrWhiteSpace("$environmentVariableName")) {
-        return [System.Environment]::GetEnvironmentVariable("$environmentVariableName")
-    }
-
-    return Get-NovaPackageSettingValue -InputObject $AuthSettings -Name 'Token'
+    return Resolve-NovaSecretValue -SecretSources ([pscustomobject]@{
+        ExplicitValue = $Token
+        ExplicitEnvironmentVariableName = $TokenEnvironmentVariable
+        ConfiguredEnvironmentVariableName = Get-NovaPackageSettingValue -InputObject $AuthSettings -Name 'TokenEnvironmentVariable'
+        ConfiguredValue = Get-NovaPackageSettingValue -InputObject $AuthSettings -Name 'Token'
+    })
 }
 

--- a/src/private/release/GetLocalModulePathEntryList.ps1
+++ b/src/private/release/GetLocalModulePathEntryList.ps1
@@ -1,8 +1,13 @@
 function Get-LocalModulePathEntryList {
     $separator = [IO.Path]::PathSeparator
+    $modulePath = Get-NovaEnvironmentVariableValue -Name 'PSModulePath'
+
+    if ( [string]::IsNullOrWhiteSpace($modulePath)) {
+        return @()
+    }
 
     return @(
-    $env:PSModulePath -split $separator |
+    $modulePath -split $separator |
             ForEach-Object {$_.Trim()} |
             Where-Object {-not [string]::IsNullOrWhiteSpace($_)} |
             Select-Object -Unique

--- a/src/private/release/PublishNovaBuiltModuleToRepository.ps1
+++ b/src/private/release/PublishNovaBuiltModuleToRepository.ps1
@@ -1,3 +1,16 @@
+function Get-NovaPublishRepositoryDefaultApiKeyEnvironmentVariable {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Repository
+    )
+
+    if ( $Repository.Equals('PSGallery', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return 'PSGALLERY_API'
+    }
+
+    return $null
+}
+
 function Publish-NovaBuiltModuleToRepository {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(
@@ -10,10 +23,10 @@ function Publish-NovaBuiltModuleToRepository {
         [string]$ApiKey
     )
 
-    $resolvedApiKey = $ApiKey
-    if ($Repository -eq 'PSGallery' -and [string]::IsNullOrWhiteSpace($resolvedApiKey)) {
-        $resolvedApiKey = $env:PSGALLERY_API
-    }
+    $resolvedApiKey = Resolve-NovaSecretValue -SecretSources ([pscustomobject]@{
+        ExplicitValue = $ApiKey
+        DefaultEnvironmentVariableName = Get-NovaPublishRepositoryDefaultApiKeyEnvironmentVariable -Repository $Repository
+    })
 
     $publishParams = @{
         Path = $ProjectInfo.OutputModuleDir

--- a/src/private/shared/GetNovaEnvironmentVariableValue.ps1
+++ b/src/private/shared/GetNovaEnvironmentVariableValue.ps1
@@ -1,0 +1,13 @@
+function Get-NovaEnvironmentVariableValue {
+    [CmdletBinding()]
+    param(
+        [string]$Name
+    )
+
+    if ( [string]::IsNullOrWhiteSpace($Name)) {
+        return $null
+    }
+
+    return [System.Environment]::GetEnvironmentVariable($Name.Trim())
+}
+

--- a/src/private/shared/GetNovaFirstConfiguredValue.ps1
+++ b/src/private/shared/GetNovaFirstConfiguredValue.ps1
@@ -1,0 +1,31 @@
+function Get-NovaFirstConfiguredValue {
+    [CmdletBinding()]
+    param(
+        [AllowNull()][AllowEmptyCollection()][object[]]$CandidateList = @()
+    )
+
+    foreach ($candidate in $CandidateList) {
+        if (Test-NovaConfiguredValue -Value $candidate) {
+            return $candidate
+        }
+    }
+
+    return $null
+}
+
+function Test-NovaConfiguredValue {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]$Value
+    )
+
+    if ($null -eq $Value) {
+        return $false
+    }
+
+    if ($Value -is [string]) {
+        return -not [string]::IsNullOrWhiteSpace($Value)
+    }
+
+    return $true
+}

--- a/src/private/shared/GetNovaSettingsDirectoryPath.ps1
+++ b/src/private/shared/GetNovaSettingsDirectoryPath.ps1
@@ -9,9 +9,11 @@ function Get-NovaSettingsDirectoryPath {
 
 function Get-NovaSettingsRootPath {
     [CmdletBinding()]
-    param()
+    param(
+        [bool]$IsWindowsPlatform = $IsWindows
+    )
 
-    if ($IsWindows) {
+    if ($IsWindowsPlatform) {
         $appData = Get-NovaEnvironmentVariableValue -Name 'APPDATA'
         if (Test-NovaConfiguredValue -Value $appData) {
             return $appData

--- a/src/private/shared/GetNovaSettingsDirectoryPath.ps1
+++ b/src/private/shared/GetNovaSettingsDirectoryPath.ps1
@@ -1,0 +1,28 @@
+function Get-NovaSettingsDirectoryPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ApplicationName
+    )
+
+    return Join-Path (Get-NovaSettingsRootPath) $ApplicationName
+}
+
+function Get-NovaSettingsRootPath {
+    [CmdletBinding()]
+    param()
+
+    if ($IsWindows) {
+        $appData = Get-NovaEnvironmentVariableValue -Name 'APPDATA'
+        if (Test-NovaConfiguredValue -Value $appData) {
+            return $appData
+        }
+    }
+
+    $xdgConfigHome = Get-NovaEnvironmentVariableValue -Name 'XDG_CONFIG_HOME'
+    if (Test-NovaConfiguredValue -Value $xdgConfigHome) {
+        return $xdgConfigHome
+    }
+
+    return Join-Path $HOME '.config'
+}
+

--- a/src/private/shared/ResolveNovaSecretValue.ps1
+++ b/src/private/shared/ResolveNovaSecretValue.ps1
@@ -1,0 +1,36 @@
+function Get-NovaSecretSourceValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$SecretSources,
+        [Parameter(Mandatory)][string]$Name
+    )
+
+    if ($SecretSources.PSObject.Properties.Name -contains $Name) {
+        return $SecretSources.$Name
+    }
+
+    return $null
+}
+
+function Resolve-NovaSecretValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$SecretSources
+    )
+
+    $explicitValue = Get-NovaSecretSourceValue -SecretSources $SecretSources -Name 'ExplicitValue'
+    if (Test-NovaConfiguredValue -Value $explicitValue) {
+        return $explicitValue
+    }
+
+    $environmentVariableName = Get-NovaFirstConfiguredValue -CandidateList @(
+        (Get-NovaSecretSourceValue -SecretSources $SecretSources -Name 'ExplicitEnvironmentVariableName')
+        (Get-NovaSecretSourceValue -SecretSources $SecretSources -Name 'ConfiguredEnvironmentVariableName')
+        (Get-NovaSecretSourceValue -SecretSources $SecretSources -Name 'DefaultEnvironmentVariableName')
+    )
+    if (Test-NovaConfiguredValue -Value $environmentVariableName) {
+        return Get-NovaEnvironmentVariableValue -Name $environmentVariableName
+    }
+
+    return Get-NovaFirstConfiguredValue -CandidateList @((Get-NovaSecretSourceValue -SecretSources $SecretSources -Name 'ConfiguredValue'))
+}

--- a/src/private/update/GetNovaUpdateSettingsFilePath.ps1
+++ b/src/private/update/GetNovaUpdateSettingsFilePath.ps1
@@ -2,15 +2,5 @@ function Get-NovaUpdateSettingsFilePath {
     [CmdletBinding()]
     param()
 
-    $settingsRoot = if ($IsWindows -and -not [string]::IsNullOrWhiteSpace($env:APPDATA)) {
-        Join-Path $env:APPDATA 'NovaModuleTools'
-    }
-    elseif (-not [string]::IsNullOrWhiteSpace($env:XDG_CONFIG_HOME)) {
-        Join-Path $env:XDG_CONFIG_HOME 'NovaModuleTools'
-    }
-    else {
-        Join-Path (Join-Path $HOME '.config') 'NovaModuleTools'
-    }
-
-    return Join-Path $settingsRoot 'settings.json'
+    return Join-Path (Get-NovaSettingsDirectoryPath -ApplicationName 'NovaModuleTools') 'settings.json'
 }

--- a/tests/NovaCommandModel.PackageUpload.Tests.ps1
+++ b/tests/NovaCommandModel.PackageUpload.Tests.ps1
@@ -290,6 +290,125 @@ Describe 'Nova command model - package upload behavior' {
         }
     }
 
+    It 'Resolve-NovaPackageUploadHeaders keeps token precedence explicit when <Name>' -ForEach @(
+        @{
+            Name = 'an explicit token overrides explicit and configured environment variables'
+            UploadTarget = [pscustomobject]@{
+                Headers = [ordered]@{}
+                Auth = [ordered]@{
+                    HeaderName = 'X-Api-Key'
+                    TokenEnvironmentVariable = 'NOVA_PACKAGE_CONFIGURED_TOKEN'
+                    Token = 'configured-literal-token'
+                }
+            }
+            UploadOption = [pscustomobject]@{
+                Headers = [ordered]@{}
+                Token = 'explicit-token'
+                TokenEnvironmentVariable = 'NOVA_PACKAGE_EXPLICIT_TOKEN'
+                AuthenticationScheme = $null
+            }
+            Environment = @{
+                NOVA_PACKAGE_CONFIGURED_TOKEN = 'configured-environment-token'
+                NOVA_PACKAGE_EXPLICIT_TOKEN = 'explicit-environment-token'
+            }
+            ExpectedHeaderValue = 'explicit-token'
+        }
+        @{
+            Name = 'an explicit token environment variable overrides configured auth values'
+            UploadTarget = [pscustomobject]@{
+                Headers = [ordered]@{}
+                Auth = [ordered]@{
+                    HeaderName = 'X-Api-Key'
+                    TokenEnvironmentVariable = 'NOVA_PACKAGE_CONFIGURED_TOKEN'
+                    Token = 'configured-literal-token'
+                }
+            }
+            UploadOption = [pscustomobject]@{
+                Headers = [ordered]@{}
+                Token = $null
+                TokenEnvironmentVariable = 'NOVA_PACKAGE_EXPLICIT_TOKEN'
+                AuthenticationScheme = $null
+            }
+            Environment = @{
+                NOVA_PACKAGE_CONFIGURED_TOKEN = 'configured-environment-token'
+                NOVA_PACKAGE_EXPLICIT_TOKEN = 'explicit-environment-token'
+            }
+            ExpectedHeaderValue = 'explicit-environment-token'
+        }
+        @{
+            Name = 'a configured token environment variable overrides a configured literal token'
+            UploadTarget = [pscustomobject]@{
+                Headers = [ordered]@{}
+                Auth = [ordered]@{
+                    HeaderName = 'X-Api-Key'
+                    TokenEnvironmentVariable = 'NOVA_PACKAGE_CONFIGURED_TOKEN'
+                    Token = 'configured-literal-token'
+                }
+            }
+            UploadOption = [pscustomobject]@{
+                Headers = [ordered]@{}
+                Token = $null
+                TokenEnvironmentVariable = $null
+                AuthenticationScheme = $null
+            }
+            Environment = @{
+                NOVA_PACKAGE_CONFIGURED_TOKEN = 'configured-environment-token'
+                NOVA_PACKAGE_EXPLICIT_TOKEN = $null
+            }
+            ExpectedHeaderValue = 'configured-environment-token'
+        }
+    ) {
+        $originalConfiguredToken = [System.Environment]::GetEnvironmentVariable('NOVA_PACKAGE_CONFIGURED_TOKEN')
+        $originalExplicitToken = [System.Environment]::GetEnvironmentVariable('NOVA_PACKAGE_EXPLICIT_TOKEN')
+
+        try {
+            [System.Environment]::SetEnvironmentVariable('NOVA_PACKAGE_CONFIGURED_TOKEN', $_.Environment.NOVA_PACKAGE_CONFIGURED_TOKEN, 'Process')
+            [System.Environment]::SetEnvironmentVariable('NOVA_PACKAGE_EXPLICIT_TOKEN', $_.Environment.NOVA_PACKAGE_EXPLICIT_TOKEN, 'Process')
+
+            InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+                param($TestCase)
+
+                $result = Resolve-NovaPackageUploadHeaders -UploadTarget $TestCase.UploadTarget -UploadOption $TestCase.UploadOption
+
+                $result['X-Api-Key'] | Should -Be $TestCase.ExpectedHeaderValue
+                $result.Keys.Count | Should -Be 1
+            }
+        }
+        finally {
+            [System.Environment]::SetEnvironmentVariable('NOVA_PACKAGE_CONFIGURED_TOKEN', $originalConfiguredToken, 'Process')
+            [System.Environment]::SetEnvironmentVariable('NOVA_PACKAGE_EXPLICIT_TOKEN', $originalExplicitToken, 'Process')
+        }
+    }
+
+    It 'Resolve-NovaPackageUploadTarget missing URL errors do not leak configured token values' {
+        $layout = Initialize-TestNovaPackageUploadLayout -ProjectRoot (Join-Path $TestDrive 'missing-upload-url-secret-safe')
+        $secretToken = 'do-not-log-this-token'
+
+        InModuleScope $script:moduleName -Parameters @{
+            SecretToken = $secretToken
+            ProjectInfo = (New-TestNovaPackageUploadProjectInfo -Layout $layout -Options @{
+                Auth = [ordered]@{
+                    Token = $secretToken
+                }
+            })
+        } {
+            param($ProjectInfo, $SecretToken)
+
+            $thrown = $null
+
+            try {
+                Resolve-NovaPackageUploadTarget -ProjectInfo $ProjectInfo
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Not -Match [regex]::Escape($SecretToken)
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Configuration.PackageUploadTargetUrlMissing'
+        }
+    }
+
     It 'Deploy-NovaPackage uploads the specified package file to the specified raw URL' {
         $layout = Initialize-TestNovaPackageUploadLayout -ProjectRoot (Join-Path $TestDrive 'explicit-upload')
         $packagePath = New-TestNovaPackageArtifactFile -Directory $layout.PackageOutputDir -Name 'PackageProject.2.3.4.zip'

--- a/tests/NovaCommandModel.ReleasePublish.Tests.ps1
+++ b/tests/NovaCommandModel.ReleasePublish.Tests.ps1
@@ -579,6 +579,69 @@ Describe 'Nova command model - release and publish behavior' {
         }
     }
 
+    It 'Publish-NovaBuiltModuleToRepository resolves API key precedence clearly when <Name>' -ForEach @(
+        @{
+            Name = 'an explicit API key overrides the PSGallery environment fallback'
+            Repository = 'PSGallery'
+            ApiKey = 'explicit-gallery-key'
+            EnvironmentApiKey = 'environment-gallery-key'
+            ExpectedApiKey = 'explicit-gallery-key'
+        }
+        @{
+            Name = 'PSGallery falls back to PSGALLERY_API when ApiKey is omitted'
+            Repository = 'PSGallery'
+            ApiKey = $null
+            EnvironmentApiKey = 'environment-gallery-key'
+            ExpectedApiKey = 'environment-gallery-key'
+        }
+    ) {
+        $originalApiKey = [System.Environment]::GetEnvironmentVariable('PSGALLERY_API')
+
+        try {
+            [System.Environment]::SetEnvironmentVariable('PSGALLERY_API', $_.EnvironmentApiKey, 'Process')
+
+            InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+                param($TestCase)
+
+                Mock Publish-PSResource {}
+
+                Publish-NovaBuiltModuleToRepository -ProjectInfo ([pscustomobject]@{OutputModuleDir = '/tmp/dist'}) -Repository $TestCase.Repository -ApiKey $TestCase.ApiKey
+
+                Assert-MockCalled Publish-PSResource -Times 1 -ParameterFilter {
+                    $Path -eq '/tmp/dist' -and
+                            $Repository -eq $TestCase.Repository -and
+                            $ApiKey -eq $TestCase.ExpectedApiKey
+                }
+            }
+        }
+        finally {
+            [System.Environment]::SetEnvironmentVariable('PSGALLERY_API', $originalApiKey, 'Process')
+        }
+    }
+
+    It 'Publish-NovaBuiltModuleToRepository does not reuse the PSGallery fallback for other repositories' {
+        $originalApiKey = [System.Environment]::GetEnvironmentVariable('PSGALLERY_API')
+
+        try {
+            [System.Environment]::SetEnvironmentVariable('PSGALLERY_API', 'environment-gallery-key', 'Process')
+
+            InModuleScope $script:moduleName {
+                Mock Publish-PSResource {}
+
+                Publish-NovaBuiltModuleToRepository -ProjectInfo ([pscustomobject]@{OutputModuleDir = '/tmp/dist'}) -Repository 'InternalFeed'
+
+                Assert-MockCalled Publish-PSResource -Times 1 -ParameterFilter {
+                    $Path -eq '/tmp/dist' -and
+                            $Repository -eq 'InternalFeed' -and
+                            -not $PSBoundParameters.ContainsKey('ApiKey')
+                }
+            }
+        }
+        finally {
+            [System.Environment]::SetEnvironmentVariable('PSGALLERY_API', $originalApiKey, 'Process')
+        }
+    }
+
     It 'Get-NovaPackageWorkflowContext resolves package metadata, target, and operation for all requested package types' {
         InModuleScope $script:moduleName {
             $projectInfo = [pscustomobject]@{

--- a/tests/RemainingHelperCoverage.Tests.ps1
+++ b/tests/RemainingHelperCoverage.Tests.ps1
@@ -131,6 +131,34 @@ Describe 'Coverage for remaining manifest, JSON, and help-locale helpers' {
         }
     }
 
+    It 'Get-LocalModulePathEntryList returns an empty list when PSModulePath is missing' {
+        $originalModulePath = $env:PSModulePath
+
+        try {
+            $env:PSModulePath = $null
+
+            InModuleScope $script:moduleName {
+                @(Get-LocalModulePathEntryList) | Should -Be @()
+            }
+        }
+        finally {
+            $env:PSModulePath = $originalModulePath
+        }
+    }
+
+    It 'Get-NovaEnvironmentVariableValue returns nothing when the variable name is blank' {
+        InModuleScope $script:moduleName {
+            Get-NovaEnvironmentVariableValue -Name '   ' | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'Get-NovaFirstConfiguredValue treats non-string values as configured' {
+        InModuleScope $script:moduleName {
+            Get-NovaFirstConfiguredValue -CandidateList @($null, '', 0, 'fallback') | Should -Be 0
+            Get-NovaFirstConfiguredValue -CandidateList @($null, ' ', $false, 'fallback') | Should -BeFalse
+        }
+    }
+
     It 'module PSData helpers read release notes from both supported metadata shapes' -ForEach @(
         @{
             ModuleInfo = [pscustomobject]@{

--- a/tests/UpdateNotification.Tests.ps1
+++ b/tests/UpdateNotification.Tests.ps1
@@ -377,6 +377,48 @@ Describe 'Update notification behavior' {
         }
     }
 
+    It 'Get-NovaSettingsRootPath prefers APPDATA when the Windows platform branch is used' {
+        $configRoot = Join-Path $TestDrive 'config-unused-root'
+        $appDataRoot = Join-Path $TestDrive 'appdata-preferred-root'
+        $originalConfigHome = $env:XDG_CONFIG_HOME
+        $originalAppData = $env:APPDATA
+
+        try {
+            $env:XDG_CONFIG_HOME = $configRoot
+            $env:APPDATA = $appDataRoot
+
+            InModuleScope $script:moduleName -Parameters @{ExpectedRoot = $appDataRoot} {
+                param($ExpectedRoot)
+
+                Get-NovaSettingsRootPath -IsWindowsPlatform $true | Should -Be $ExpectedRoot
+            }
+        }
+        finally {
+            $env:XDG_CONFIG_HOME = $originalConfigHome
+            $env:APPDATA = $originalAppData
+        }
+    }
+
+    It 'Get-NovaSettingsRootPath falls back to HOME dot-config when environment roots are blank' {
+        $originalConfigHome = $env:XDG_CONFIG_HOME
+        $originalAppData = $env:APPDATA
+
+        try {
+            $env:XDG_CONFIG_HOME = '   '
+            $env:APPDATA = '   '
+
+            InModuleScope $script:moduleName -Parameters @{ExpectedRoot = (Join-Path $HOME '.config')} {
+                param($ExpectedRoot)
+
+                Get-NovaSettingsRootPath | Should -Be $ExpectedRoot
+            }
+        }
+        finally {
+            $env:XDG_CONFIG_HOME = $originalConfigHome
+            $env:APPDATA = $originalAppData
+        }
+    }
+
     It 'Set-NovaUpdateNotificationPreference can disable and re-enable prerelease notifications' {
         $result = Invoke-TestNotificationPreferenceToggle -ConfigDirectoryName 'config-toggle'
 

--- a/tests/UpdateNotification.Tests.ps1
+++ b/tests/UpdateNotification.Tests.ps1
@@ -348,6 +348,35 @@ Describe 'Update notification behavior' {
         }
     }
 
+    It 'Get-NovaUpdateSettingsFilePath keeps platform settings-root precedence explicit' {
+        $configRoot = Join-Path $TestDrive 'config-shared-root'
+        $appDataRoot = Join-Path $TestDrive 'appdata-shared-root'
+        $originalConfigHome = $env:XDG_CONFIG_HOME
+        $originalAppData = $env:APPDATA
+
+        try {
+            $env:XDG_CONFIG_HOME = $configRoot
+            $env:APPDATA = $appDataRoot
+
+            InModuleScope $script:moduleName -Parameters @{
+                ExpectedPath = if ($IsWindows) {
+                    Join-Path $appDataRoot 'NovaModuleTools/settings.json'
+                }
+                else {
+                    Join-Path $configRoot 'NovaModuleTools/settings.json'
+                }
+            } {
+                param($ExpectedPath)
+
+                Get-NovaUpdateSettingsFilePath | Should -Be $ExpectedPath
+            }
+        }
+        finally {
+            $env:XDG_CONFIG_HOME = $originalConfigHome
+            $env:APPDATA = $originalAppData
+        }
+    }
+
     It 'Set-NovaUpdateNotificationPreference can disable and re-enable prerelease notifications' {
         $result = Invoke-TestNotificationPreferenceToggle -ConfigDirectoryName 'config-toggle'
 


### PR DESCRIPTION
## Summary

- Centralized configuration and secret resolution for raw package upload, PSGallery publishing, update-notification settings, and shared environment access.
- This change was needed because precedence had been spread across command parameters, `project.json`, repository settings, environment variables, and local settings files, which made behavior harder to understand, test, and maintain.
- Follow-up work tracked in `plan.md`.

## Affected area

- [ ] `nova` CLI or command routing
- [x] Public PowerShell cmdlet behavior
- [x] Scaffolding or `project.json` handling
- [ ] Build, test, analyzer, coverage, or CI helper flow
- [x] Package, raw upload, or package metadata workflow
- [x] Publish, release, semantic-release, or GitHub Actions automation
- [x] Self-update or notification preference behavior
- [x] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
- [x] End-user docs (`docs/*.html`)
- [ ] Command help (`docs/NovaModuleTools/en-US/*.md`)
- [ ] `src/resources/example/`
- [ ] Dependency or manifest changes (`package.json`, workflow dependencies, release tooling)
- [x] Security-sensitive change
- [ ] Documentation-only change
- [ ] Other

## Review guidance

- Start with the shared helpers in `src/private/shared/`:
  - `GetNovaEnvironmentVariableValue.ps1`
  - `GetNovaFirstConfiguredValue.ps1`
  - `ResolveNovaSecretValue.ps1`
  - `GetNovaSettingsDirectoryPath.ps1`
- Then review the migrated call sites:
  - `src/private/package/GetNovaPackageUploadToken.ps1`
  - `src/private/package/GetNovaPackageUploadTargetUrl.ps1`
  - `src/private/package/GetNovaPackageUploadPath.ps1`
  - `src/private/release/PublishNovaBuiltModuleToRepository.ps1`
  - `src/private/update/GetNovaUpdateSettingsFilePath.ps1`
  - `src/private/release/GetLocalModulePathEntryList.ps1`
- Main behavior change to verify:
  - raw upload config precedence is now explicit
  - secret lookup follows one shared precedence model
  - `PSGALLERY_API` fallback remains limited to `PSGallery`
  - update settings path resolution now uses one shared settings-root helper
- Trade-offs / follow-up:
  - this centralizes the highest-value flows first; other direct environment lookups can be migrated later for consistency
  - the public command surface remains stable, but internal precedence rules are now much easier to extend and test

## Validation

- [x] `Invoke-NovaBuild`
- [ ] `Test-NovaBuild`
- [ ] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
- [ ] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`,
  `% nova publish`,
  `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
- [ ] Docs/example only; executable validation not needed

Validation notes:

```text
Executed:
- pwsh -NoLogo -NoProfile -Command 'Set-Location "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools"; Invoke-NovaBuild'
- pwsh -NoLogo -NoProfile -Command 'Set-Location "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools"; Invoke-Pester ./tests/NovaCommandModel.PackageUpload.Tests.ps1 -Output Detailed'
- pwsh -NoLogo -NoProfile -Command 'Set-Location "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools"; Invoke-Pester ./tests/UpdateNotification.Tests.ps1 -Output Detailed'
- pwsh -NoLogo -NoProfile -Command 'Set-Location "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools"; Invoke-Pester ./tests/NovaCommandModel.ReleasePublish.Tests.ps1 -Output Detailed'
- git -C "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools" --no-pager diff --check
- CodeScene pre-commit safeguard on the current change set

Observed results:
- Package upload tests: 33 passed, 0 failed
- Update notification tests: 35 passed, 0 failed
- Release/publish tests: 47 passed, 0 failed
- git diff --check: passed
- CodeScene pre-commit safeguard: quality_gates = passed

Not run in this pass:
- full Test-NovaBuild
- ScriptAnalyzer CI helper
- CI parity helper
- direct end-to-end CLI command executions
```

## Documentation and release follow-up

- [x] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
- [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
- [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [ ] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
- [x] `docs/*.html` updated if end-user workflows or examples changed
- [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
  changed
- [ ] No documentation, changelog, or example updates were needed

## Maintainability, compatibility, and risk

- [x] Code Health / maintainability impact considered
- [x] No breaking change
- [ ] Breaking change
- [x] Security-sensitive change
- [ ] CI, workflow, or release-pipeline impact
- [ ] Dependency-review impact

Risk, rollout, or rollback notes:

```text
Compatibility:
- No public parameter contracts were changed.
- The main intent is to preserve existing behavior while making precedence explicit and shared.

Risk:
- The change touches secret and configuration resolution for upload/publish flows, so the main operational risk is unexpected precedence changes.
- That risk is mitigated by focused regression tests covering explicit overrides, repository/package defaults, environment-variable lookup, and secret-safe error behavior.

Rollback:
- Revert the shared helper introduction plus the small set of migrated call sites in package, release, and update helpers.
- Documentation updates can be reverted independently if needed.
```

> [!IMPORTANT]
> Do not use a public pull request to disclose a vulnerability before coordinated handling.
> Use the private reporting path in `SECURITY.md` for new security issues.

