### PR TITLE
feat(#105): consolidate CLI helper functions for improved command han…

### DIFF
--- a/src/private/cli/GetNovaCliInvocationContext.ps1
+++ b/src/private/cli/GetNovaCliInvocationContext.ps1
@@ -1,41 +1,41 @@
-function Get-NovaCliBaseInvocationData {
+function Get-NovaCliResolvedInvocationContext {
     [CmdletBinding()]
     param(
+        [Parameter(Mandatory)][string]$Command,
+        [AllowEmptyCollection()][string[]]$Arguments = @(),
         [Parameter(Mandatory)][hashtable]$CommonParameters,
         [Parameter(Mandatory)][hashtable]$MutatingCommonParameters,
         [Parameter(Mandatory)][string]$ModuleName,
-        [Parameter(Mandatory)][bool]$WhatIfEnabled
+        [Parameter(Mandatory)][bool]$WhatIfEnabled,
+        [Parameter(Mandatory)][bool]$CliConfirmEnabled,
+        [AllowNull()][pscustomobject]$HelpRequest = $null
     )
 
     return [pscustomobject]@{
+        Command = $Command
+        Arguments = @($Arguments)
         CommonParameters = $CommonParameters
         MutatingCommonParameters = $MutatingCommonParameters
+        IsHelpRequest = $null -ne $HelpRequest
+        HelpRequest = $HelpRequest
         ModuleName = $ModuleName
         WhatIfEnabled = $WhatIfEnabled
+        CliConfirmEnabled = $CliConfirmEnabled
     }
 }
 
-function Get-NovaCliHelpInvocationContext {
+function Get-NovaCliInvocationWhatIfState {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][pscustomobject]$HelpRequest,
-        [Parameter(Mandatory)][pscustomobject]$BaseInvocationData
+        [switch]$WhatIfEnabled,
+        [Parameter(Mandatory)][hashtable]$MutatingCommonParameters,
+        [switch]$RoutingWhatIfEnabled
     )
 
-    return [pscustomobject]@{
-        Command = $HelpRequest.Command
-        Arguments = @()
-        CommonParameters = $BaseInvocationData.CommonParameters
-        MutatingCommonParameters = $BaseInvocationData.MutatingCommonParameters
-        IsHelpRequest = $true
-        HelpRequest = $HelpRequest
-        ModuleName = $BaseInvocationData.ModuleName
-        WhatIfEnabled = $BaseInvocationData.WhatIfEnabled
-        CliConfirmEnabled = $false
-    }
+    return $WhatIfEnabled.IsPresent -or $RoutingWhatIfEnabled.IsPresent -or $MutatingCommonParameters.ContainsKey('WhatIf')
 }
 
-function Get-NovaCliConfirmState {
+function Get-NovaCliInvocationConfirmState {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][hashtable]$MutatingCommonParameters
@@ -48,27 +48,6 @@ function Get-NovaCliConfirmState {
     $cliConfirmEnabled = [bool]$MutatingCommonParameters.Confirm
     $MutatingCommonParameters.Remove('Confirm')
     return $cliConfirmEnabled
-}
-
-function Get-NovaCliRoutedInvocationContext {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)][pscustomobject]$RoutingState,
-        [Parameter(Mandatory)][pscustomobject]$BaseInvocationData,
-        [Parameter(Mandatory)][bool]$CliConfirmEnabled
-    )
-
-    return [pscustomobject]@{
-        Command = $RoutingState.Command
-        Arguments = $RoutingState.Arguments
-        CommonParameters = $BaseInvocationData.CommonParameters
-        MutatingCommonParameters = $BaseInvocationData.MutatingCommonParameters
-        IsHelpRequest = $false
-        HelpRequest = $null
-        ModuleName = $BaseInvocationData.ModuleName
-        WhatIfEnabled = $BaseInvocationData.WhatIfEnabled
-        CliConfirmEnabled = $CliConfirmEnabled
-    }
 }
 
 function Get-NovaCliInvocationContext {
@@ -85,14 +64,14 @@ function Get-NovaCliInvocationContext {
     Assert-NovaCliArgumentSyntax -Arguments (@($InvocationRequest.Command) + $normalizedArguments)
     $helpRequest = Get-NovaCliHelpRequest -Command $InvocationRequest.Command -Arguments $normalizedArguments
     $moduleName = $ExecutionContext.SessionState.Module.Name
-    $helpBaseInvocationData = Get-NovaCliBaseInvocationData -CommonParameters $commonParameters -MutatingCommonParameters $mutatingCommonParameters -ModuleName $moduleName -WhatIfEnabled:($WhatIfEnabled.IsPresent -or $mutatingCommonParameters.ContainsKey('WhatIf'))
+    $whatIfState = Get-NovaCliInvocationWhatIfState -WhatIfEnabled:$WhatIfEnabled -MutatingCommonParameters $mutatingCommonParameters
 
     if ($null -ne $helpRequest) {
-        return Get-NovaCliHelpInvocationContext -HelpRequest $helpRequest -BaseInvocationData $helpBaseInvocationData
+        return Get-NovaCliResolvedInvocationContext -Command $helpRequest.Command -Arguments @() -CommonParameters $commonParameters -MutatingCommonParameters $mutatingCommonParameters -ModuleName $moduleName -WhatIfEnabled:$whatIfState -CliConfirmEnabled:$false -HelpRequest $helpRequest
     }
 
     $routingState = Get-NovaCliArgumentRoutingState -Command $InvocationRequest.Command -Arguments $normalizedArguments
-    $cliConfirmEnabled = Get-NovaCliConfirmState -MutatingCommonParameters $mutatingCommonParameters
+    $cliConfirmEnabled = Get-NovaCliInvocationConfirmState -MutatingCommonParameters $mutatingCommonParameters
 
     if ( $routingState.ForwardedParameters.ContainsKey('Verbose')) {
         $commonParameters.Verbose = $true
@@ -100,7 +79,7 @@ function Get-NovaCliInvocationContext {
 
     $mutatingCommonParameters = Merge-NovaCliParameterSet -BaseParameters $mutatingCommonParameters -AdditionalParameters $routingState.ForwardedParameters
     $cliConfirmEnabled = $cliConfirmEnabled -or $routingState.CliConfirmEnabled
-    $routedBaseInvocationData = Get-NovaCliBaseInvocationData -CommonParameters $commonParameters -MutatingCommonParameters $mutatingCommonParameters -ModuleName $moduleName -WhatIfEnabled:($WhatIfEnabled.IsPresent -or $routingState.WhatIfEnabled -or $mutatingCommonParameters.ContainsKey('WhatIf'))
+    $whatIfState = Get-NovaCliInvocationWhatIfState -WhatIfEnabled:$WhatIfEnabled -MutatingCommonParameters $mutatingCommonParameters -RoutingWhatIfEnabled:$routingState.WhatIfEnabled
 
-    return Get-NovaCliRoutedInvocationContext -RoutingState $routingState -BaseInvocationData $routedBaseInvocationData -CliConfirmEnabled:$cliConfirmEnabled
+    return Get-NovaCliResolvedInvocationContext -Command $routingState.Command -Arguments $routingState.Arguments -CommonParameters $commonParameters -MutatingCommonParameters $mutatingCommonParameters -ModuleName $moduleName -WhatIfEnabled:$whatIfState -CliConfirmEnabled:$cliConfirmEnabled
 }

--- a/src/private/cli/InvokeNovaCliCommandRoute.ps1
+++ b/src/private/cli/InvokeNovaCliCommandRoute.ps1
@@ -1,18 +1,3 @@
-function Get-NovaCliCommandHandler {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)][hashtable]$CommandHandlerMap,
-        [Parameter(Mandatory)][string]$Command
-    )
-
-    $commandHandler = $CommandHandlerMap[$Command]
-    if ($null -eq $commandHandler) {
-        Stop-NovaOperation -Message "Unknown command: <$Command> | Use 'nova --help' to see available commands." -ErrorId 'Nova.Validation.UnknownCliCommand' -Category InvalidArgument -TargetObject $Command
-    }
-
-    return $commandHandler
-}
-
 function Confirm-NovaCliRoutedCommand {
     [CmdletBinding()]
     param(
@@ -156,7 +141,7 @@ function Invoke-NovaCliCommandRoute {
             return Get-NovaCliHelp
         }
         default {
-            return Get-NovaCliCommandHandler -CommandHandlerMap @{} -Command $command
+            Stop-NovaOperation -Message "Unknown command: <$command> | Use 'nova --help' to see available commands." -ErrorId 'Nova.Validation.UnknownCliCommand' -Category InvalidArgument -TargetObject $command
         }
     }
 }

