### PR TITLE
feat(#98): refactor CLI argument handling for improved consistency an…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change `Publish-NovaModule -Local` and `% nova publish --local` so a successful local publish also reloads the
   published
   module from the local install path into the active PowerShell session.
+- Refactor the simple routed `nova` parsers to use shared declarative parser helpers while keeping the existing CLI
+  syntax, validation, and routed command behavior unchanged.
+    - `nova build`, `nova test`, and `nova bump` now share one switch-parser pattern.
+    - `nova update`, `nova version`, and `nova notification` now share one mode-parser pattern.
 
 ### Fixed
 

--- a/src/private/cli/ConvertFromNovaBuildCliArgument.ps1
+++ b/src/private/cli/ConvertFromNovaBuildCliArgument.ps1
@@ -4,20 +4,9 @@ function ConvertFrom-NovaBuildCliArgument {
         [string[]]$Arguments
     )
 
-    $Arguments = ConvertTo-NovaCliArgumentArray -BoundParameters $PSBoundParameters -Arguments $Arguments
-    $options = @{}
-
-    foreach ($token in $Arguments) {
-        switch -Regex ($token) {
-            '^(--continuous-integration|-i)$' {
-                $options.ContinuousIntegration = $true
-            }
-            default {
-                Stop-NovaOperation -Message "Unknown argument: $token" -ErrorId 'Nova.Validation.UnknownCliArgument' -Category InvalidArgument -TargetObject $token
-            }
-        }
+    return ConvertFrom-NovaCliSwitchArgument -Arguments $Arguments -TokenMap @{
+        '--continuous-integration' = 'ContinuousIntegration'
+        '-i' = 'ContinuousIntegration'
     }
-
-    return $options
 }
 

--- a/src/private/cli/ConvertFromNovaBumpCliArgument.ps1
+++ b/src/private/cli/ConvertFromNovaBumpCliArgument.ps1
@@ -4,23 +4,11 @@ function ConvertFrom-NovaBumpCliArgument {
         [string[]]$Arguments
     )
 
-    $Arguments = ConvertTo-NovaCliArgumentArray -BoundParameters $PSBoundParameters -Arguments $Arguments
-    $options = @{}
-
-    foreach ($token in $Arguments) {
-        switch -Regex ($token) {
-            '^(--preview|-p)$' {
-                $options.Preview = $true
-            }
-            '^(--continuous-integration|-i)$' {
-                $options.ContinuousIntegration = $true
-            }
-            default {
-                Stop-NovaOperation -Message "Unknown argument: $token" -ErrorId 'Nova.Validation.UnknownCliArgument' -Category InvalidArgument -TargetObject $token
-            }
-        }
+    return ConvertFrom-NovaCliSwitchArgument -Arguments $Arguments -TokenMap @{
+        '--preview' = 'Preview'
+        '-p' = 'Preview'
+        '--continuous-integration' = 'ContinuousIntegration'
+        '-i' = 'ContinuousIntegration'
     }
-
-    return $options
 }
 

--- a/src/private/cli/ConvertFromNovaCliModeArgument.ps1
+++ b/src/private/cli/ConvertFromNovaCliModeArgument.ps1
@@ -1,0 +1,27 @@
+function Get-NovaCliModeArgumentValue {
+    [CmdletBinding()]
+    param(
+        [string[]]$Arguments,
+        [Parameter(Mandatory)][pscustomobject]$Definition
+    )
+
+    $Arguments = ConvertTo-NovaCliArgumentArray -BoundParameters $PSBoundParameters -Arguments $Arguments
+    if ($Arguments.Count -eq 0) {
+        return $Definition.EmptyResult
+    }
+
+    if ($Arguments.Count -ne 1) {
+        Stop-NovaOperation -Message $Definition.Usage.Message -ErrorId $Definition.Usage.ErrorId -Category InvalidArgument -TargetObject $Arguments
+    }
+
+    $value = $Definition.TokenMap[$Arguments[0]]
+    if ($null -ne $value) {
+        return $value
+    }
+
+    if ($Definition.UnknownArgumentUsesUsageError) {
+        Stop-NovaOperation -Message $Definition.Usage.Message -ErrorId $Definition.Usage.ErrorId -Category InvalidArgument -TargetObject $Arguments
+    }
+
+    Stop-NovaOperation -Message "Unknown argument: $( $Arguments[0] )" -ErrorId 'Nova.Validation.UnknownCliArgument' -Category InvalidArgument -TargetObject $Arguments[0]
+}

--- a/src/private/cli/ConvertFromNovaCliSwitchArgument.ps1
+++ b/src/private/cli/ConvertFromNovaCliSwitchArgument.ps1
@@ -1,0 +1,30 @@
+function Get-NovaCliSwitchOptionName {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][hashtable]$TokenMap,
+        [Parameter(Mandatory)][string]$Token
+    )
+
+    $optionName = $TokenMap[$Token]
+    if ( [string]::IsNullOrWhiteSpace($optionName)) {
+        Stop-NovaOperation -Message "Unknown argument: $Token" -ErrorId 'Nova.Validation.UnknownCliArgument' -Category InvalidArgument -TargetObject $Token
+    }
+
+    return $optionName
+}
+
+function ConvertFrom-NovaCliSwitchArgument {
+    [CmdletBinding()]
+    param(
+        [string[]]$Arguments,
+        [Parameter(Mandatory)][hashtable]$TokenMap
+    )
+
+    $Arguments = ConvertTo-NovaCliArgumentArray -BoundParameters $PSBoundParameters -Arguments $Arguments
+    $options = @{}
+    foreach ($token in $Arguments) {
+        $options[(Get-NovaCliSwitchOptionName -TokenMap $TokenMap -Token $token)] = $true
+    }
+
+    return $options
+}

