### PR TITLE
feat(#99): enhance adapter architecture for external dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       entry point for all
       operations.
 - Change `nova` help to a dedicated CLI-native help system with both short and long command help forms.
+- Isolate external workflow execution behind smaller internal adapters so git, raw package upload, repository publish,
+  self-update, settings-file I/O, and CLI environment access have clearer change points and smaller test seams.
     - `% nova <command> --help` and `% nova <command> -h` now show short CLI help.
     - `% nova --help <command>` and `% nova -h <command>` now show long CLI help.
   - Long command help now includes the matching public GitHub Pages guide URL for the selected command, while short help

--- a/src/private/cli/ConfirmNovaCliAction.ps1
+++ b/src/private/cli/ConfirmNovaCliAction.ps1
@@ -52,14 +52,27 @@ function Read-NovaCliPromptKey {
     }
 }
 
+function Get-NovaCliConfirmResponseKey {
+    [CmdletBinding()]
+    param()
+
+    $response = Get-NovaEnvironmentVariableValue -Name 'NOVA_CLI_CONFIRM_RESPONSE'
+    if ( [string]::IsNullOrWhiteSpace($response)) {
+        return $null
+    }
+
+    return [char]$response[0]
+}
+
 function Get-NovaCliCommandPromptKey {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string]$Message
     )
 
-    if (-not [string]::IsNullOrWhiteSpace($env:NOVA_CLI_CONFIRM_RESPONSE)) {
-        return [char]$env:NOVA_CLI_CONFIRM_RESPONSE[0]
+    $configuredResponse = Get-NovaCliConfirmResponseKey
+    if ($null -ne $configuredResponse) {
+        return $configuredResponse
     }
 
     Write-Host 'Confirm'

--- a/src/private/cli/ConfirmNovaCliAction.ps1
+++ b/src/private/cli/ConfirmNovaCliAction.ps1
@@ -37,7 +37,15 @@ function Invoke-NovaCliConsoleReadKey {
     [CmdletBinding()]
     param()
 
-    return [Console]::ReadKey($true)
+    $consoleReader = Get-NovaCliConsoleReadKeyReader
+    return & $consoleReader
+}
+
+function Get-NovaCliConsoleReadKeyReader {
+    [CmdletBinding()]
+    param()
+
+    return {[Console]::ReadKey($true)}
 }
 
 function Read-NovaCliPromptKey {
@@ -140,4 +148,3 @@ function Confirm-NovaCliCommandAction {
         return
     } while ($true)
 }
-

--- a/src/private/cli/GetNovaCliInstallDirectory.ps1
+++ b/src/private/cli/GetNovaCliInstallDirectory.ps1
@@ -8,7 +8,7 @@ function Get-NovaCliInstallDirectory {
         return [System.IO.Path]::GetFullPath($DestinationDirectory)
     }
 
-    $homeDirectory = $env:HOME
+    $homeDirectory = Get-NovaEnvironmentVariableValue -Name 'HOME'
 
     if ( [string]::IsNullOrWhiteSpace($homeDirectory)) {
         Stop-NovaOperation -Message 'HOME environment variable is not set. Provide -DestinationDirectory explicitly.' -ErrorId 'Nova.Environment.HomeDirectoryMissing' -Category ResourceUnavailable -TargetObject 'HOME'

--- a/src/private/cli/TestNovaCliDirectoryOnPath.ps1
+++ b/src/private/cli/TestNovaCliDirectoryOnPath.ps1
@@ -5,7 +5,8 @@ function Test-NovaCliDirectoryOnPath {
     )
 
     $resolvedDirectory = [System.IO.Path]::GetFullPath($Directory)
-    foreach ($entry in @($env:PATH -split [regex]::Escape([string][System.IO.Path]::PathSeparator))) {
+    $pathValue = Get-NovaEnvironmentVariableValue -Name 'PATH'
+    foreach ($entry in @($pathValue -split [regex]::Escape([string][System.IO.Path]::PathSeparator))) {
         if ( [string]::IsNullOrWhiteSpace($entry)) {
             continue
         }

--- a/src/private/package/InvokeNovaPackageArtifactUpload.ps1
+++ b/src/private/package/InvokeNovaPackageArtifactUpload.ps1
@@ -9,22 +9,8 @@ function Invoke-NovaPackageArtifactUpload {
         Stop-NovaOperation -Message "Package file not found: $( $UploadArtifact.PackagePath )" -ErrorId 'Nova.Environment.PackageUploadFileNotFound' -Category ObjectNotFound -TargetObject $UploadArtifact.PackagePath
     }
 
-    $webRequestParameters = @{
-        Uri = $UploadArtifact.UploadUrl
-        Method = 'Put'
-        InFile = $UploadArtifact.PackagePath
-    }
-    if (@($UploadArtifact.Headers.Keys).Count -gt 0) {
-        $webRequestParameters.Headers = $UploadArtifact.Headers
-    }
-
-    $webRequestCommand = Get-Command -Name Invoke-WebRequest -CommandType Cmdlet -ErrorAction Stop
-    if ( $webRequestCommand.Parameters.ContainsKey('UseBasicParsing')) {
-        $webRequestParameters.UseBasicParsing = $true
-    }
-
     try {
-        $response = Invoke-WebRequest @webRequestParameters
+        $response = Invoke-NovaPackageUploadRequest -UploadArtifact $UploadArtifact
     }
     catch {
         Stop-NovaOperation -Message "Package upload failed for $( $UploadArtifact.PackagePath ) -> $( $UploadArtifact.UploadUrl ). $( $_.Exception.Message )" -ErrorId 'Nova.Dependency.PackageUploadRequestFailed' -Category ConnectionError -TargetObject $UploadArtifact.UploadUrl

--- a/src/private/package/InvokeNovaPackageUploadRequest.ps1
+++ b/src/private/package/InvokeNovaPackageUploadRequest.ps1
@@ -1,0 +1,42 @@
+function Get-NovaPackageUploadRequestParameterMap {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$UploadArtifact
+    )
+
+    $parameters = @{
+        Uri = $UploadArtifact.UploadUrl
+        Method = 'Put'
+        InFile = $UploadArtifact.PackagePath
+    }
+    if (@($UploadArtifact.Headers.Keys).Count -gt 0) {
+        $parameters.Headers = $UploadArtifact.Headers
+    }
+
+    return $parameters
+}
+
+function Add-NovaLegacyWebRequestOption {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][hashtable]$Parameters
+    )
+
+    $webRequestCommand = Get-Command -Name Invoke-WebRequest -CommandType Cmdlet -ErrorAction Stop
+    if ( $webRequestCommand.Parameters.ContainsKey('UseBasicParsing')) {
+        $Parameters.UseBasicParsing = $true
+    }
+
+    return $Parameters
+}
+
+function Invoke-NovaPackageUploadRequest {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$UploadArtifact
+    )
+
+    $parameters = Get-NovaPackageUploadRequestParameterMap -UploadArtifact $UploadArtifact
+    $parameters = Add-NovaLegacyWebRequestOption -Parameters $parameters
+    return Invoke-WebRequest @parameters
+}

--- a/src/private/release/GetGitCommitMessagesForVersionBump.ps1
+++ b/src/private/release/GetGitCommitMessagesForVersionBump.ps1
@@ -9,20 +9,38 @@ function Get-GitCommitMessageForVersionBump {
     }
 
     $format = '%s%n%b%n--END-COMMIT--'
-    $lastTag = & git -C $ProjectRoot describe --tags --abbrev=0 2> $null
+    $lastTagResult = Invoke-NovaGitCommand -ProjectRoot $ProjectRoot -Arguments @('describe', '--tags', '--abbrev=0')
+    $logResult = Get-NovaVersionBumpCommitLogResult -ProjectRoot $ProjectRoot -Format $format -LastTagResult $lastTagResult
+    return @(ConvertFrom-NovaVersionBumpCommitLogResult -Result $logResult)
+}
 