--- a/tests/CoverageGaps.Cli.Tests.ps1
+++ b/tests/CoverageGaps.Cli.Tests.ps1
@@ -115,6 +115,7 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
                 }
                 ModuleName = 'NovaModuleTools'
                 WhatIfEnabled = $false
+                CliConfirmEnabled = $false
             }
             Mock Get-NovaCliCommandHelp {'package-help'}
 
@@ -212,14 +213,33 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
         }
     }
 
-    It 'Get-NovaCliCommandHandler returns the mapped handler for a known command' {
+    It 'Invoke-NovaCliCommandRoute throws the stable unknown-command error for unmapped commands' {
         InModuleScope $script:moduleName {
-            $expectedHandler = [pscustomobject]@{Name = 'publish-handler'}
-            $handlerMap = @{publish = $expectedHandler}
+            $invocationContext = [pscustomobject]@{
+                Command = 'banana'
+                Arguments = @()
+                CommonParameters = @{}
+                MutatingCommonParameters = @{}
+                IsHelpRequest = $false
+                HelpRequest = $null
+                ModuleName = 'NovaModuleTools'
+                WhatIfEnabled = $false
+                CliConfirmEnabled = $false
+            }
 
-            $result = Get-NovaCliCommandHandler -CommandHandlerMap $handlerMap -Command 'publish'
+            $thrown = $null
+            try {
+                Invoke-NovaCliCommandRoute -InvocationContext $invocationContext
+            }
+            catch {
+                $thrown = $_
+            }
 
-            $result | Should -Be $expectedHandler
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be "Unknown command: <banana> | Use 'nova --help' to see available commands."
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Validation.UnknownCliCommand'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidArgument)
+            $thrown.TargetObject | Should -Be 'banana'
         }
     }
 
@@ -290,6 +310,21 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
             $buildContext.MutatingCommonParameters.ContainsKey('Confirm') | Should -BeFalse
             $buildContext.WhatIfEnabled | Should -BeTrue
             $buildContext.CliConfirmEnabled | Should -BeTrue
+        }
+    }
+
+    It 'Get-NovaCliInvocationContext strips raw Confirm from mutating parameters while preserving CLI confirm intent' {
+        InModuleScope $script:moduleName {
+            $invocationRequest = [pscustomobject]@{
+                Command = 'publish'
+                BoundParameters = @{Command = 'publish'; Arguments = @('--confirm'); Confirm = $true}
+                Arguments = @('--confirm')
+            }
+            $result = Get-NovaCliInvocationContext -InvocationRequest $invocationRequest
+
+            $result.Command | Should -Be 'publish'
+            $result.CliConfirmEnabled | Should -BeTrue
+            $result.MutatingCommonParameters.ContainsKey('Confirm') | Should -BeFalse
         }
     }
 