--- a/src/private/cli/ConvertFromNovaNotificationCliArgument.ps1
+++ b/src/private/cli/ConvertFromNovaNotificationCliArgument.ps1
@@ -4,24 +4,18 @@ function ConvertFrom-NovaNotificationCliArgument {
         [string[]]$Arguments
     )
 
-    $Arguments = ConvertTo-NovaCliArgumentArray -BoundParameters $PSBoundParameters -Arguments $Arguments
-    if ($Arguments.Count -eq 0) {
-        return 'status'
-    }
-
-    if ($Arguments.Count -ne 1) {
-        Stop-NovaOperation -Message "Unsupported 'nova notification' usage. Use 'nova notification', 'nova notification --enable'/'nova notification -e', or 'nova notification --disable'/'nova notification -d'." -ErrorId 'Nova.Validation.UnsupportedNotificationCliUsage' -Category InvalidArgument -TargetObject $Arguments
-    }
-
-    switch -Regex ($Arguments[0]) {
-        '^(--enable|-e)$' {
-            return 'enable'
+    return Get-NovaCliModeArgumentValue -Arguments $Arguments -Definition ([pscustomobject]@{
+        EmptyResult = 'status'
+        TokenMap = @{
+            '--enable' = 'enable'
+            '-e' = 'enable'
+            '--disable' = 'disable'
+            '-d' = 'disable'
         }
-        '^(--disable|-d)$' {
-            return 'disable'
+        Usage = [pscustomobject]@{
+            Message = "Unsupported 'nova notification' usage. Use 'nova notification', 'nova notification --enable'/'nova notification -e', or 'nova notification --disable'/'nova notification -d'."
+            ErrorId = 'Nova.Validation.UnsupportedNotificationCliUsage'
         }
-        default {
-            Stop-NovaOperation -Message "Unknown argument: $( $Arguments[0] )" -ErrorId 'Nova.Validation.UnknownCliArgument' -Category InvalidArgument -TargetObject $Arguments[0]
-        }
-    }
+        UnknownArgumentUsesUsageError = $false
+    })
 }

--- a/src/private/cli/ConvertFromNovaTestCliArgument.ps1
+++ b/src/private/cli/ConvertFromNovaTestCliArgument.ps1
@@ -4,20 +4,9 @@ function ConvertFrom-NovaTestCliArgument {
         [string[]]$Arguments
     )
 
-    $Arguments = ConvertTo-NovaCliArgumentArray -BoundParameters $PSBoundParameters -Arguments $Arguments
-    $options = @{}
-
-    foreach ($token in $Arguments) {
-        switch -Regex ($token) {
-            '^(--build|-b)$' {
-                $options.Build = $true
-            }
-            default {
-                Stop-NovaOperation -Message "Unknown argument: $token" -ErrorId 'Nova.Validation.UnknownCliArgument' -Category InvalidArgument -TargetObject $token
-            }
-        }
+    return ConvertFrom-NovaCliSwitchArgument -Arguments $Arguments -TokenMap @{
+        '--build' = 'Build'
+        '-b' = 'Build'
     }
-
-    return $options
 }
 

--- a/src/private/cli/ConvertFromNovaUpdateCliArgument.ps1
+++ b/src/private/cli/ConvertFromNovaUpdateCliArgument.ps1
@@ -4,10 +4,13 @@ function ConvertFrom-NovaUpdateCliArgument {
         [string[]]$Arguments
     )
 
-    $Arguments = ConvertTo-NovaCliArgumentArray -BoundParameters $PSBoundParameters -Arguments $Arguments
-    if ($Arguments.Count -eq 0) {
-        return @{}
-    }
-
-    Stop-NovaOperation -Message "Unsupported 'nova update' usage. Use 'nova update'." -ErrorId 'Nova.Validation.UnsupportedUpdateCliUsage' -Category InvalidArgument -TargetObject $Arguments
+    return Get-NovaCliModeArgumentValue -Arguments $Arguments -Definition ([pscustomobject]@{
+        EmptyResult = @{}
+        TokenMap = @{}
+        Usage = [pscustomobject]@{
+            Message = "Unsupported 'nova update' usage. Use 'nova update'."
+            ErrorId = 'Nova.Validation.UnsupportedUpdateCliUsage'
+        }
+        UnknownArgumentUsesUsageError = $true
+    })
 }