-    if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($lastTag)) {
-        $raw = & git -C $ProjectRoot log "$lastTag..HEAD" --format=$format 2> $null
-    }
-    else {
-        $raw = & git -C $ProjectRoot log --format=$format 2> $null
+function Get-NovaVersionBumpCommitLogResult {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ProjectRoot,
+        [Parameter(Mandatory)][string]$Format,
+        [Parameter(Mandatory)][pscustomobject]$LastTagResult
+    )
+
+    $lastTag = Get-NovaGitCommandOutputText -Result $LastTagResult
+    if ($LastTagResult.ExitCode -eq 0 -and -not [string]::IsNullOrWhiteSpace($lastTag)) {
+        return Invoke-NovaGitCommand -ProjectRoot $ProjectRoot -Arguments @('log', "$lastTag..HEAD", "--format=$format")
     }
 
-    if ($LASTEXITCODE -ne 0 -or -not $raw) {
+    return Invoke-NovaGitCommand -ProjectRoot $ProjectRoot -Arguments @('log', "--format=$format")
+}
+
+function ConvertFrom-NovaVersionBumpCommitLogResult {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Result
+    )
+
+    if ($Result.ExitCode -ne 0 -or @($Result.Output).Count -eq 0) {
         return @()
     }
 
-    $text = ($raw -join [Environment]::NewLine)
+    $text = (@($Result.Output) -join [Environment]::NewLine)
     $commits = $text -split '(?m)^--END-COMMIT--\r?$'
     return @($commits | ForEach-Object {$_.Trim()} | Where-Object {-not [string]::IsNullOrWhiteSpace($_)})
 }

--- a/src/private/release/GetNovaVersionLabelForBump.ps1
+++ b/src/private/release/GetNovaVersionLabelForBump.ps1
@@ -34,8 +34,8 @@ function Test-GitRepositoryIsAvailable {
         return $false
     }
 
-    $null = & git -C $ProjectRoot rev-parse --git-dir 2> $null
-    return $LASTEXITCODE -eq 0
+    $result = Invoke-NovaGitCommand -ProjectRoot $ProjectRoot -Arguments @('rev-parse', '--git-dir')
+    return $result.ExitCode -eq 0
 }
 
 function Test-GitRepositoryHasCommittedHead {
@@ -44,8 +44,8 @@ function Test-GitRepositoryHasCommittedHead {
         [Parameter(Mandatory)][string]$ProjectRoot
     )
 
-    $null = & git -C $ProjectRoot rev-parse --verify HEAD 2> $null
-    return $LASTEXITCODE -eq 0
+    $result = Invoke-NovaGitCommand -ProjectRoot $ProjectRoot -Arguments @('rev-parse', '--verify', 'HEAD')
+    return $result.ExitCode -eq 0
 }
 
 function Test-GitRepositoryHasCommitsSinceLatestTag {
@@ -54,11 +54,13 @@ function Test-GitRepositoryHasCommitsSinceLatestTag {
         [Parameter(Mandatory)][string]$ProjectRoot
     )
 
-    $lastTag = & git -C $ProjectRoot describe --tags --abbrev=0 2> $null
-    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($lastTag)) {
+    $lastTagResult = Invoke-NovaGitCommand -ProjectRoot $ProjectRoot -Arguments @('describe', '--tags', '--abbrev=0')
+    $lastTag = Get-NovaGitCommandOutputText -Result $lastTagResult
+    if ($lastTagResult.ExitCode -ne 0 -or [string]::IsNullOrWhiteSpace($lastTag)) {
         return $true
     }
 
-    $commitCount = & git -C $ProjectRoot rev-list --count "$lastTag..HEAD" 2> $null
-    return $LASTEXITCODE -ne 0 -or $commitCount -ne '0'
+    $commitCountResult = Invoke-NovaGitCommand -ProjectRoot $ProjectRoot -Arguments @('rev-list', '--count', "$lastTag..HEAD")
+    $commitCount = Get-NovaGitCommandOutputText -Result $commitCountResult
+    return $commitCountResult.ExitCode -ne 0 -or $commitCount -ne '0'
 }

