### PR TITLE
feat(#104): implement package upload file selection utilities

### DIFF
--- a/src/private/package/GetNovaPackageUploadFileInfo.ps1
+++ b/src/private/package/GetNovaPackageUploadFileInfo.ps1
@@ -1,0 +1,19 @@
+function Get-NovaPackageUploadFileInfo {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$PackageType,
+        [Parameter(Mandatory)][string]$PackagePath,
+        [string]$PackageFileName
+    )
+
+    $resolvedPackageFileName = $PackageFileName
+    if ( [string]::IsNullOrWhiteSpace($resolvedPackageFileName)) {
+        $resolvedPackageFileName = [System.IO.Path]::GetFileName($PackagePath)
+    }
+
+    return [pscustomobject]@{
+        Type = $PackageType
+        PackagePath = $PackagePath
+        PackageFileName = $resolvedPackageFileName
+    }
+}

--- a/src/private/package/GetNovaPackageUploadOutputDirectoryFileList.ps1
+++ b/src/private/package/GetNovaPackageUploadOutputDirectoryFileList.ps1
@@ -1,0 +1,21 @@
+function Get-NovaPackageUploadOutputDirectoryFileList {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Package upload output directory file list is the domain term represented by this helper.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$OutputDirectory,
+        [Parameter(Mandatory)][string]$SearchPattern,
+        [Parameter(Mandatory)][string]$PackageType
+    )
+
+    $matchingFileList = @(
+    Get-ChildItem -LiteralPath $OutputDirectory -File -ErrorAction Stop |
+            Where-Object {$_.Name -like $SearchPattern} |
+            Sort-Object Name
+    )
+
+    if ($matchingFileList.Count -eq 0) {
+        Stop-NovaOperation -Message "Package file not found for package type '$PackageType' in '$OutputDirectory'. Expected pattern: $SearchPattern. Run New-NovaModulePackage first or provide -PackagePath." -ErrorId 'Nova.Workflow.PackageOutputArtifactNotFound' -Category InvalidOperation -TargetObject $PackageType
+    }
+
+    return $matchingFileList
+}

--- a/src/private/package/GetNovaPackageUploadRequestedTypeList.ps1
+++ b/src/private/package/GetNovaPackageUploadRequestedTypeList.ps1
@@ -1,0 +1,15 @@
+function Get-NovaPackageUploadRequestedTypeList {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Package upload requested type list is the domain term represented by this helper.')]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
+        [string[]]$PackageType
+    )
+
+    $requestedTypeList = @($PackageType | Where-Object {-not [string]::IsNullOrWhiteSpace("$_")})
+    if ($requestedTypeList.Count -eq 0) {
+        return @()
+    }
+
+    return @(Resolve-NovaPackageUploadTypeList -ProjectInfo $ProjectInfo -PackageType $requestedTypeList)
+}

--- a/src/private/package/ResolveNovaPackageUploadExplicitFile.ps1
+++ b/src/private/package/ResolveNovaPackageUploadExplicitFile.ps1
@@ -15,10 +15,5 @@ function Resolve-NovaPackageUploadExplicitFile {
         Stop-NovaOperation -Message "Package selection is ambiguous. Explicit PackagePath '$resolvedPackagePath' resolves to type '$resolvedPackageType', but requested PackageType values are: $( $RequestedPackageTypeList -join ', ' )." -ErrorId 'Nova.Validation.PackageUploadSelectionAmbiguous' -Category InvalidArgument -TargetObject $resolvedPackagePath
     }
 
-    return [pscustomobject]@{
-        Type = $resolvedPackageType
-        PackagePath = $resolvedPackagePath
-        PackageFileName = [System.IO.Path]::GetFileName($resolvedPackagePath)
-    }
+    return Get-NovaPackageUploadFileInfo -PackageType $resolvedPackageType -PackagePath $resolvedPackagePath
 }
-

--- a/src/private/package/ResolveNovaPackageUploadExplicitFileList.ps1
+++ b/src/private/package/ResolveNovaPackageUploadExplicitFileList.ps1
@@ -7,10 +7,7 @@ function Resolve-NovaPackageUploadExplicitFileList {
         [string[]]$PackageType
     )
 