--- a/src/private/cli/ConvertFromNovaVersionCliArgument.ps1
+++ b/src/private/cli/ConvertFromNovaVersionCliArgument.ps1
@@ -4,14 +4,16 @@ function ConvertFrom-NovaVersionCliArgument {
         [string[]]$Arguments
     )
 
-    $Arguments = ConvertTo-NovaCliArgumentArray -BoundParameters $PSBoundParameters -Arguments $Arguments
-    if ($Arguments.Count -eq 0) {
-        return @{Installed = $false}
-    }
-
-    if ($Arguments.Count -eq 1 -and $Arguments[0] -match '^(--installed|-i)$') {
-        return @{Installed = $true}
-    }
-
-    Stop-NovaOperation -Message "Unsupported 'nova version' usage. Use 'nova version' or 'nova version --installed'/'nova version -i'." -ErrorId 'Nova.Validation.UnsupportedVersionCliUsage' -Category InvalidArgument -TargetObject $Arguments
+    return Get-NovaCliModeArgumentValue -Arguments $Arguments -Definition ([pscustomobject]@{
+        EmptyResult = @{Installed = $false}
+        TokenMap = @{
+            '--installed' = @{Installed = $true}
+            '-i' = @{Installed = $true}
+        }
+        Usage = [pscustomobject]@{
+            Message = "Unsupported 'nova version' usage. Use 'nova version' or 'nova version --installed'/'nova version -i'."
+            ErrorId = 'Nova.Validation.UnsupportedVersionCliUsage'
+        }
+        UnknownArgumentUsesUsageError = $true
+    })
 }