### PR DESCRIPTION
## Summary

- Refactored the private CLI layer to make invocation-context preparation and command routing contracts easier to understand without changing public `Invoke-NovaCli` behavior.
- Consolidated the invocation-context shaping in `src/private/cli/GetNovaCliInvocationContext.ps1` so the final routed/help context, `WhatIf` state, and CLI confirm intent are derived through smaller explicit seams instead of several overlapping context builders.
- Simplified `src/private/cli/InvokeNovaCliCommandRoute.ps1` by removing the dead unknown-command adapter path and keeping the stable unknown-command error contract directly in the router.
- Updated `tests/CoverageGaps.Cli.Tests.ps1` to validate the stable private CLI contracts directly: unknown-command routing and raw `Confirm` stripping while preserving CLI confirm intent.
- This follow-up was needed because the private CLI layer had become more modular after the public-entrypoint refactor, but some helper boundaries were still more fragmented than necessary.
- Follow-up reference: private CLI helper consolidation plan captured in `plan.md`.

## Affected area

- [x] `nova` CLI or command routing
- [x] Public PowerShell cmdlet behavior
- [ ] Scaffolding or `project.json` handling
- [x] Build, test, analyzer, coverage, or CI helper flow
- [ ] Package, raw upload, or package metadata workflow
- [ ] Publish, release, semantic-release, or GitHub Actions automation
- [ ] Self-update or notification preference behavior
- [ ] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
- [ ] End-user docs (`docs/*.html`)
- [ ] Command help (`docs/NovaModuleTools/en-US/*.md`)
- [ ] `src/resources/example/`
- [ ] Dependency or manifest changes (`package.json`, workflow dependencies, release tooling)
- [ ] Security-sensitive change
- [ ] Documentation-only change
- [x] Other

Other affected area details:

- Private CLI helper contracts in `src/private/cli/`

## Review guidance