--- a/src/private/release/InitiateGitRepo.ps1
+++ b/src/private/release/InitiateGitRepo.ps1
@@ -5,32 +5,44 @@ function New-InitiateGitRepo {
         [string]$DirectoryPath
     )
 
-    # Check if Git is installed
-    if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
-        Write-Warning 'Git is not installed. Please install Git and initialize repo manually' 
+    if (-not (Test-NovaGitCommandAvailable)) {
+        Write-Warning 'Git is not installed. Please install Git and initialize repo manually'
         return
     }
-    Push-Location -StackName 'GitInit'
+
+    if (Test-Path -LiteralPath (Join-Path $DirectoryPath '.git')) {
+        Write-Warning 'A Git repository already exists in this directory.'
+        return
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($DirectoryPath, "Initiating git on $DirectoryPath")) {
+        return
+    }
+
     try {
-        # Navigate to the specified directory
-        Set-Location $DirectoryPath
-
-        # Check if a Git repository already exists
-        if (Test-Path -Path '.git') {
-            Write-Warning 'A Git repository already exists in this directory.'
-            return
-        }
-
-        if ( $PSCmdlet.ShouldProcess($DirectoryPath, ("Initiating git on $DirectoryPath"))) {
-            try {
-                git init | Out-Null
-            } catch {
-                Stop-NovaOperation -Message "Failed to initialize Git repo: $( $_.Exception.Message )" -ErrorId 'Nova.Dependency.GitRepositoryInitializationFailed' -Category OpenError -TargetObject $DirectoryPath
-            }
-        }
-        Write-Verbose 'Git repository initialized successfully'
+        $result = Invoke-NovaGitCommand -ProjectRoot $DirectoryPath -Arguments @('init')
     }
-    finally {
-        Pop-Location -StackName 'GitInit'
+    catch {
+        Stop-NovaOperation -Message "Failed to initialize Git repo: $( $_.Exception.Message )" -ErrorId 'Nova.Dependency.GitRepositoryInitializationFailed' -Category OpenError -TargetObject $DirectoryPath
     }
+
+    if ($result.ExitCode -ne 0) {
+        Stop-NovaOperation -Message (Get-NovaGitInitializationFailureMessage -Result $result) -ErrorId 'Nova.Dependency.GitRepositoryInitializationFailed' -Category OpenError -TargetObject $DirectoryPath
+    }
+
+    Write-Verbose 'Git repository initialized successfully'
+}
+
+function Get-NovaGitInitializationFailureMessage {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Result
+    )
+
+    $details = Get-NovaGitCommandOutputText -Result $Result
+    if ( [string]::IsNullOrWhiteSpace($details)) {
+        return 'Failed to initialize Git repo.'
+    }
+
+    return "Failed to initialize Git repo: $details"
 }

--- a/src/private/release/InvokeNovaRepositoryPublishCommand.ps1
+++ b/src/private/release/InvokeNovaRepositoryPublishCommand.ps1
@@ -1,0 +1,8 @@
+function Invoke-NovaRepositoryPublishCommand {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][hashtable]$PublishParameters
+    )
+
+    Publish-PSResource @PublishParameters
+}

--- a/src/private/release/PublishNovaBuiltModuleToRepository.ps1
+++ b/src/private/release/PublishNovaBuiltModuleToRepository.ps1
@@ -11,6 +11,29 @@ function Get-NovaPublishRepositoryDefaultApiKeyEnvironmentVariable {
     return $null
 }
 
+function Get-NovaRepositoryPublishParameterMap {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
+        [Parameter(Mandatory)][string]$Repository,
+        [string]$ApiKey,
+        [Parameter(Mandatory)][bool]$VerboseRequested
+    )
+
+    $publishParams = @{
+        Path = $ProjectInfo.OutputModuleDir
+        Repository = $Repository
+    }
+    if ($VerboseRequested) {
+        $publishParams.Verbose = $true
+    }
+    if (-not [string]::IsNullOrWhiteSpace($ApiKey)) {
+        $publishParams.ApiKey = $ApiKey
+    }
+
+    return $publishParams
+}
+
 function Publish-NovaBuiltModuleToRepository {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(
@@ -27,23 +50,11 @@ function Publish-NovaBuiltModuleToRepository {
         ExplicitValue = $ApiKey
         DefaultEnvironmentVariableName = Get-NovaPublishRepositoryDefaultApiKeyEnvironmentVariable -Repository $Repository
     })
-
-    $publishParams = @{
-        Path = $ProjectInfo.OutputModuleDir
-        Repository = $Repository
-    }
-
-    if ( $PSBoundParameters.ContainsKey('Verbose')) {
-        $publishParams.Verbose = $true
-    }
-
-    if (-not [string]::IsNullOrWhiteSpace($resolvedApiKey)) {
-        $publishParams.ApiKey = $resolvedApiKey
-    }
+    $publishParams = Get-NovaRepositoryPublishParameterMap -ProjectInfo $ProjectInfo -Repository $Repository -ApiKey $resolvedApiKey -VerboseRequested:$PSBoundParameters.ContainsKey('Verbose')
 
     if (-not $PSCmdlet.ShouldProcess($Repository, 'Publish built module to repository')) {
         return
     }
 
-    Publish-PSResource @publishParams
+    Invoke-NovaRepositoryPublishCommand -PublishParameters $publishParams
 }

--- a/src/private/shared/InvokeNovaGitCommand.ps1
+++ b/src/private/shared/InvokeNovaGitCommand.ps1
@@ -1,0 +1,29 @@
+function Test-NovaGitCommandAvailable {
+    [CmdletBinding()]
+    param()
+
+    return $null -ne (Get-Command -Name 'git' -ErrorAction SilentlyContinue)
+}
+
+function Invoke-NovaGitCommand {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ProjectRoot,
+        [Parameter(Mandatory)][string[]]$Arguments
+    )
+
+    $output = & git -C $ProjectRoot @Arguments 2> $null
+    return [pscustomobject]@{
+        ExitCode = $LASTEXITCODE
+        Output = @($output)
+    }
+}
+
+function Get-NovaGitCommandOutputText {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Result
+    )
+
+    return (@($Result.Output) -join [Environment]::NewLine).Trim()
+}

