### PR TITLE
Feature/100 add architecture tests or architectural guardrails for novamoduletools

### DIFF
--- a/tests/ArchitectureGuardrails.Tests.ps1
+++ b/tests/ArchitectureGuardrails.Tests.ps1
@@ -80,28 +80,45 @@ Describe 'Architecture guardrails' {
         (Compare-Object -ReferenceObject $expected -DifferenceObject $actual) | Should -BeNullOrEmpty -Because (($actual -join ', '), (& $script:formatMatches -MatchList $matches) -join [Environment]::NewLine)
     }
 
-    It 'public orchestration entrypoints keep delegating to their context and workflow helpers' {
+    It 'public command files use only their approved Nova helper surface' {
         $testCases = @(
-            [pscustomobject]@{Path = 'src/public/DeployNovaPackage.ps1'; ContextPattern = '\bGet-NovaPackageUploadWorkflowContext\b'; ActionPattern = '\bInvoke-NovaPackageUploadWorkflow\b'}
-            [pscustomobject]@{Path = 'src/public/InitializeNovaModule.ps1'; ContextPattern = '\bGet-NovaModuleInitializationWorkflowContext\b'; ActionPattern = '\bInvoke-NovaModuleInitializationWorkflow\b'}
-            [pscustomobject]@{Path = 'src/public/InstallNovaCli.ps1'; ContextPattern = '\bGet-NovaCliInstallWorkflowContext\b'; ActionPattern = '\bInvoke-NovaCliInstallWorkflow\b'}
-            [pscustomobject]@{Path = 'src/public/InvokeNovaBuild.ps1'; ContextPattern = '\bGet-NovaBuildWorkflowContext\b'; ActionPattern = '\bInvoke-NovaBuildWorkflow\b'}
-            [pscustomobject]@{Path = 'src/public/InvokeNovaCli.ps1'; ContextPattern = '\bGet-NovaCliInvocationContext\b'; ActionPattern = '\bInvoke-NovaCliCommandRoute\b'}
-            [pscustomobject]@{Path = 'src/public/InvokeNovaRelease.ps1'; ContextPattern = '\bGet-NovaPublishWorkflowContext\b'; ActionPattern = '\bInvoke-NovaReleaseWorkflow\b'}
-            [pscustomobject]@{Path = 'src/public/NewNovaModulePackage.ps1'; ContextPattern = '\bGet-NovaPackageWorkflowContext\b'; ActionPattern = '\bInvoke-NovaPackageWorkflow\b'}
-            [pscustomobject]@{Path = 'src/public/PublishNovaModule.ps1'; ContextPattern = '\bGet-NovaPublishWorkflowContext\b'; ActionPattern = '\bInvoke-NovaPublishWorkflow\b'}
-            [pscustomobject]@{Path = 'src/public/SetNovaUpdateNotificationPreference.ps1'; ContextPattern = '\bGet-NovaUpdateNotificationPreferenceChangeContext\b'; ActionPattern = '\bInvoke-NovaUpdateNotificationPreferenceChange\b'}
-            [pscustomobject]@{Path = 'src/public/TestNovaBuild.ps1'; ContextPattern = '\bGet-NovaTestWorkflowContext\b'; ActionPattern = '\bInvoke-NovaTestWorkflow\b'}
-            [pscustomobject]@{Path = 'src/public/UpdateNovaModuleTools.ps1'; ContextPattern = '\bGet-NovaModuleSelfUpdateWorkflowContext\b'; ActionPattern = '\bInvoke-NovaModuleSelfUpdateWorkflow\b'}
-            [pscustomobject]@{Path = 'src/public/UpdateNovaModuleVersion.ps1'; ContextPattern = '\bGet-NovaVersionUpdateWorkflowContext\b'; ActionPattern = '\bInvoke-NovaVersionUpdateWorkflow\b'}
+            [pscustomobject]@{Path = 'src/public/DeployNovaPackage.ps1'; ExpectedHelpers = @('Get-NovaPackageUploadWorkflowContext', 'Get-NovaProjectInfo', 'Invoke-NovaPackageUploadWorkflow', 'New-NovaPackageUploadDynamicParameterDictionary', 'New-NovaPackageUploadOption')}
+            [pscustomobject]@{Path = 'src/public/GetNovaProjectInfo.ps1'; ExpectedHelpers = @('Get-NovaProjectInfoContext', 'Get-NovaProjectInfoResult')}
+            [pscustomobject]@{Path = 'src/public/GetNovaUpdateNotificationPreference.ps1'; ExpectedHelpers = @('Get-NovaUpdateNotificationPreferenceStatus')}
+            [pscustomobject]@{Path = 'src/public/InitializeNovaModule.ps1'; ExpectedHelpers = @('Get-NovaModuleInitializationWorkflowContext', 'Invoke-NovaModuleInitializationWorkflow')}
+            [pscustomobject]@{Path = 'src/public/InstallNovaCli.ps1'; ExpectedHelpers = @('Get-NovaCliInstallWorkflowContext', 'Invoke-NovaCliInstallWorkflow', 'Write-NovaModuleReleaseNotesLink')}
+            [pscustomobject]@{Path = 'src/public/InvokeNovaBuild.ps1'; ExpectedHelpers = @('Get-NovaBuildWorkflowContext', 'Invoke-NovaBuildWorkflow')}
+            [pscustomobject]@{Path = 'src/public/InvokeNovaCli.ps1'; ExpectedHelpers = @('Get-NovaCliInvocationContext', 'Invoke-NovaCliCommandRoute')}
+            [pscustomobject]@{Path = 'src/public/InvokeNovaRelease.ps1'; ExpectedHelpers = @('Get-NovaProjectInfo', 'Get-NovaPublishWorkflowContext', 'Get-NovaShouldProcessForwardingParameter', 'Invoke-NovaReleaseWorkflow', 'Write-NovaPublishWorkflowContext')}
+            [pscustomobject]@{Path = 'src/public/NewNovaModulePackage.ps1'; ExpectedHelpers = @('Get-NovaPackageWorkflowContext', 'Get-NovaShouldProcessForwardingParameter', 'Invoke-NovaPackageWorkflow')}
+            [pscustomobject]@{Path = 'src/public/PublishNovaModule.ps1'; ExpectedHelpers = @('Get-NovaDynamicDeliveryParameterDictionary', 'Get-NovaProjectInfo', 'Get-NovaPublishWorkflowContext', 'Get-NovaShouldProcessForwardingParameter', 'Invoke-NovaPublishWorkflow', 'Write-NovaPublishWorkflowContext')}
+            [pscustomobject]@{Path = 'src/public/SetNovaUpdateNotificationPreference.ps1'; ExpectedHelpers = @('Get-NovaUpdateNotificationPreferenceChangeContext', 'Invoke-NovaUpdateNotificationPreferenceChange')}
+            [pscustomobject]@{Path = 'src/public/TestNovaBuild.ps1'; ExpectedHelpers = @('Get-NovaTestWorkflowContext', 'Invoke-NovaTestWorkflow', 'New-NovaTestDynamicParameterDictionary')}
+            [pscustomobject]@{Path = 'src/public/UpdateNovaModuleTools.ps1'; ExpectedHelpers = @('Complete-NovaModuleSelfUpdateResult', 'Confirm-NovaPrereleaseModuleUpdate', 'Get-NovaModuleSelfUpdateWorkflowContext', 'Invoke-NovaModuleSelfUpdateWorkflow', 'Write-NovaModuleReleaseNotesLink')}
+            [pscustomobject]@{Path = 'src/public/UpdateNovaModuleVersion.ps1'; ExpectedHelpers = @('Get-NovaVersionUpdateCiActivatedCommand', 'Get-NovaVersionUpdateWorkflowContext', 'Invoke-NovaVersionUpdateWorkflow')}
         )
+        $expectedPaths = @($testCases | ForEach-Object Path | Sort-Object)
+        $actualPaths = @(
+        Get-ChildItem -LiteralPath (Join-Path $script:srcRoot 'public') -Filter '*.ps1' -File |
+                ForEach-Object {([System.IO.Path]::GetRelativePath($script:repoRoot, $_.FullName)).Replace('\', '/')} |
+                Sort-Object
+        )
+
+        (Compare-Object -ReferenceObject $expectedPaths -DifferenceObject $actualPaths) | Should -BeNullOrEmpty -Because "Public command allowlist should stay in sync with src/public. Expected: $( $expectedPaths -join ', ' ) | Actual: $( $actualPaths -join ', ' )"
 
         foreach ($testCase in $testCases) {
             $filePath = Join-Path $script:repoRoot $testCase.Path
-            $content = Get-Content -LiteralPath $filePath -Raw
+            $null = $tokens = $parseErrors = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$tokens, [ref]$parseErrors)
+            $actualHelpers = @(
+            $ast.FindAll({param($node) $node -is [System.Management.Automation.Language.CommandAst]}, $true) |
+                    ForEach-Object {$_.GetCommandName()} |
+                    Where-Object {$_ -like '*Nova*'} |
+                    Sort-Object -Unique
+            )
+            $expectedHelpers = @($testCase.ExpectedHelpers | Sort-Object -Unique)
 
-            $content | Should -Match $testCase.ContextPattern -Because "$( $testCase.Path ) should build or resolve its workflow/context state before orchestration"
-            $content | Should -Match $testCase.ActionPattern -Because "$( $testCase.Path ) should delegate execution to its workflow or routing helper"
+            (Compare-Object -ReferenceObject $expectedHelpers -DifferenceObject $actualHelpers) | Should -BeNullOrEmpty -Because "$( $testCase.Path ) should only use its approved Nova helper surface. Expected: $( $expectedHelpers -join ', ' ) | Actual: $( $actualHelpers -join ', ' )"
         }
     }
 

--- a/tests/ArchitectureGuardrails.Tests.ps1
+++ b/tests/ArchitectureGuardrails.Tests.ps1
@@ -71,4 +71,49 @@ Describe 'Architecture guardrails' {
 
         (Compare-Object -ReferenceObject $expected -DifferenceObject $actual) | Should -BeNullOrEmpty -Because (($actual -join ', '), (& $script:formatMatches -MatchList $matches) -join [Environment]::NewLine)
     }
+
+    It 'self-update execution stays behind the update command adapter' {
+        $matches = & $script:findMatches -RootPath $script:srcRoot -Pattern '^\s*(?:return\s+)?Update-Module\b'
+        $actual = & $script:getMatchedPaths -MatchList $matches
+        $expected = @('src/private/update/InvokeNovaModuleUpdateCommand.ps1')
+
+        (Compare-Object -ReferenceObject $expected -DifferenceObject $actual) | Should -BeNullOrEmpty -Because (($actual -join ', '), (& $script:formatMatches -MatchList $matches) -join [Environment]::NewLine)
+    }
+
+    It 'public orchestration entrypoints keep delegating to their context and workflow helpers' {
+        $testCases = @(
+            [pscustomobject]@{Path = 'src/public/DeployNovaPackage.ps1'; ContextPattern = '\bGet-NovaPackageUploadWorkflowContext\b'; ActionPattern = '\bInvoke-NovaPackageUploadWorkflow\b'}
+            [pscustomobject]@{Path = 'src/public/InitializeNovaModule.ps1'; ContextPattern = '\bGet-NovaModuleInitializationWorkflowContext\b'; ActionPattern = '\bInvoke-NovaModuleInitializationWorkflow\b'}
+            [pscustomobject]@{Path = 'src/public/InstallNovaCli.ps1'; ContextPattern = '\bGet-NovaCliInstallWorkflowContext\b'; ActionPattern = '\bInvoke-NovaCliInstallWorkflow\b'}
+            [pscustomobject]@{Path = 'src/public/InvokeNovaBuild.ps1'; ContextPattern = '\bGet-NovaBuildWorkflowContext\b'; ActionPattern = '\bInvoke-NovaBuildWorkflow\b'}
+            [pscustomobject]@{Path = 'src/public/InvokeNovaCli.ps1'; ContextPattern = '\bGet-NovaCliInvocationContext\b'; ActionPattern = '\bInvoke-NovaCliCommandRoute\b'}
+            [pscustomobject]@{Path = 'src/public/InvokeNovaRelease.ps1'; ContextPattern = '\bGet-NovaPublishWorkflowContext\b'; ActionPattern = '\bInvoke-NovaReleaseWorkflow\b'}
+            [pscustomobject]@{Path = 'src/public/NewNovaModulePackage.ps1'; ContextPattern = '\bGet-NovaPackageWorkflowContext\b'; ActionPattern = '\bInvoke-NovaPackageWorkflow\b'}
+            [pscustomobject]@{Path = 'src/public/PublishNovaModule.ps1'; ContextPattern = '\bGet-NovaPublishWorkflowContext\b'; ActionPattern = '\bInvoke-NovaPublishWorkflow\b'}
+            [pscustomobject]@{Path = 'src/public/SetNovaUpdateNotificationPreference.ps1'; ContextPattern = '\bGet-NovaUpdateNotificationPreferenceChangeContext\b'; ActionPattern = '\bInvoke-NovaUpdateNotificationPreferenceChange\b'}
+            [pscustomobject]@{Path = 'src/public/TestNovaBuild.ps1'; ContextPattern = '\bGet-NovaTestWorkflowContext\b'; ActionPattern = '\bInvoke-NovaTestWorkflow\b'}
+            [pscustomobject]@{Path = 'src/public/UpdateNovaModuleTools.ps1'; ContextPattern = '\bGet-NovaModuleSelfUpdateWorkflowContext\b'; ActionPattern = '\bInvoke-NovaModuleSelfUpdateWorkflow\b'}
+            [pscustomobject]@{Path = 'src/public/UpdateNovaModuleVersion.ps1'; ContextPattern = '\bGet-NovaVersionUpdateWorkflowContext\b'; ActionPattern = '\bInvoke-NovaVersionUpdateWorkflow\b'}
+        )
+
+        foreach ($testCase in $testCases) {
+            $filePath = Join-Path $script:repoRoot $testCase.Path
+            $content = Get-Content -LiteralPath $filePath -Raw
+
+            $content | Should -Match $testCase.ContextPattern -Because "$( $testCase.Path ) should build or resolve its workflow/context state before orchestration"
+            $content | Should -Match $testCase.ActionPattern -Because "$( $testCase.Path ) should delegate execution to its workflow or routing helper"
+        }
+    }
+
+    It 'project.json persistence stays limited to the shared writer and its expected callers' {
+        $matches = & $script:findMatches -RootPath $script:srcRoot -Pattern '\bWrite-ProjectJsonData\b'
+        $actual = & $script:getMatchedPaths -MatchList $matches
+        $expected = @(
+            'src/private/release/SetNovaModuleVersion.ps1'
+            'src/private/scaffold/WriteNovaModuleProjectJson.ps1'
+            'src/private/shared/Write-ProjectJsonData.ps1'
+        )
+
+        (Compare-Object -ReferenceObject $expected -DifferenceObject $actual) | Should -BeNullOrEmpty -Because (($actual -join ', '), (& $script:formatMatches -MatchList $matches) -join [Environment]::NewLine)
+    }
 }

--- a/tests/ArchitectureGuardrails.Tests.ps1
+++ b/tests/ArchitectureGuardrails.Tests.ps1
@@ -1,0 +1,74 @@
+BeforeAll {
+    $script:repoRoot = Split-Path -Parent $PSScriptRoot
+    $script:srcRoot = Join-Path $script:repoRoot 'src'
+    $script:findMatches = {
+        param(
+            [Parameter(Mandatory)][string]$Pattern,
+            [Parameter(Mandatory)][string]$RootPath
+        )
+
+        $matches = foreach ($file in (Get-ChildItem -LiteralPath $RootPath -Filter '*.ps1' -Recurse -File)) {
+            foreach ($match in (Select-String -Path $file.FullName -Pattern $Pattern)) {
+                [pscustomobject]@{
+                    Path = ([System.IO.Path]::GetRelativePath($script:repoRoot, $file.FullName)).Replace('\', '/')
+                    Line = $match.LineNumber
+                    Text = $match.Line.Trim()
+                }
+            }
+        }
+
+        return @($matches)
+    }
+    $script:getMatchedPaths = {
+        param([AllowNull()][object[]]$MatchList)
+
+        if ($null -eq $MatchList) {
+            return @()
+        }
+
+        return @($MatchList | ForEach-Object Path | Sort-Object -Unique)
+    }
+    $script:formatMatches = {
+        param([AllowNull()][object[]]$MatchList)
+
+        if ($null -eq $MatchList) {
+            return 'No matches.'
+        }
+
+        return ($MatchList | ForEach-Object {
+            "$( $_.Path ):$( $_.Line ) -> $( $_.Text )"
+        }) -join [Environment]::NewLine
+    }
+}
+
+Describe 'Architecture guardrails' {
+    It 'public commands stay free of raw infrastructure primitives' {
+        $matches = & $script:findMatches -RootPath (Join-Path $script:srcRoot 'public') -Pattern 'ConvertFrom-Json|ConvertTo-Json|Invoke-WebRequest|Invoke-RestMethod|Update-Module|&\s*git\b|\$env:|GetEnvironmentVariable\('
+
+        $matches | Should -BeNullOrEmpty -Because (& $script:formatMatches -MatchList $matches)
+    }
+
+    It 'direct environment-variable access stays centralized in the shared helper' {
+        $matches = & $script:findMatches -RootPath $script:srcRoot -Pattern '\$env:|GetEnvironmentVariable\('
+        $actual = & $script:getMatchedPaths -MatchList $matches
+        $expected = @('src/private/shared/GetNovaEnvironmentVariableValue.ps1')
+
+        (Compare-Object -ReferenceObject $expected -DifferenceObject $actual) | Should -BeNullOrEmpty -Because (($actual -join ', '), (& $script:formatMatches -MatchList $matches) -join [Environment]::NewLine)
+    }
+
+    It 'direct git execution stays centralized in the shared git adapter' {
+        $matches = & $script:findMatches -RootPath $script:srcRoot -Pattern '&\s*git\b'
+        $actual = & $script:getMatchedPaths -MatchList $matches
+        $expected = @('src/private/shared/InvokeNovaGitCommand.ps1')
+
+        (Compare-Object -ReferenceObject $expected -DifferenceObject $actual) | Should -BeNullOrEmpty -Because (($actual -join ', '), (& $script:formatMatches -MatchList $matches) -join [Environment]::NewLine)
+    }
+
+    It 'raw upload requests stay behind the package request adapter' {
+        $matches = & $script:findMatches -RootPath $script:srcRoot -Pattern '\bInvoke-WebRequest\b'
+        $actual = & $script:getMatchedPaths -MatchList $matches
+        $expected = @('src/private/package/InvokeNovaPackageUploadRequest.ps1')
+
+        (Compare-Object -ReferenceObject $expected -DifferenceObject $actual) | Should -BeNullOrEmpty -Because (($actual -join ', '), (& $script:formatMatches -MatchList $matches) -join [Environment]::NewLine)
+    }
+}


### PR DESCRIPTION
## Summary

- Added lightweight architecture guardrails in `tests/ArchitectureGuardrails.Tests.ps1` so key infrastructure seams and layering expectations stay enforced by automated tests instead of convention alone.
- Expanded `plan.md` with the next architecture follow-up slices and recorded `tests/ArchitectureGuardrails.Tests.ps1` as the current host for these checks.
- This change was needed to make recent maintainability improvements harder to regress accidentally, especially around self-update execution, thin public command orchestration, and centralized `project.json` persistence.
- Follow-up reference: architecture-guardrail follow-up captured in `plan.md`.

## Affected area

- [ ] `nova` CLI or command routing
- [x] Public PowerShell cmdlet behavior
- [x] Scaffolding or `project.json` handling
- [x] Build, test, analyzer, coverage, or CI helper flow
- [x] Package, raw upload, or package metadata workflow
- [x] Publish, release, semantic-release, or GitHub Actions automation
- [x] Self-update or notification preference behavior
- [ ] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
- [ ] End-user docs (`docs/*.html`)
- [ ] Command help (`docs/NovaModuleTools/en-US/*.md`)
- [ ] `src/resources/example/`
- [ ] Dependency or manifest changes (`package.json`, workflow dependencies, release tooling)
- [ ] Security-sensitive change
- [ ] Documentation-only change
- [x] Other

Other affected area details:

- Architecture guardrails and maintainability enforcement in `tests/ArchitectureGuardrails.Tests.ps1`

## Review guidance

- Start with `tests/ArchitectureGuardrails.Tests.ps1`.
- Focus first on the new guardrails that protect:
  - direct `Update-Module` usage staying behind `Invoke-NovaModuleUpdateCommand`
  - public command files using only their approved Nova helper surface via AST-backed allowlists
  - `project.json` writes staying limited to `Write-ProjectJsonData` and its known callers
- Then review `plan.md` for the recorded follow-up plan and the updated examples of guardrails worth extending later.
- Primary files changed:
  - `tests/ArchitectureGuardrails.Tests.ps1`
  - `plan.md`
- Trade-off: the public-command helper rule is intentionally strict. When a public command legitimately adds or removes Nova helper calls, the allowlist in `tests/ArchitectureGuardrails.Tests.ps1` must be updated alongside that change.

## Validation

- [ ] `Invoke-NovaBuild`
- [ ] `Test-NovaBuild`
- [ ] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
- [ ] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`,
  `% nova publish`,
  `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
- [ ] Docs/example only; executable validation not needed

Validation notes:

```text
Focused guardrail validation:
- pwsh -NoLogo -NoProfile -Command 'Invoke-Pester ./tests/ArchitectureGuardrails.Tests.ps1 -Output Detailed'
  Result: 7/7 tests passed.

Broader targeted validation completed during the architecture-guardrail work:
- UpdateNotification.Tests.ps1
- NovaCommandModel.BumpAndCli.Tests.ps1
- NovaCommandModel.ReleasePublish.Tests.ps1
- CoverageGaps.ReleaseInternals.Tests.ps1
- CoverageGaps.Tests.ps1
  Result: 197/197 tests passed.

Additional targeted validation after the stricter public-command allowlist was introduced:
- NovaCommandModel.Tests.ps1
- NovaCommandModel.ReleasePublish.Tests.ps1
- NovaCommandModel.BumpAndCli.Tests.ps1
- UpdateNotification.Tests.ps1
  Result: 163/163 tests passed.

Full repository validation completed during the change:
- pwsh -NoLogo -NoProfile -File ./run.ps1
  Result: PSScriptAnalyzer: no findings. Discovery found 561 tests. Tests Passed: 561, Failed: 0.

Diff hygiene:
- git --no-pager diff --check
  Result: clean.

Maintainability safeguards:
- CodeScene pre-commit safeguard: passed
- Code Health review for tests/ArchitectureGuardrails.Tests.ps1: 10.0

The template-specific boxes above remain unchecked because this change was validated through focused architecture suites and the repository quality flow (`run.ps1`) rather than by running those exact individual template commands in this final step.
```

## Documentation and release follow-up

- [ ] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
- [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
- [ ] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [ ] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
- [ ] `docs/*.html` updated if end-user workflows or examples changed
- [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
  changed
- [x] No documentation, changelog, or example updates were needed

## Maintainability, compatibility, and risk

- [x] Code Health / maintainability impact considered
- [x] No breaking change
- [ ] Breaking change
- [ ] Security-sensitive change
- [ ] CI, workflow, or release-pipeline impact
- [ ] Dependency-review impact

Risk, rollout, or rollback notes:

```text
Compatibility impact is low because the change adds tests and planning guidance only; it does not alter exported command behavior.

Rollback is straightforward:
- revert the new guardrails in tests/ArchitectureGuardrails.Tests.ps1
- revert the architecture follow-up notes in plan.md

Main maintainer follow-up:
- keep the public-command helper allowlist in sync when legitimate helper usage changes in src/public/*.ps1
- extend the guardrail suite incrementally instead of adding broad brittle restrictions
```