- Start with `src/public/InvokeNovaCli.ps1`, then go immediately to `src/private/cli/GetNovaCliInvocationContext.ps1`.
- Reviewers should focus on these files in order:
  - `src/private/cli/GetNovaCliInvocationContext.ps1`
  - `src/private/cli/InvokeNovaCliCommandRoute.ps1`
  - `tests/CoverageGaps.Cli.Tests.ps1`
- Main changes to inspect:
  - the shared invocation-context shaping now happens through `Get-NovaCliResolvedInvocationContext`
  - `WhatIf` and CLI confirm intent are derived through explicit helpers instead of duplicated inline context shaping
  - the router now throws the stable unknown-command error directly instead of delegating through a dead adapter
- Trade-off: this intentionally does not perform a broad CLI redesign. It only tightens the current high-value seams that were still vague or redundant.

## Validation

- [x] `Invoke-NovaBuild`
- [ ] `Test-NovaBuild`
- [ ] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
- [x] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`,
  `% nova publish`,
  `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
- [ ] Docs/example only; executable validation not needed

Validation notes:

```text
Focused validation:
- pwsh -NoLogo -NoProfile -Command 'Invoke-NovaBuild'
  Result: passed.

- pwsh -NoLogo -NoProfile -Command 'Invoke-Pester ./tests/CliSharedParser.Tests.ps1 -Output Detailed'
  Result: 3/3 passed.

- pwsh -NoLogo -NoProfile -Command 'Invoke-Pester ./tests/CoverageGaps.Cli.Tests.ps1 -Output Detailed'
  Result: 61/61 passed.
  Included the updated private-contract coverage for:
	* stable unknown-command routing
	* invocation-context stripping of raw Confirm while preserving CliConfirmEnabled

- pwsh -NoLogo -NoProfile -Command 'Invoke-Pester ./tests/NovaCommandModel.StandaloneCli.Tests.ps1 -Output Detailed'
  Result: 69/69 passed.

- pwsh -NoLogo -NoProfile -Command 'Invoke-Pester ./tests/NovaCommandModel.BumpAndCli.Tests.ps1 -Output Detailed'
  Result: 33/33 passed.

- pwsh -NoLogo -NoProfile -Command 'Invoke-Pester ./tests/RemainingCommandCoverage.Tests.ps1 -Output Detailed'
  Result: 25/25 passed.

Full repository quality flow:
- zsh -lc 'pwsh -NoLogo -NoProfile -File "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools/run.ps1" > /tmp/novamoduletools-run-private-cli.log 2>&1; rc=$?; tail -n 80 /tmp/novamoduletools-run-private-cli.log | cat; echo "EXIT:$rc"'
  Result: EXIT:0
  Tests Passed: 568, Failed: 0

Diff hygiene:
- git --no-pager diff --check
  Result: clean.

Maintainability safeguards:
- CodeScene pre-commit safeguard: passed
- Code Health review:
	* src/private/cli/GetNovaCliInvocationContext.ps1 -> 10.0
	* src/private/cli/InvokeNovaCliCommandRoute.ps1 -> 10.0
	* tests/CoverageGaps.Cli.Tests.ps1 -> 10.0

The unchecked template boxes above were not run as separate standalone commands in this task; their coverage came through the full repository quality flow.
```

## Documentation and release follow-up

- [ ] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
- [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
- [ ] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [ ] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
- [ ] `docs/*.html` updated if end-user workflows or examples changed
- [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
  changed
- [x] No documentation, changelog, or example updates were needed

## Maintainability, compatibility, and risk

- [x] Code Health / maintainability impact considered
- [x] No breaking change
- [ ] Breaking change
- [ ] Security-sensitive change
- [ ] CI, workflow, or release-pipeline impact
- [ ] Dependency-review impact

Risk, rollout, or rollback notes:

```text
Compatibility risk is low because the change stayed inside private CLI helpers and preserved the public Invoke-NovaCli behavior and existing user-visible CLI contracts.

Rollback is straightforward:
- restore the previous invocation-context helper structure in src/private/cli/GetNovaCliInvocationContext.ps1
- restore the previous unknown-command adapter path in src/private/cli/InvokeNovaCliCommandRoute.ps1
- remove the two focused CLI coverage additions from tests/CoverageGaps.Cli.Tests.ps1 if the old structure returns

Maintainer follow-up:
- continue reviewing private CLI helpers only where consolidation improves cohesion rather than hiding behavior
- keep tests focused on stable CLI contracts instead of incidental wrappers
```

> [!IMPORTANT]
> Do not use a public pull request to disclose a vulnerability before coordinated handling.
> Use the private reporting path in `SECURITY.md` for new security issues.