--- a/src/private/shared/InvokeNovaJsonFile.ps1
+++ b/src/private/shared/InvokeNovaJsonFile.ps1
@@ -1,0 +1,39 @@
+function Read-NovaJsonFileData {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$LiteralPath
+    )
+
+    if (-not (Test-Path -LiteralPath $LiteralPath -PathType Leaf)) {
+        return $null
+    }
+
+    try {
+        return Get-Content -LiteralPath $LiteralPath -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+    }
+    catch {
+        return $null
+    }
+}
+
+function Initialize-NovaDirectoryPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+        $null = New-Item -ItemType Directory -Path $Path -Force
+    }
+}
+
+function Write-NovaJsonFileData {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$LiteralPath,
+        [Parameter(Mandatory)]$Value
+    )
+
+    Initialize-NovaDirectoryPath -Path (Split-Path -Parent $LiteralPath)
+    $Value | ConvertTo-Json | Set-Content -LiteralPath $LiteralPath -Encoding utf8
+}

--- a/src/private/update/InvokeNovaModuleSelfUpdate.ps1
+++ b/src/private/update/InvokeNovaModuleSelfUpdate.ps1
@@ -5,14 +5,6 @@ function Invoke-NovaModuleSelfUpdate {
         [switch]$AllowPrerelease
     )
 
-    $updateParameters = @{
-        Name = $ModuleName
-        ErrorAction = 'Stop'
-    }
-
-    if ($AllowPrerelease) {
-        $updateParameters.AllowPrerelease = $true
-    }
-
-    return Update-Module @updateParameters
+    $updateParameters = Get-NovaModuleUpdateParameterMap -ModuleName $ModuleName -AllowPrereleaseRequested:$AllowPrerelease.IsPresent
+    return Invoke-NovaModuleUpdateCommand -UpdateParameters $updateParameters
 }

--- a/src/private/update/InvokeNovaModuleUpdateCommand.ps1
+++ b/src/private/update/InvokeNovaModuleUpdateCommand.ps1
@@ -1,0 +1,26 @@
+function Get-NovaModuleUpdateParameterMap {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ModuleName,
+        [Parameter(Mandatory)][bool]$AllowPrereleaseRequested
+    )
+
+    $parameters = @{
+        Name = $ModuleName
+        ErrorAction = 'Stop'
+    }
+    if ($AllowPrereleaseRequested) {
+        $parameters.AllowPrerelease = $true
+    }
+
+    return $parameters
+}
+
+function Invoke-NovaModuleUpdateCommand {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][hashtable]$UpdateParameters
+    )
+
+    return Update-Module @UpdateParameters
+}

--- a/src/private/update/ReadNovaUpdateNotificationPreference.ps1
+++ b/src/private/update/ReadNovaUpdateNotificationPreference.ps1
@@ -1,21 +1,19 @@
+function Get-NovaDefaultUpdateNotificationPreference {
+    [CmdletBinding()]
+    param()
+
+    return [pscustomobject]@{
+        PrereleaseNotificationsEnabled = $true
+    }
+}
+
 function Read-NovaUpdateNotificationPreference {
     [CmdletBinding()]
     param()
 
-    $settingsPath = Get-NovaUpdateSettingsFilePath
-    $defaultPreference = [pscustomobject]@{
-        PrereleaseNotificationsEnabled = $true
-    }
-
-    if (-not (Test-Path -LiteralPath $settingsPath -PathType Leaf)) {
-        return $defaultPreference
-    }
-
-    try {
-        $settings = Get-Content -LiteralPath $settingsPath -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
-    }
-    catch {
-        return $defaultPreference
+    $settings = Read-NovaJsonFileData -LiteralPath (Get-NovaUpdateSettingsFilePath)
+    if ($null -eq $settings) {
+        return Get-NovaDefaultUpdateNotificationPreference
     }
 
     return [pscustomobject]@{

--- a/src/private/update/WriteNovaUpdateNotificationPreference.ps1
+++ b/src/private/update/WriteNovaUpdateNotificationPreference.ps1
@@ -4,17 +4,9 @@ function Write-NovaUpdateNotificationPreference {
         [Parameter(Mandatory)][bool]$PrereleaseNotificationsEnabled
     )
 
-    $settingsPath = Get-NovaUpdateSettingsFilePath
-    $settingsDirectory = Split-Path -Parent $settingsPath
-    if (-not (Test-Path -LiteralPath $settingsDirectory -PathType Container)) {
-        $null = New-Item -ItemType Directory -Path $settingsDirectory -Force
-    }
-
     $settings = [ordered]@{
         PrereleaseNotificationsEnabled = $PrereleaseNotificationsEnabled
     }
 
-    $settings |
-            ConvertTo-Json |
-            Set-Content -LiteralPath $settingsPath -Encoding utf8
+    Write-NovaJsonFileData -LiteralPath (Get-NovaUpdateSettingsFilePath) -Value $settings
 }

--- a/tests/CoverageGaps.Cli.Tests.ps1
+++ b/tests/CoverageGaps.Cli.Tests.ps1
@@ -852,6 +852,23 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
         }
     }
 
+    It 'Invoke-NovaCliConsoleReadKey invokes the shared console reader delegate' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaCliConsoleReadKeyReader {
+                $delegate = {
+                    [pscustomobject]@{KeyChar = [char]'y'}
+                }
+
+                return $delegate
+            }
+
+            $result = Invoke-NovaCliConsoleReadKey
+
+            $result.KeyChar | Should -Be ([char]'y')
+            Assert-MockCalled Get-NovaCliConsoleReadKeyReader -Times 1
+        }
+    }
+
     It 'Invoke-NovaCliConsoleReadKey executes the console read path when standard input is redirected' {
         $runnerPath = Join-Path $TestDrive 'Invoke-NovaCliConsoleReadKey.Runner.ps1'
         $stdinPath = Join-Path $TestDrive 'Invoke-NovaCliConsoleReadKey.stdin.txt'

--- a/tests/CoverageGaps.Cli.Tests.ps1
+++ b/tests/CoverageGaps.Cli.Tests.ps1
@@ -1012,6 +1012,15 @@ catch {
         }
     }
 