-    $requestedTypeList = @()
-    if (@($PackageType).Count -gt 0) {
-        $requestedTypeList = @(Resolve-NovaPackageUploadTypeList -ProjectInfo $ProjectInfo -PackageType $PackageType)
-    }
+    $requestedTypeList = @(Get-NovaPackageUploadRequestedTypeList -ProjectInfo $ProjectInfo -PackageType $PackageType)
 
     $resolvedFileList = @(
     $PackagePath |
@@ -20,4 +17,3 @@ function Resolve-NovaPackageUploadExplicitFileList {
 
     return $resolvedFileList
 }
-

--- a/src/private/package/ResolveNovaPackageUploadOutputFileList.ps1
+++ b/src/private/package/ResolveNovaPackageUploadOutputFileList.ps1
@@ -6,13 +6,14 @@ function Resolve-NovaPackageUploadOutputFileList {
         [string[]]$PackageType
     )
 
+    $resolvedTypeList = @(Resolve-NovaPackageUploadTypeList -ProjectInfo $ProjectInfo -PackageType $PackageType)
     $outputDirectory = Get-NovaPackageOutputDirectory -ProjectInfo $ProjectInfo
     if (-not (Test-Path -LiteralPath $outputDirectory -PathType Container)) {
         Stop-NovaOperation -Message "Package output directory not found: $outputDirectory. Run New-NovaModulePackage first or provide -PackagePath." -ErrorId 'Nova.Environment.PackageOutputDirectoryNotFound' -Category ObjectNotFound -TargetObject $outputDirectory
     }
 
     return @(
-    @(Resolve-NovaPackageUploadTypeList -ProjectInfo $ProjectInfo -PackageType $PackageType) |
+    $resolvedTypeList |
             ForEach-Object {
                 Resolve-NovaPackageUploadOutputFileSet -OutputDirectory $outputDirectory -ProjectInfo $ProjectInfo -PackageType $_
             }

--- a/src/private/package/ResolveNovaPackageUploadOutputFileSet.ps1
+++ b/src/private/package/ResolveNovaPackageUploadOutputFileSet.ps1
@@ -8,23 +8,11 @@ function Resolve-NovaPackageUploadOutputFileSet {
     )
 
     $searchPattern = Get-NovaPackageArtifactSearchPattern -ProjectInfo $ProjectInfo -PackageType $PackageType
-    $matchingFileList = @(
-    Get-ChildItem -LiteralPath $OutputDirectory -File -ErrorAction Stop |
-            Where-Object {$_.Name -like $searchPattern} |
-            Sort-Object Name
-    )
-
-    if ($matchingFileList.Count -eq 0) {
-        Stop-NovaOperation -Message "Package file not found for package type '$PackageType' in '$OutputDirectory'. Expected pattern: $searchPattern. Run New-NovaModulePackage first or provide -PackagePath." -ErrorId 'Nova.Workflow.PackageOutputArtifactNotFound' -Category InvalidOperation -TargetObject $PackageType
-    }
+    $matchingFileList = @(Get-NovaPackageUploadOutputDirectoryFileList -OutputDirectory $OutputDirectory -SearchPattern $searchPattern -PackageType $PackageType)
 
     return @(
     $matchingFileList | ForEach-Object {
-        [pscustomobject]@{
-            Type = $PackageType
-            PackagePath = $_.FullName
-            PackageFileName = $_.Name
-        }
+        Get-NovaPackageUploadFileInfo -PackageType $PackageType -PackagePath $_.FullName -PackageFileName $_.Name
     }
     )
 }

--- a/tests/NovaCommandModel.PackageUpload.Tests.ps1
+++ b/tests/NovaCommandModel.PackageUpload.Tests.ps1
@@ -22,6 +22,7 @@ foreach ($functionName in $global:novaCommandModelTestSupportFunctionNameList) {
     $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
     Set-Item -Path "function:global:$functionName" -Value $scriptBlock
 }
+
 foreach ($functionName in $global:novaCommandModelPackageUploadTestSupportFunctionNameList) {
     $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
     Set-Item -Path "function:global:$functionName" -Value $scriptBlock
@@ -237,6 +238,131 @@ Describe 'Nova command model - package upload behavior' {
             Assert-MockCalled Resolve-NovaPackageUploadTarget -Times 1 -ParameterFilter {$ProjectInfo.ProjectName -eq 'PackageProject' -and $Repository -eq 'LocalRaw' -and $UploadPath -eq 'modules'}
             Assert-MockCalled Resolve-NovaPackageUploadHeaders -Times 1 -ParameterFilter {$UploadTarget.Repository -eq 'LocalRaw' -and $UploadOption.Repository -eq 'LocalRaw'}
             Assert-MockCalled Get-NovaPackageUploadArtifact -Times 1 -ParameterFilter {$PackageFileInfo.PackageFileName -eq 'PackageProject.2.3.4.zip' -and $UploadTarget.Repository -eq 'LocalRaw'}
+        }
+    }
+
+    It 'Get-NovaPackageUploadFileList prefers explicit package paths over output discovery' {
+        InModuleScope $script:moduleName {
+            $projectInfo = [pscustomobject]@{ProjectName = 'PackageProject'}
+            $explicitFileList = @(
+                [pscustomobject]@{Type = 'Zip'; PackagePath = '/tmp/project/artifacts/packages/PackageProject.2.3.4.zip'; PackageFileName = 'PackageProject.2.3.4.zip'}
+            )
+
+            Mock Resolve-NovaPackageUploadExplicitFileList {$explicitFileList}
+            Mock Resolve-NovaPackageUploadOutputFileList {throw 'explicit package selection should not fall back to output discovery'}
+
+            $result = @(Get-NovaPackageUploadFileList -ProjectInfo $projectInfo -PackagePath @(' ', '/tmp/project/artifacts/packages/PackageProject.2.3.4.zip', '') -PackageType @('Zip'))
+
+            $result.PackagePath | Should -Be @('/tmp/project/artifacts/packages/PackageProject.2.3.4.zip')
+            Assert-MockCalled Resolve-NovaPackageUploadExplicitFileList -Times 1 -ParameterFilter {
+                $ProjectInfo.ProjectName -eq 'PackageProject' -and
+                        $PackagePath.Count -eq 1 -and
+                        $PackagePath[0] -eq '/tmp/project/artifacts/packages/PackageProject.2.3.4.zip' -and
+                        $PackageType.Count -eq 1 -and
+                        $PackageType[0] -eq 'Zip'
+            }
+            Assert-MockCalled Resolve-NovaPackageUploadOutputFileList -Times 0
+        }
+    }
+
+    It 'Get-NovaPackageUploadFileList falls back to output discovery when explicit package paths are not provided' {
+        InModuleScope $script:moduleName {
+            $projectInfo = [pscustomobject]@{ProjectName = 'PackageProject'}
+            $outputFileList = @(
+                [pscustomobject]@{Type = 'Zip'; PackagePath = '/tmp/project/artifacts/packages/PackageProject.2.3.4.zip'; PackageFileName = 'PackageProject.2.3.4.zip'}
+            )
+
+            Mock Resolve-NovaPackageUploadExplicitFileList {throw 'output discovery should be used when PackagePath is empty'}
+            Mock Resolve-NovaPackageUploadOutputFileList {$outputFileList}
+
+            $result = @(Get-NovaPackageUploadFileList -ProjectInfo $projectInfo -PackagePath @('', '   ') -PackageType @('Zip'))
+
+            $result.PackagePath | Should -Be @('/tmp/project/artifacts/packages/PackageProject.2.3.4.zip')
+            Assert-MockCalled Resolve-NovaPackageUploadExplicitFileList -Times 0
+            Assert-MockCalled Resolve-NovaPackageUploadOutputFileList -Times 1 -ParameterFilter {
+                $ProjectInfo.ProjectName -eq 'PackageProject' -and
+                        $PackageType.Count -eq 1 -and
+                        $PackageType[0] -eq 'Zip'
+            }
+        }
+    }
+
+    It 'Get-NovaPackageUploadRequestedTypeList returns an empty list when PackageType is omitted or whitespace' {
+        InModuleScope $script:moduleName {
+            $projectInfo = [pscustomobject]@{ProjectName = 'PackageProject'}
+
+            Mock Resolve-NovaPackageUploadTypeList {throw 'type resolution should be skipped when no package types were requested'}
+
+            $result = @(Get-NovaPackageUploadRequestedTypeList -ProjectInfo $projectInfo -PackageType @('', '   '))
+
+            $result.Count | Should -Be 0
+            Assert-MockCalled Resolve-NovaPackageUploadTypeList -Times 0
+        }
+    }
+
+    It 'Resolve-NovaPackageUploadExplicitFileList resolves requested types once and deduplicates by package path' {
+        InModuleScope $script:moduleName {
+            $projectInfo = [pscustomobject]@{ProjectName = 'PackageProject'}
+
+            Mock Get-NovaPackageUploadRequestedTypeList {@('Zip')}
+            Mock Resolve-NovaPackageUploadExplicitFile {
+                [pscustomobject]@{
+                    Type = 'Zip'
+                    PackagePath = '/tmp/project/artifacts/packages/PackageProject.2.3.4.zip'
+                    PackageFileName = 'PackageProject.2.3.4.zip'
+                }
+            }
+
+            $result = @(Resolve-NovaPackageUploadExplicitFileList -ProjectInfo $projectInfo -PackagePath @('/tmp/project/artifacts/packages/PackageProject.2.3.4.zip', './artifacts/packages/PackageProject.2.3.4.zip') -PackageType @('Zip'))
+
+            $result.Count | Should -Be 1
+            $result[0].PackageFileName | Should -Be 'PackageProject.2.3.4.zip'
+            Assert-MockCalled Get-NovaPackageUploadRequestedTypeList -Times 1 -ParameterFilter {
+                $ProjectInfo.ProjectName -eq 'PackageProject' -and
+                        $PackageType.Count -eq 1 -and
+                        $PackageType[0] -eq 'Zip'
+            }
+            Assert-MockCalled Resolve-NovaPackageUploadExplicitFile -Times 2 -ParameterFilter {
+                $RequestedPackageTypeList.Count -eq 1 -and
+                        $RequestedPackageTypeList[0] -eq 'Zip'
+            }
+        }
+    }
+
+    It 'Resolve-NovaPackageUploadOutputFileList resolves types before discovering artifacts in the output directory' {
+        InModuleScope $script:moduleName {
+            $projectInfo = [pscustomobject]@{ProjectName = 'PackageProject'}
+
+            Mock Resolve-NovaPackageUploadTypeList {@('NuGet', 'Zip')}
+            Mock Get-NovaPackageOutputDirectory {'/tmp/project/artifacts/packages'}
+            Mock Test-Path {$true} -ParameterFilter {$LiteralPath -eq '/tmp/project/artifacts/packages' -and $PathType -eq 'Container'}
+            Mock Resolve-NovaPackageUploadOutputFileSet {
+                [pscustomobject]@{
+                    Type = $PackageType
+                    PackagePath = "/tmp/project/artifacts/packages/PackageProject.2.3.4.$($PackageType.ToLower() )"
+                    PackageFileName = "PackageProject.2.3.4.$($PackageType.ToLower() )"
+                }
+            }
+
+            $result = @(Resolve-NovaPackageUploadOutputFileList -ProjectInfo $projectInfo -PackageType @('NuGet', 'Zip'))
+
+            $result.Type | Should -Be @('NuGet', 'Zip')
+            Assert-MockCalled Resolve-NovaPackageUploadTypeList -Times 1 -ParameterFilter {
+                $ProjectInfo.ProjectName -eq 'PackageProject' -and
+                        $PackageType.Count -eq 2
+            }
+            Assert-MockCalled Resolve-NovaPackageUploadOutputFileSet -Times 1 -ParameterFilter {$PackageType -eq 'NuGet' -and $OutputDirectory -eq '/tmp/project/artifacts/packages'}
+            Assert-MockCalled Resolve-NovaPackageUploadOutputFileSet -Times 1 -ParameterFilter {$PackageType -eq 'Zip' -and $OutputDirectory -eq '/tmp/project/artifacts/packages'}
+        }
+    }
+
+    It 'Get-NovaPackageUploadFileInfo falls back to the package path file name when none is provided' {
+        InModuleScope $script:moduleName {
+            $result = Get-NovaPackageUploadFileInfo -PackageType 'Zip' -PackagePath '/tmp/project/artifacts/packages/PackageProject.2.3.4.zip'
+
+            $result.Type | Should -Be 'Zip'
+            $result.PackagePath | Should -Be '/tmp/project/artifacts/packages/PackageProject.2.3.4.zip'
+            $result.PackageFileName | Should -Be 'PackageProject.2.3.4.zip'
         }
     }
 


### PR DESCRIPTION
## Summary

- Refactored the private package-upload file-selection chain so the responsibilities around explicit path handling, requested type normalization, output-directory discovery, and upload file-info shaping are clearer and easier to evolve.
- Added focused private seams in `src/private/package/`:
  - `Get-NovaPackageUploadRequestedTypeList`
  - `Get-NovaPackageUploadOutputDirectoryFileList`
  - `Get-NovaPackageUploadFileInfo`
- Updated the existing private helpers so the orchestration now reads more top-down without changing the public contract of `Deploy-NovaPackage` or `Invoke-NovaCli deploy`.
- This follow-up was needed because the upload-selection chain still mixed orchestration and resolution details, which made the private upload path harder to reason about and refactor safely.
- Follow-up reference: internal maintainability plan captured in `plan.md`.

## Affected area

- [ ] `nova` CLI or command routing
- [x] Public PowerShell cmdlet behavior
- [ ] Scaffolding or `project.json` handling
- [x] Build, test, analyzer, coverage, or CI helper flow
- [x] Package, raw upload, or package metadata workflow
- [ ] Publish, release, semantic-release, or GitHub Actions automation
- [ ] Self-update or notification preference behavior
- [ ] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
- [ ] End-user docs (`docs/*.html`)
- [ ] Command help (`docs/NovaModuleTools/en-US/*.md`)
- [ ] `src/resources/example/`
- [ ] Dependency or manifest changes (`package.json`, workflow dependencies, release tooling)
- [ ] Security-sensitive change
- [ ] Documentation-only change
- [x] Other

Other affected area details:

- Private package-upload helper layering in `src/private/package/`

## Review guidance

- Start with `src/private/package/GetNovaPackageUploadFileList.ps1` to see the high-level split between explicit package-path resolution and output-directory fallback.
- Then review these private seams in order:
  - `src/private/package/GetNovaPackageUploadRequestedTypeList.ps1`
  - `src/private/package/ResolveNovaPackageUploadExplicitFileList.ps1`
  - `src/private/package/GetNovaPackageUploadOutputDirectoryFileList.ps1`
  - `src/private/package/ResolveNovaPackageUploadOutputFileSet.ps1`
  - `src/private/package/GetNovaPackageUploadFileInfo.ps1`
- Review `tests/NovaCommandModel.PackageUpload.Tests.ps1` for the new regression coverage that makes the internal boundaries explicit.
- Trade-off: the refactor intentionally stops at the private selection seams. It does not redesign `Deploy-NovaPackage`, `Resolve-NovaPackageUploadInvocation`, or the public CLI route because the plan constrained this work to private internals only.

## Validation

- [x] `Invoke-NovaBuild`
- [ ] `Test-NovaBuild`
- [ ] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
- [x] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`,
  `% nova publish`,
  `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
- [ ] Docs/example only; executable validation not needed

Validation notes:

```text
Build and focused regression coverage:
- pwsh -NoLogo -NoProfile -Command 'Invoke-NovaBuild'
  Result: passed.

- pwsh -NoLogo -NoProfile -Command 'Invoke-Pester ./tests/NovaCommandModel.PackageUpload.Tests.ps1 -Output Detailed'
  Result: 40/40 passed.
  Included the new private-boundary tests for:
	* explicit path precedence
	* output discovery fallback
	* requested type normalization
	* output-file discovery ordering
	* shared upload file-info shaping

- pwsh -NoLogo -NoProfile -Command 'Invoke-Pester ./tests/NovaCommandModel.StandaloneCli.Tests.ps1 -Output Detailed'
  Result: 69/69 passed.
  This preserved the public deploy/CLI behavior while the private package-upload chain changed underneath it.

Full repository quality flow:
- zsh -lc 'pwsh -NoLogo -NoProfile -File "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools/run.ps1" > /tmp/novamoduletools-run-file-selection.log 2>&1; rc=$?; tail -n 80 /tmp/novamoduletools-run-file-selection.log | cat; echo "EXIT:$rc"'
  Result: EXIT:0
  Tests Passed: 567, Failed: 0

Diff hygiene:
- git --no-pager diff --check
  Result: clean.

Maintainability safeguards:
- CodeScene pre-commit safeguard: passed
- Code Health review: 10.0 for
	* src/private/package/ResolveNovaPackageUploadExplicitFileList.ps1
	* src/private/package/ResolveNovaPackageUploadOutputFileSet.ps1
	* tests/NovaCommandModel.PackageUpload.Tests.ps1

The unchecked template boxes above were not run as separate standalone commands in this task. Their coverage came through the full repository quality flow instead.
```

## Documentation and release follow-up

- [ ] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
- [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
- [ ] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [ ] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
- [ ] `docs/*.html` updated if end-user workflows or examples changed
- [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
  changed
- [x] No documentation, changelog, or example updates were needed

## Maintainability, compatibility, and risk

- [x] Code Health / maintainability impact considered
- [x] No breaking change
- [ ] Breaking change
- [ ] Security-sensitive change
- [ ] CI, workflow, or release-pipeline impact
- [ ] Dependency-review impact

Risk, rollout, or rollback notes:

```text
Compatibility risk is low because the work stayed inside private package-upload helpers and preserved the public deploy and CLI contracts.

Rollback is straightforward:
- revert the new helper files
- restore the previous implementations in the four touched private package-upload helpers
- keep the package-upload regression tests aligned with whichever structure remains

Maintainer follow-up:
- continue adding small private seams only where orchestration and resolution become mixed again
- avoid broad abstraction layers unless another package workflow needs the same helper behavior
```

> [!IMPORTANT]
> Do not use a public pull request to disclose a vulnerability before coordinated handling.
> Use the private reporting path in `SECURITY.md` for new security issues.