--- a/tests/CliSharedParser.Tests.ps1
+++ b/tests/CliSharedParser.Tests.ps1
@@ -1,0 +1,132 @@
+$script:coverageGapsCliTestSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'CoverageGaps.Cli.TestSupport.ps1')).Path
+. $script:coverageGapsCliTestSupportPath
+$global:cliSharedParserTestSupportFunctionNameList = @(
+    'Assert-TestStructuredCliError'
+)
+
+foreach ($functionName in $global:cliSharedParserTestSupportFunctionNameList) {
+    $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
+    Set-Item -Path "function:global:$functionName" -Value $scriptBlock
+}
+
+BeforeAll {
+    $here = Split-Path -Parent $PSCommandPath
+    $script:repoRoot = Split-Path -Parent $here
+    $script:moduleName = (Get-Content -LiteralPath (Join-Path $script:repoRoot 'project.json') -Raw | ConvertFrom-Json).ProjectName
+    $script:distModuleDir = Join-Path $script:repoRoot "dist/$script:moduleName"
+    $coverageGapsCliTestSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'CoverageGaps.Cli.TestSupport.ps1')).Path
+
+    if (-not (Test-Path -LiteralPath $script:distModuleDir)) {
+        throw "Expected built $script:moduleName module at: $script:distModuleDir. Run Invoke-NovaBuild in the repo root first."
+    }
+
+    . $coverageGapsCliTestSupportPath
+    foreach ($functionName in $global:cliSharedParserTestSupportFunctionNameList) {
+        $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
+        Set-Item -Path "function:global:$functionName" -Value $scriptBlock
+    }
+    Remove-Module $script:moduleName -ErrorAction SilentlyContinue
+    Import-Module $script:distModuleDir -Force
+}
+
+Describe 'CLI shared parser helpers' {
+    It 'ConvertFrom-NovaCliSwitchArgument maps declarative switch schemas into boolean option sets' {
+        InModuleScope $script:moduleName {
+            $options = ConvertFrom-NovaCliSwitchArgument -Arguments @('--preview', '-i') -TokenMap @{
+                '--preview' = 'Preview'
+                '-p' = 'Preview'
+                '--continuous-integration' = 'ContinuousIntegration'
+                '-i' = 'ContinuousIntegration'
+            }
+
+            $options.Preview | Should -BeTrue
+            $options.ContinuousIntegration | Should -BeTrue
+        }
+    }
+
+    It 'Get-NovaCliModeArgumentValue supports empty results, mapped values, usage errors, and unknown arguments' {
+        InModuleScope $script:moduleName {
+            $notificationDefinition = [pscustomobject]@{
+                EmptyResult = 'status'
+                TokenMap = @{
+                    '--enable' = 'enable'
+                }
+                Usage = [pscustomobject]@{
+                    Message = "Unsupported 'nova notification' usage."
+                    ErrorId = 'Nova.Validation.UnsupportedNotificationCliUsage'
+                }
+                UnknownArgumentUsesUsageError = $false
+            }
+            $updateDefinition = [pscustomobject]@{
+                EmptyResult = @{}
+                TokenMap = @{}
+                Usage = [pscustomobject]@{
+                    Message = "Unsupported 'nova update' usage. Use 'nova update'."
+                    ErrorId = 'Nova.Validation.UnsupportedUpdateCliUsage'
+                }
+                UnknownArgumentUsesUsageError = $true
+            }
+
+            $emptyResult = Get-NovaCliModeArgumentValue -Arguments @() -Definition $notificationDefinition
+            $mappedResult = Get-NovaCliModeArgumentValue -Arguments @('--enable') -Definition $notificationDefinition
+
+            $usageError = $null
+            try {
+                Get-NovaCliModeArgumentValue -Arguments @('--enable', '--disable') -Definition $notificationDefinition
+            }
+            catch {
+                $usageError = $_
+            }
+
+            $unknownArgumentError = $null
+            try {
+                Get-NovaCliModeArgumentValue -Arguments @('--bogus') -Definition $notificationDefinition
+            }
+            catch {
+                $unknownArgumentError = $_
+            }
+
+            $updateUsageError = $null
+            try {
+                Get-NovaCliModeArgumentValue -Arguments @('--bogus') -Definition $updateDefinition
+            }
+            catch {
+                $updateUsageError = $_
+            }
+
+            $emptyResult | Should -Be 'status'
+            $mappedResult | Should -Be 'enable'
+            Assert-TestStructuredCliError -ThrownError $usageError -ExpectedError ([pscustomobject]@{
+                Message = "Unsupported 'nova notification' usage."
+                ErrorId = 'Nova.Validation.UnsupportedNotificationCliUsage'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+            })
+            Assert-TestStructuredCliError -ThrownError $unknownArgumentError -ExpectedError ([pscustomobject]@{
+                Message = 'Unknown argument: --bogus'
+                ErrorId = 'Nova.Validation.UnknownCliArgument'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                TargetObject = '--bogus'
+            })
+            Assert-TestStructuredCliError -ThrownError $updateUsageError -ExpectedError ([pscustomobject]@{
+                Message = "Unsupported 'nova update' usage. Use 'nova update'."
+                ErrorId = 'Nova.Validation.UnsupportedUpdateCliUsage'
+                Category = [System.Management.Automation.ErrorCategory]::InvalidArgument
+            })
+        }
+    }
+
+    It 'the shared parsers preserve the existing routed CLI contracts for bump, version, update, and notification' {
+        InModuleScope $script:moduleName {
+            $bumpOptions = ConvertFrom-NovaBumpCliArgument -Arguments @('--preview', '--continuous-integration')
+
+            $bumpOptions.Preview | Should -BeTrue
+            $bumpOptions.ContinuousIntegration | Should -BeTrue
+            (ConvertFrom-NovaVersionCliArgument).Installed | Should -BeFalse
+            (ConvertFrom-NovaVersionCliArgument -Arguments @('--installed')).Installed | Should -BeTrue
+            ConvertFrom-NovaNotificationCliArgument | Should -Be 'status'
+            ConvertFrom-NovaNotificationCliArgument -Arguments @('--enable') | Should -Be 'enable'
+            ConvertFrom-NovaNotificationCliArgument -Arguments @('-d') | Should -Be 'disable'
+            (ConvertFrom-NovaUpdateCliArgument).Count | Should -Be 0
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Refactor the simple routed `nova` CLI parsers to use shared declarative parser helpers instead of repeating manual token-walking logic in each command-specific parser.
- This change was needed to make CLI parsing more consistent, easier to extend, and easier to keep aligned across parsing, validation, and routed command behavior without changing the existing CLI contract.
- Follow-up for `plan.md` CLI parser maintainability work.

## Affected area

- [x] `nova` CLI or command routing
- [ ] Public PowerShell cmdlet behavior
- [ ] Scaffolding or `project.json` handling
- [x] Build, test, analyzer, coverage, or CI helper flow
- [ ] Package, raw upload, or package metadata workflow
- [ ] Publish, release, semantic-release, or GitHub Actions automation
- [x] Self-update or notification preference behavior
- [ ] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
- [ ] End-user docs (`docs/*.html`)
- [ ] Command help (`docs/NovaModuleTools/en-US/*.md`)
- [ ] `src/resources/example/`
- [ ] Dependency or manifest changes (`package.json`, workflow dependencies, release tooling)
- [ ] Security-sensitive change
- [ ] Documentation-only change
- [x] Other

## Review guidance

- Start with the shared parser helpers in `src/private/cli/ConvertFromNovaCliSwitchArgument.ps1` and `src/private/cli/ConvertFromNovaCliModeArgument.ps1`, then review the migrated command parsers in `src/private/cli/`.
- Primary files changed:
  - `src/private/cli/ConvertFromNovaBuildCliArgument.ps1`
  - `src/private/cli/ConvertFromNovaBumpCliArgument.ps1`
  - `src/private/cli/ConvertFromNovaNotificationCliArgument.ps1`
  - `src/private/cli/ConvertFromNovaTestCliArgument.ps1`
  - `src/private/cli/ConvertFromNovaUpdateCliArgument.ps1`
  - `src/private/cli/ConvertFromNovaVersionCliArgument.ps1`
  - `tests/CliSharedParser.Tests.ps1`
  - `CHANGELOG.md`
- Trade-offs / limitations:
  - This is an incremental refactor, not a full rewrite of every CLI parser.
  - The existing CLI syntax and behavior were intentionally preserved.
  - `init` and `deploy` remain specialized and can be evaluated separately in follow-up work.

## Validation

- [x] `Invoke-NovaBuild`
- [ ] `Test-NovaBuild`
- [ ] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
- [x] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`,
  `% nova publish`,
  `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
- [ ] Docs/example only; executable validation not needed

Validation notes:

```text
Commands run:

pwsh -NoLogo -NoProfile -Command 'Set-Location "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools"; Invoke-NovaBuild'

pwsh -NoLogo -NoProfile -Command 'Set-Location "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools"; Invoke-Pester ./tests/CliSharedParser.Tests.ps1 -Output Detailed'

pwsh -NoLogo -NoProfile -Command 'Set-Location "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools"; Invoke-Pester ./tests/CoverageGaps.Cli.Tests.ps1 -Output Detailed'

pwsh -NoLogo -NoProfile -Command 'Set-Location "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools"; Invoke-Pester ./tests/NovaCommandModel.BumpAndCli.Tests.ps1 -Output Detailed'

pwsh -NoLogo -NoProfile -Command 'Set-Location "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools"; Invoke-Pester ./tests/NovaCommandModel.StandaloneCli.Tests.ps1 -Output Detailed'

git -C "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools" --no-pager diff --check
git -C "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools" --no-pager diff --cached --check

Results:
- Invoke-NovaBuild passed.
- CliSharedParser.Tests.ps1: 3 passed.
- CoverageGaps.Cli.Tests.ps1: 56 passed.
- NovaCommandModel.BumpAndCli.Tests.ps1: 33 passed.
- NovaCommandModel.StandaloneCli.Tests.ps1: 69 passed.
- diff --check passed for working tree and index.
- CodeScene pre-commit safeguard passed.

The targeted validation covers the migrated `nova build`, `nova test`, `nova bump`, `nova update`, `nova version`, and `nova notification` parsing paths through focused and standalone CLI tests.
```

## Documentation and release follow-up

- [ ] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
- [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
- [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [ ] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
- [ ] `docs/*.html` updated if end-user workflows or examples changed
- [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
  changed
- [ ] No documentation, changelog, or example updates were needed

## Maintainability, compatibility, and risk

- [x] Code Health / maintainability impact considered
- [x] No breaking change
- [ ] Breaking change
- [ ] Security-sensitive change
- [ ] CI, workflow, or release-pipeline impact
- [ ] Dependency-review impact

Risk, rollout, or rollback notes:

```text
Compatibility impact is low because the refactor preserves existing CLI syntax, validation behavior, and routed command contracts while centralizing repeated parsing patterns.

Rollback is straightforward: revert the shared helper introduction and restore the prior command-specific parser implementations in src/private/cli/.

README.md was reviewed and no update was needed because contributor workflow and user-facing command syntax did not change; the change is maintainability-focused. CHANGELOG.md was updated because the refactor is relevant to maintainers and reviewers.
```

> [!IMPORTANT]
> Do not use a public pull request to disclose a vulnerability before coordinated handling.
> Use the private reporting path in `SECURITY.md` for new security issues.