+    It 'Get-NovaCliInstallDirectory reads HOME through the shared environment helper' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaEnvironmentVariableValue {'/tmp/nova-home'} -ParameterFilter {$Name -eq 'HOME'}
+
+            Get-NovaCliInstallDirectory | Should -Be ([System.IO.Path]::Join('/tmp/nova-home', '.local', 'bin'))
+            Assert-MockCalled Get-NovaEnvironmentVariableValue -Times 1 -ParameterFilter {$Name -eq 'HOME'}
+        }
+    }
+
     It 'Invoke-NovaCliInitCommand rejects WhatIf with a structured validation error' {
         InModuleScope $script:moduleName {
             $unsupportedWhatIfError = $null
@@ -1243,6 +1252,17 @@ catch {
             finally {
                 $env:PATH = $originalPath
             }
+        }
+    }
+
+    It 'Test-NovaCliDirectoryOnPath reads PATH through the shared environment helper' {
+        InModuleScope $script:moduleName {
+            $separator = [string][System.IO.Path]::PathSeparator
+            $targetDirectory = [System.IO.Path]::GetFullPath($TestDrive)
+            Mock Get-NovaEnvironmentVariableValue {"/tmp/other${separator}$targetDirectory"} -ParameterFilter {$Name -eq 'PATH'}
+
+            Test-NovaCliDirectoryOnPath -Directory $TestDrive | Should -BeTrue
+            Assert-MockCalled Get-NovaEnvironmentVariableValue -Times 1 -ParameterFilter {$Name -eq 'PATH'}
         }
     }
 

--- a/tests/CoverageGaps.Cli.Tests.ps1
+++ b/tests/CoverageGaps.Cli.Tests.ps1
@@ -852,6 +852,15 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
         }
     }
 
+    It 'Get-NovaCliConsoleReadKeyReader returns the default console read delegate' {
+        InModuleScope $script:moduleName {
+            $reader = Get-NovaCliConsoleReadKeyReader
+
+            $reader | Should -BeOfType 'scriptblock'
+            ($reader.ToString()).Trim() | Should -Be '[Console]::ReadKey($true)'
+        }
+    }
+
     It 'Invoke-NovaCliConsoleReadKey invokes the shared console reader delegate' {
         InModuleScope $script:moduleName {
             Mock Get-NovaCliConsoleReadKeyReader {

--- a/tests/CoverageGaps.ReleaseInternals.Tests.ps1
+++ b/tests/CoverageGaps.ReleaseInternals.Tests.ps1
@@ -400,6 +400,76 @@ Describe 'Coverage gaps for release and git internals' {
         }
     }
 
+    It 'Get-GitCommitMessageForVersionBump uses the shared git adapter to resolve tagged commit history' {
+        InModuleScope $script:moduleName {
+            $projectRoot = Join-Path $TestDrive 'mocked-git-history'
+            New-Item -ItemType Directory -Path (Join-Path $projectRoot '.git') -Force | Out-Null
+
+            Mock Invoke-NovaGitCommand {
+                if ($Arguments[0] -eq 'describe') {
+                    return [pscustomobject]@{ExitCode = 0; Output = @('v1.0.0')}
+                }
+
+                return [pscustomobject]@{
+                    ExitCode = 0
+                    Output = @(
+                        'docs: update readme'
+                        ''
+                        '--END-COMMIT--'
+                        'fix: patch bug'
+                        'Detailed patch note'
+                        '--END-COMMIT--'
+                    )
+                }
+            }
+
+            $messages = @(Get-GitCommitMessageForVersionBump -ProjectRoot $projectRoot)
+
+            $messages | Should -Be @(
+                'docs: update readme'
+                "fix: patch bug$( [Environment]::NewLine )Detailed patch note"
+            )
+            Assert-MockCalled Invoke-NovaGitCommand -Times 1 -ParameterFilter {$ProjectRoot -eq $projectRoot -and $Arguments[0] -eq 'describe'}
+            Assert-MockCalled Invoke-NovaGitCommand -Times 1 -ParameterFilter {$ProjectRoot -eq $projectRoot -and $Arguments[0] -eq 'log' -and $Arguments[1] -eq 'v1.0.0..HEAD'}
+        }
+    }
+
+    It 'Get-NovaVersionLabelForBump uses the shared git adapter to detect a tagged head with no new commits' {
+        InModuleScope $script:moduleName {
+            $projectRoot = Join-Path $TestDrive 'mocked-git-state'
+            New-Item -ItemType Directory -Path (Join-Path $projectRoot '.git') -Force | Out-Null
+
+            Mock Invoke-NovaGitCommand {
+                switch ($Arguments[0]) {
+                    'rev-parse' {
+                        return [pscustomobject]@{ExitCode = 0; Output = @('.git')}
+                    }
+                    'describe' {
+                        return [pscustomobject]@{ExitCode = 0; Output = @('v1.0.0')}
+                    }
+                    'rev-list' {
+                        return [pscustomobject]@{ExitCode = 0; Output = @('0')}
+                    }
+                    default {
+                        throw "Unexpected git args: $( $Arguments -join ' ' )"
+                    }
+                }
+            }
+
+            $thrown = $null
+            try {
+                Get-NovaVersionLabelForBump -ProjectRoot $projectRoot
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown.Exception.Message | Should -Be 'Cannot bump version because there are no commits since the latest tag.'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Workflow.NoCommitsSinceLatestTag'
+            Assert-MockCalled Invoke-NovaGitCommand -Times 1 -ParameterFilter {$Arguments[0] -eq 'rev-list' -and $Arguments[2] -eq 'v1.0.0..HEAD'}
+        }
+    }
+
     It 'Get-NovaVersionLabelForBump throws a clear error when the repository has no commits yet' {
         if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
             Set-ItResult -Skipped -Because 'git is not available in this environment'

--- a/tests/CoverageGaps.ReleaseInternals.Tests.ps1
+++ b/tests/CoverageGaps.ReleaseInternals.Tests.ps1
@@ -470,6 +470,31 @@ Describe 'Coverage gaps for release and git internals' {
         }
     }
 
+    It 'Get-NovaVersionLabelForBump returns Patch when the repository has commits but no tags yet' {
+        InModuleScope $script:moduleName {
+            $projectRoot = Join-Path $TestDrive 'mocked-git-without-tags'
+            New-Item -ItemType Directory -Path (Join-Path $projectRoot '.git') -Force | Out-Null
+
+            Mock Invoke-NovaGitCommand {
+                switch ($Arguments[0]) {
+                    'rev-parse' {
+                        return [pscustomobject]@{ExitCode = 0; Output = @('.git')}
+                    }
+                    'describe' {
+                        return [pscustomobject]@{ExitCode = 1; Output = @()}
+                    }
+                    default {
+                        throw "Unexpected git args: $( $Arguments -join ' ' )"
+                    }
+                }
+            }
+
+            Get-NovaVersionLabelForBump -ProjectRoot $projectRoot | Should -Be 'Patch'
+            Assert-MockCalled Invoke-NovaGitCommand -Times 1 -ParameterFilter {$Arguments[0] -eq 'describe' -and $Arguments[1] -eq '--tags'}
+            Assert-MockCalled Invoke-NovaGitCommand -Times 0 -ParameterFilter {$Arguments[0] -eq 'rev-list'}
+        }
+    }
+
     It 'Get-NovaVersionLabelForBump throws a clear error when the repository has no commits yet' {
         if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
             Set-ItResult -Skipped -Because 'git is not available in this environment'
@@ -601,5 +626,3 @@ Describe 'Coverage gaps for release and git internals' {
         }
     }
 }
-
-

--- a/tests/NovaCommandModel.PackageUpload.Tests.ps1
+++ b/tests/NovaCommandModel.PackageUpload.Tests.ps1
@@ -809,6 +809,36 @@ Describe 'Nova command model - package upload behavior' {
         }
     }
 
+    It 'Invoke-NovaPackageArtifactUpload delegates request execution to the upload adapter' {
+        $layout = Initialize-TestNovaPackageUploadLayout -ProjectRoot (Join-Path $TestDrive 'upload-request-adapter')
+        $packagePath = New-TestNovaPackageArtifactFile -Directory $layout.PackageOutputDir -Name 'PackageProject.2.3.4.zip'
+
+        InModuleScope $script:moduleName -Parameters @{PackagePath = $packagePath} {
+            param($PackagePath)
+
+            $uploadArtifact = [pscustomobject]@{
+                Type = 'Zip'
+                PackagePath = $PackagePath
+                PackageFileName = 'PackageProject.2.3.4.zip'
+                Repository = 'LocalRaw'
+                UploadUrl = 'https://packages.example/raw/PackageProject.2.3.4.zip'
+                Headers = [ordered]@{'X-Trace-Id' = 'trace-123'}
+            }
+
+            Mock Invoke-NovaPackageUploadRequest {
+                [pscustomobject]@{StatusCode = 202}
+            }
+
+            $result = Invoke-NovaPackageArtifactUpload -UploadArtifact $uploadArtifact
+
+            $result.StatusCode | Should -Be 202
+            Assert-MockCalled Invoke-NovaPackageUploadRequest -Times 1 -ParameterFilter {
+                $UploadArtifact.PackagePath -eq $PackagePath -and
+                        $UploadArtifact.Headers['X-Trace-Id'] -eq 'trace-123'
+            }
+        }
+    }
+
     It 'Invoke-NovaPackageArtifactUpload exposes a structured dependency error when the upload request fails' {
         $layout = Initialize-TestNovaPackageUploadLayout -ProjectRoot (Join-Path $TestDrive 'upload-request-fails')
         $packagePath = New-TestNovaPackageArtifactFile -Directory $layout.PackageOutputDir -Name 'PackageProject.2.3.4.zip'
@@ -825,7 +855,7 @@ Describe 'Nova command model - package upload behavior' {
                 Headers = [ordered]@{}
             }
 
-            Mock Invoke-WebRequest {throw 'network down'}
+            Mock Invoke-NovaPackageUploadRequest {throw 'network down'}
 
             $thrown = $null
             try {

--- a/tests/NovaCommandModel.ReleasePublish.Tests.ps1
+++ b/tests/NovaCommandModel.ReleasePublish.Tests.ps1
@@ -642,6 +642,21 @@ Describe 'Nova command model - release and publish behavior' {
         }
     }
 
+    It 'Publish-NovaBuiltModuleToRepository delegates publish execution through the repository adapter' {
+        InModuleScope $script:moduleName {
+            Mock Invoke-NovaRepositoryPublishCommand {}
+
+            Publish-NovaBuiltModuleToRepository -ProjectInfo ([pscustomobject]@{OutputModuleDir = '/tmp/dist'}) -Repository PSGallery -ApiKey 'gallery-secret' -Verbose
+
+            Assert-MockCalled Invoke-NovaRepositoryPublishCommand -Times 1 -ParameterFilter {
+                $PublishParameters.Path -eq '/tmp/dist' -and
+                        $PublishParameters.Repository -eq 'PSGallery' -and
+                        $PublishParameters.ApiKey -eq 'gallery-secret' -and
+                        $PublishParameters.Verbose
+            }
+        }
+    }
+
     It 'Get-NovaPackageWorkflowContext resolves package metadata, target, and operation for all requested package types' {
         InModuleScope $script:moduleName {
             $projectInfo = [pscustomobject]@{

--- a/tests/RemainingCommandCoverage.Tests.ps1
+++ b/tests/RemainingCommandCoverage.Tests.ps1
@@ -131,6 +131,48 @@ Describe 'Coverage for remaining command and filesystem branches' {
         }
     }
 
+    It 'New-InitiateGitRepo stops with a default failure message when git init returns no details' {
+        $repoPath = Join-Path $TestDrive 'git-init-nonzero'
+        New-Item -ItemType Directory -Path $repoPath -Force | Out-Null
+
+        InModuleScope $script:moduleName -Parameters @{RepoPath = $repoPath} {
+            param($RepoPath)
+
+            Mock Get-Command {[pscustomobject]@{Name = 'git'}} -ParameterFilter {$Name -eq 'git'}
+            Mock Invoke-NovaGitCommand {
+                [pscustomobject]@{
+                    ExitCode = 1
+                    Output = @()
+                }
+            }
+
+            $thrown = $null
+            try {
+                New-InitiateGitRepo -DirectoryPath $RepoPath -Confirm:$false
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be 'Failed to initialize Git repo.'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Dependency.GitRepositoryInitializationFailed'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::OpenError)
+            $thrown.TargetObject | Should -Be $RepoPath
+        }
+    }
+
+    It 'Get-NovaGitInitializationFailureMessage includes git output details when they are available' {
+        InModuleScope $script:moduleName {
+            $result = [pscustomobject]@{
+                ExitCode = 1
+                Output = @('permission denied')
+            }
+
+            Get-NovaGitInitializationFailureMessage -Result $result | Should -Be 'Failed to initialize Git repo: permission denied'
+        }
+    }
+
     It 'Get-NovaTestWorkflowContext prepares the Pester workflow state and resolves the report writers' -ForEach @(
         @{Build = $false; ExpectedOperation = 'Run Pester tests and write test results'}
         @{Build = $true; ExpectedOperation = 'Build project, run Pester tests, and write test results'}

--- a/tests/RemainingHelperCoverage.Tests.ps1
+++ b/tests/RemainingHelperCoverage.Tests.ps1
@@ -464,6 +464,17 @@ function Get-Second {
         }
     }
 
+    It 'Read-NovaJsonFileData returns null when the file content is not valid JSON' {
+        $jsonPath = Join-Path $TestDrive 'invalid-settings.json'
+        '{ invalid json }' | Set-Content -LiteralPath $jsonPath -Encoding utf8
+
+        InModuleScope $script:moduleName -Parameters @{JsonPath = $jsonPath} {
+            param($JsonPath)
+
+            Read-NovaJsonFileData -LiteralPath $JsonPath | Should -BeNullOrEmpty
+        }
+    }
+
     It 'Write-ProjectJsonData preserves nested objects, arrays, and unicode text when writing project.json' {
         $projectJsonPath = Join-Path $TestDrive 'written-project.json'
 

--- a/tests/UpdateNotification.Tests.ps1
+++ b/tests/UpdateNotification.Tests.ps1
@@ -137,6 +137,34 @@ Describe 'Update notification behavior' {
         }
     }
 
+    It 'Read-NovaUpdateNotificationPreference delegates settings file parsing to the shared JSON adapter' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaUpdateSettingsFilePath {'/tmp/nova/settings.json'}
+            Mock Read-NovaJsonFileData {
+                [pscustomobject]@{PrereleaseNotificationsEnabled = $false}
+            }
+
+            $result = Read-NovaUpdateNotificationPreference
+
+            $result.PrereleaseNotificationsEnabled | Should -BeFalse
+            Assert-MockCalled Read-NovaJsonFileData -Times 1 -ParameterFilter {$LiteralPath -eq '/tmp/nova/settings.json'}
+        }
+    }
+
+    It 'Write-NovaUpdateNotificationPreference delegates settings persistence to the shared JSON adapter' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaUpdateSettingsFilePath {'/tmp/nova/settings.json'}
+            Mock Write-NovaJsonFileData {}
+
+            Write-NovaUpdateNotificationPreference -PrereleaseNotificationsEnabled:$false
+
+            Assert-MockCalled Write-NovaJsonFileData -Times 1 -ParameterFilter {
+                $LiteralPath -eq '/tmp/nova/settings.json' -and
+                        -not $Value.PrereleaseNotificationsEnabled
+            }
+        }
+    }
+
     It 'Set-NovaUpdateNotificationPreference delegates context resolution and workflow execution to private helpers' {
         InModuleScope $script:moduleName {
             Mock Get-NovaUpdateNotificationPreferenceChangeContext {
@@ -562,6 +590,20 @@ Describe 'Update notification behavior' {
             {Invoke-NovaModuleSelfUpdate -ModuleName 'NovaModuleTools' -AllowPrerelease} | Should -Throw '*was not installed by using Install-Module*'
             Assert-MockCalled Update-Module -Times 1 -ParameterFilter {
                 $Name -eq 'NovaModuleTools' -and $AllowPrerelease -and $ErrorAction -eq 'Stop'
+            }
+        }
+    }
+
+    It 'Invoke-NovaModuleSelfUpdate delegates through the self-update adapter with the resolved parameter map' {
+        InModuleScope $script:moduleName {
+            Mock Invoke-NovaModuleUpdateCommand {}
+
+            Invoke-NovaModuleSelfUpdate -ModuleName 'NovaModuleTools' -AllowPrerelease
+
+            Assert-MockCalled Invoke-NovaModuleUpdateCommand -Times 1 -ParameterFilter {
+                $UpdateParameters.Name -eq 'NovaModuleTools' -and
+                        $UpdateParameters.AllowPrerelease -and
+                        $UpdateParameters.ErrorAction -eq 'Stop'
             }
         }
     }


### PR DESCRIPTION
## Summary

- What changed?
  - Refactored several internal Nova workflows to isolate external dependency access behind smaller adapter-style helpers.
  - Added clearer seams around `git`, raw upload request execution, repository publish execution, module self-update execution,
    settings JSON persistence, and CLI environment-variable access.
  - Updated targeted tests to mock the new seams directly, and renamed new helper functions to satisfy
    `PSScriptAnalyzer` singular-noun rules so the local quality flow stays green.
- Why was this change needed?
  - The workflow logic had direct coupling to external tools and system APIs in a few high-value areas, which made tests
    broader than necessary and made change points less explicit.
  - The refactor keeps outward behavior stable while making release, upload, publish, update, and environment-dependent
    paths easier to reason about, isolate, and evolve.
- Link the issue, discussion, or follow-up work (for example `Closes #123`).
  - Follow-up implementation from `plan.md`.

## Affected area

- [ ] `nova` CLI or command routing
- [ ] Public PowerShell cmdlet behavior
- [ ] Scaffolding or `project.json` handling
- [x] Build, test, analyzer, coverage, or CI helper flow
- [x] Package, raw upload, or package metadata workflow
- [x] Publish, release, semantic-release, or GitHub Actions automation
- [x] Self-update or notification preference behavior
- [ ] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
- [ ] End-user docs (`docs/*.html`)
- [ ] Command help (`docs/NovaModuleTools/en-US/*.md`)
- [ ] `src/resources/example/`
- [ ] Dependency or manifest changes (`package.json`, workflow dependencies, release tooling)
- [ ] Security-sensitive change
- [ ] Documentation-only change
- [x] Other

## Review guidance

- Start with the new shared and execution-seam helpers:
  - `src/private/shared/InvokeNovaGitCommand.ps1`
  - `src/private/shared/InvokeNovaJsonFile.ps1`
  - `src/private/package/InvokeNovaPackageUploadRequest.ps1`
  - `src/private/release/InvokeNovaRepositoryPublishCommand.ps1`
  - `src/private/update/InvokeNovaModuleUpdateCommand.ps1`
- Then review the migrated workflows that now depend on those seams:
  - `src/private/release/GetGitCommitMessagesForVersionBump.ps1`
  - `src/private/release/GetNovaVersionLabelForBump.ps1`
  - `src/private/release/InitiateGitRepo.ps1`
  - `src/private/release/PublishNovaBuiltModuleToRepository.ps1`
  - `src/private/package/InvokeNovaPackageArtifactUpload.ps1`
  - `src/private/update/InvokeNovaModuleSelfUpdate.ps1`
  - `src/private/update/ReadNovaUpdateNotificationPreference.ps1`
  - `src/private/update/WriteNovaUpdateNotificationPreference.ps1`
  - `src/private/cli/ConfirmNovaCliAction.ps1`
  - `src/private/cli/GetNovaCliInstallDirectory.ps1`
  - `src/private/cli/TestNovaCliDirectoryOnPath.ps1`
- Focused tests were added or updated in:
  - `tests/CoverageGaps.ReleaseInternals.Tests.ps1`
  - `tests/NovaCommandModel.PackageUpload.Tests.ps1`
  - `tests/NovaCommandModel.ReleasePublish.Tests.ps1`
  - `tests/UpdateNotification.Tests.ps1`
  - `tests/CoverageGaps.Cli.Tests.ps1`
- Trade-offs / limitations:
  - This is intentionally an internal maintainability refactor, so behavior changes were avoided where possible.
  - The main risk area is delegation wiring: git history lookup, upload request execution, repository publish execution,
    self-update execution, and settings/environment resolution now flow through helper boundaries instead of direct calls.

## Validation

- [x] `Invoke-NovaBuild`
- [x] `Test-NovaBuild`
- [x] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
- [ ] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`,
  `% nova publish`,
  `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
- [ ] Docs/example only; executable validation not needed

Validation notes:

```text
Primary end-to-end validation:
- pwsh -NoLogo -NoProfile -File ./run.ps1
  - Passed with exit code 0
  - Final result: Tests Passed: 548, Failed: 0, Skipped: 0

Focused validation run during implementation:
- pwsh -NoLogo -NoProfile -Command 'Invoke-NovaBuild'
- pwsh -NoLogo -NoProfile -Command 'Invoke-Pester ./tests/CoverageGaps.ReleaseInternals.Tests.ps1 -Output Detailed'
- pwsh -NoLogo -NoProfile -Command 'Invoke-Pester ./tests/NovaCommandModel.PackageUpload.Tests.ps1 -Output Detailed'
- pwsh -NoLogo -NoProfile -Command 'Invoke-Pester ./tests/NovaCommandModel.ReleasePublish.Tests.ps1 -Output Detailed'
- pwsh -NoLogo -NoProfile -Command 'Invoke-Pester ./tests/UpdateNotification.Tests.ps1 -Output Detailed'
- pwsh -NoLogo -NoProfile -Command 'Invoke-Pester ./tests/CoverageGaps.Cli.Tests.ps1 -Output Detailed'
- pwsh -NoLogo -NoProfile -Command 'Invoke-Pester ./tests/RemainingCommandCoverage.Tests.ps1 -Output Detailed'
- pwsh -NoLogo -NoProfile -Command 'Invoke-Pester ./tests/CoverageCompletion.Tests.ps1 -Output Detailed'

Other checks:
- git --no-pager diff --check
- Local Code Health safeguard passed

Skipped:
- Full CI entrypoint script was not run from this summary task
- No live publish/upload/release against external services was exercised
```

## Documentation and release follow-up

- [ ] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
- [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
- [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [ ] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
- [ ] `docs/*.html` updated if end-user workflows or examples changed
- [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
  changed
- [ ] No documentation, changelog, or example updates were needed

## Maintainability, compatibility, and risk

- [x] Code Health / maintainability impact considered
- [x] No breaking change
- [ ] Breaking change
- [ ] Security-sensitive change
- [x] CI, workflow, or release-pipeline impact
- [ ] Dependency-review impact

Risk, rollout, or rollback notes:

```text
Compatibility impact:
- No intended user-facing behavior change. This change primarily restructures internal execution seams.

Main risk areas:
- git command delegation in version bump/repository-init paths
- raw upload request delegation
- repository publish delegation
- module self-update delegation
- settings JSON persistence and environment-variable lookup delegation

Rollback / maintainer follow-up:
- Rollback is straightforward because the change is mostly seam extraction and helper renaming.
- The final analyzer-related follow-up was a naming cleanup so run.ps1 no longer fails on PSScriptAnalyzer warnings.
- Branch-level PR pre-flight Code Health may still need separate cleanup for pre-existing test-file global-conditionals debt.
```

> [!IMPORTANT]
> Do not use a public pull request to disclose a vulnerability before coordinated handling.
> Use the private reporting path in `SECURITY.md` for new security issues.
