### PR TITLE
Update Node.js version requirements for release automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - CI bump now reuses the already activated built-module command when the current session is already running from
       `dist/`, so publish-then-bump prerelease automation can continue in the same session without losing private helper
       bindings.
+  - `Update-NovaModuleVersion -ContinuousIntegration` now also falls back to a patch bump when `HEAD` already matches
+    the latest tag, so release automation can prepare the next prerelease version without requiring an extra commit.
 - Keep standalone `nova bump` output stable by formatting version-update results in the CLI layer instead of relying on
   PowerShell's default object rendering.
     - `nova bump --what-if` and `% run.ps1` now surface a predictable summary for previous version, new version, label,
@@ -104,6 +106,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       failing during parameter binding.
 - Fix configuration and validation errors so empty `project.json` files and unsupported `Manifest` keys fail fast with
   clear messages.
+- Fix semantic-release PSGallery publishing on fresh CI runners by bootstrapping the PSResourceGet repository store
+  before
+  `Publish-PSResource` runs.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,9 @@ These switches keep the behavior explicit and opt-in:
 
 - `Invoke-NovaBuild -ContinuousIntegration` re-imports the freshly built module after the build succeeds
 - `Update-NovaModuleVersion -ContinuousIntegration` re-imports the built module before the bump workflow starts
+- `Update-NovaModuleVersion -ContinuousIntegration` also falls back to a patch bump when the current `HEAD` already
+  matches the latest tag, so release automation can seed the next prerelease line without requiring an extra commit
+  first
 - `Publish-NovaModule -ContinuousIntegration` restores the built module after publish completes
 - `Invoke-NovaRelease -ContinuousIntegration` forwards that CI intent through the nested build/bump boundaries and then
   restores the built module again after publish
@@ -594,6 +597,11 @@ Responsibilities currently covered by the release pipeline include:
 - creating release tags
 - creating GitHub releases
 - publishing to PowerShell Gallery
+
+The semantic-release publish script also bootstraps the local PSResourceGet repository store before calling
+`Publish-PSResource`, which keeps fresh GitHub Actions runners from failing when the PSGallery repository registration
+file
+does not exist yet.
 
 ### Where NovaModuleTools cmdlets fit
 

--- a/project.json
+++ b/project.json
@@ -1,7 +1,7 @@
 {
   "ProjectName": "NovaModuleTools",
   "Description": "NovaModuleTools is an enterprise-focused evolution of ModuleTools, designed for large-scale PowerShell projects with a strong emphasis on structure, maintainability, and automated CI/CD pipelines.",
-  "Version": "2.0.0-beta05",
+  "Version": "2.0.0-beta06",
   "Preamble": [
     "Set-StrictMode -Version Latest",
     "$ErrorActionPreference = 'Stop'"

--- a/project.json
+++ b/project.json
@@ -1,7 +1,7 @@
 {
   "ProjectName": "NovaModuleTools",
   "Description": "NovaModuleTools is an enterprise-focused evolution of ModuleTools, designed for large-scale PowerShell projects with a strong emphasis on structure, maintainability, and automated CI/CD pipelines.",
-  "Version": "2.0.0-beta04",
+  "Version": "2.0.0-beta05",
   "Preamble": [
     "Set-StrictMode -Version Latest",
     "$ErrorActionPreference = 'Stop'"

--- a/scripts/release/Publish-ToPSGallery.ps1
+++ b/scripts/release/Publish-ToPSGallery.ps1
@@ -4,6 +4,10 @@ param(
 )
 
 Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+. (Join-Path $scriptRoot 'SemanticReleaseSupport.ps1')
 
 if ([string]::IsNullOrWhiteSpace($ApiKey)) {
     throw 'PSGALLERY_API environment variable is required.'
@@ -13,4 +17,5 @@ if (-not (Test-Path -LiteralPath $ModulePath)) {
     throw "Module path not found: $ModulePath"
 }
 
-Publish-PSResource -Path $ModulePath -Repository PSGallery -ApiKey $ApiKey -Verbose
+Initialize-PSGalleryRepository
+Publish-PSResource -Path $ModulePath -Repository PSGallery -ApiKey $ApiKey -Verbose -ErrorAction Stop

--- a/scripts/release/SemanticReleaseSupport.ps1
+++ b/scripts/release/SemanticReleaseSupport.ps1
@@ -4,6 +4,8 @@ $script:supportRoot = Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path
 $script:supportFileList = @(
     'Get-ReleaseDateString.ps1'
     'Get-ReleaseRepositoryUrl.ps1'
+    'Get-PSResourceRepositoryStoreDirectory.ps1'
+    'Initialize-PSGalleryRepository.ps1'
     'ConvertTo-ReleaseTagName.ps1'
     'Read-JsonFile.ps1'
     'Write-JsonFile.ps1'

--- a/scripts/release/support/Get-PSResourceRepositoryStoreDirectory.ps1
+++ b/scripts/release/support/Get-PSResourceRepositoryStoreDirectory.ps1
@@ -1,0 +1,7 @@
+function Get-PSResourceRepositoryStoreDirectory {
+    [CmdletBinding()]
+    param()
+
+    return Join-Path $HOME '.local/share/PSResourceGet'
+}
+

--- a/scripts/release/support/Initialize-PSGalleryRepository.ps1
+++ b/scripts/release/support/Initialize-PSGalleryRepository.ps1
@@ -1,0 +1,14 @@
+function Initialize-PSGalleryRepository {
+    [CmdletBinding()]
+    param()
+
+    $storeDirectory = Get-PSResourceRepositoryStoreDirectory
+    if (-not (Test-Path -LiteralPath $storeDirectory)) {
+        New-Item -ItemType Directory -Path $storeDirectory -Force | Out-Null
+    }
+
+    if ($null -eq (Get-PSResourceRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+        Register-PSResourceRepository -PSGallery
+    }
+}
+

--- a/src/private/release/GetNovaVersionLabelForBump.ps1
+++ b/src/private/release/GetNovaVersionLabelForBump.ps1
@@ -2,7 +2,8 @@ function Get-NovaVersionLabelForBump {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string]$ProjectRoot,
-        [string[]]$CommitMessages = @()
+        [string[]]$CommitMessages = @(),
+        [switch]$ContinuousIntegrationRequested
     )
 
     if ($CommitMessages.Count -gt 0) {
@@ -18,6 +19,10 @@ function Get-NovaVersionLabelForBump {
     }
 
     if (-not (Test-GitRepositoryHasCommitsSinceLatestTag -ProjectRoot $ProjectRoot)) {
+        if ($ContinuousIntegrationRequested) {
+            return 'Patch'
+        }
+
         Stop-NovaOperation -Message 'Cannot bump version because there are no commits since the latest tag.' -ErrorId 'Nova.Workflow.NoCommitsSinceLatestTag' -Category InvalidOperation -TargetObject $ProjectRoot
     }
 

--- a/src/private/release/GetNovaVersionUpdateWorkflowContext.ps1
+++ b/src/private/release/GetNovaVersionUpdateWorkflowContext.ps1
@@ -8,7 +8,7 @@ function Get-NovaVersionUpdateWorkflowContext {
 
     $projectInfo = Get-NovaProjectInfo -Path $ProjectRoot
     $commitMessages = @(Get-GitCommitMessageForVersionBump -ProjectRoot $ProjectRoot)
-    $label = Get-NovaVersionLabelForBump -ProjectRoot $ProjectRoot -CommitMessages $commitMessages
+    $label = Get-NovaVersionLabelForBump -ProjectRoot $ProjectRoot -CommitMessages $commitMessages -ContinuousIntegrationRequested:$ContinuousIntegrationRequested
     $versionUpdatePlan = Get-NovaVersionUpdatePlan -ProjectInfo $projectInfo -Label $label -PreviewRelease:$PreviewRelease
 
     return Get-NovaVersionUpdateWorkflowContextObject -ProjectRoot $ProjectRoot -ProjectInfo $projectInfo -CommitMessages $commitMessages -Label $label -VersionUpdatePlan $versionUpdatePlan -PreviewRelease:$PreviewRelease -ContinuousIntegrationRequested:$ContinuousIntegrationRequested

--- a/tests/CoverageGaps.ReleaseInternals.Tests.ps1
+++ b/tests/CoverageGaps.ReleaseInternals.Tests.ps1
@@ -620,6 +620,33 @@ Describe 'Coverage gaps for release and git internals' {
         }
     }
 
+    It 'Get-NovaVersionLabelForBump returns Patch in CI mode when the current head already matches the latest tag' {
+        InModuleScope $script:moduleName {
+            $projectRoot = Join-Path $TestDrive 'mocked-ci-git-state'
+            New-Item -ItemType Directory -Path (Join-Path $projectRoot '.git') -Force | Out-Null
+
+            Mock Invoke-NovaGitCommand {
+                switch ($Arguments[0]) {
+                    'rev-parse' {
+                        return [pscustomobject]@{ExitCode = 0; Output = @('.git')}
+                    }
+                    'describe' {
+                        return [pscustomobject]@{ExitCode = 0; Output = @('v1.0.0')}
+                    }
+                    'rev-list' {
+                        return [pscustomobject]@{ExitCode = 0; Output = @('0')}
+                    }
+                    default {
+                        throw "Unexpected git args: $( $Arguments -join ' ' )"
+                    }
+                }
+            }
+
+            Get-NovaVersionLabelForBump -ProjectRoot $projectRoot -ContinuousIntegrationRequested | Should -Be 'Patch'
+            Assert-MockCalled Invoke-NovaGitCommand -Times 1 -ParameterFilter {$Arguments[0] -eq 'rev-list' -and $Arguments[2] -eq 'v1.0.0..HEAD'}
+        }
+    }
+
     It 'Get-NovaVersionLabelForBump returns Patch when the repository has commits but no tags yet' {
         InModuleScope $script:moduleName {
             $projectRoot = Join-Path $TestDrive 'mocked-git-without-tags'

--- a/tests/NovaCommandModel.BumpAndCli.Tests.ps1
+++ b/tests/NovaCommandModel.BumpAndCli.Tests.ps1
@@ -133,6 +133,10 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
             $result = Get-NovaVersionUpdateWorkflowContext -ProjectRoot '/tmp/project' -ContinuousIntegrationRequested
 
             $result.'ContinuousIntegrationRequested' | Should -BeTrue
+            Assert-MockCalled Get-NovaVersionLabelForBump -Times 1 -ParameterFilter {
+                $ProjectRoot -eq '/tmp/project' -and
+                        $ContinuousIntegrationRequested
+            }
         }
     }
 
@@ -520,6 +524,36 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
             $thrown.TargetObject | Should -Be $projectRoot
 
             Assert-MockCalled Get-NovaVersionUpdatePlan -Times 0
+            Assert-MockCalled Set-NovaModuleVersion -Times 0
+        }
+    }
+
+    It 'Update-NovaModuleVersion -Preview -ContinuousIntegration -WhatIf still bumps from a tagged head with no new commits' -Skip:(-not [bool](Get-Command git -ErrorAction SilentlyContinue)) {
+        InModuleScope $script:moduleName {
+            $projectRoot = Join-Path $TestDrive 'tagged-head-ci-bump-project'
+            New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+            & git -C $projectRoot init --quiet | Out-Null
+            & git -C $projectRoot config user.name 'NovaModuleTools Tests' | Out-Null
+            & git -C $projectRoot config user.email 'tests@example.invalid' | Out-Null
+            Set-Content -LiteralPath (Join-Path $projectRoot 'first.txt') -Value 'first' -Encoding utf8
+            & git -C $projectRoot add first.txt | Out-Null
+            & git -C $projectRoot commit --quiet -m 'feat: initial release' | Out-Null
+            & git -C $projectRoot tag v2.0.0 | Out-Null
+
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    Version = '2.0.0'
+                    ProjectJSON = (Join-Path $projectRoot 'project.json')
+                }
+            }
+            Mock Set-NovaModuleVersion {throw 'WhatIf should not write project.json'}
+
+            $result = Update-NovaModuleVersion -Path $projectRoot -Preview -ContinuousIntegration -WhatIf
+
+            $result.PreviousVersion | Should -Be '2.0.0'
+            $result.NewVersion | Should -Be '2.0.1-preview'
+            $result.Label | Should -Be 'Patch'
+            $result.CommitCount | Should -Be 0
             Assert-MockCalled Set-NovaModuleVersion -Times 0
         }
     }

--- a/tests/SemanticRelease.Tests.ps1
+++ b/tests/SemanticRelease.Tests.ps1
@@ -7,6 +7,8 @@ Describe 'Semantic release support' {
         $expectedFunctionList = @(
             'Get-ReleaseDateString'
             'Get-ReleaseRepositoryUrl'
+            'Get-PSResourceRepositoryStoreDirectory'
+            'Initialize-PSGalleryRepository'
             'ConvertTo-ReleaseTagName'
             'Read-JsonFile'
             'Write-JsonFile'
@@ -119,5 +121,46 @@ All notable changes to this project will be documented in this file.
 
         $project = Get-Content -LiteralPath $projectFile -Raw | ConvertFrom-Json
         $project.Version | Should -Be '2.0.0'
+    }
+
+    It 'Initialize-PSGalleryRepository creates the PSResourceGet store directory and registers PSGallery when missing' {
+        Mock Get-PSResourceRepositoryStoreDirectory {'/tmp/psresource-store'}
+        Mock Test-Path {$false} -ParameterFilter {$LiteralPath -eq '/tmp/psresource-store'}
+        Mock New-Item {}
+        Mock Get-PSResourceRepository {$null}
+        Mock Register-PSResourceRepository {}
+
+        Initialize-PSGalleryRepository
+
+        Assert-MockCalled New-Item -Times 1 -ParameterFilter {
+            $ItemType -eq 'Directory' -and
+                    $Path -eq '/tmp/psresource-store' -and
+                    $Force
+        }
+        Assert-MockCalled Get-PSResourceRepository -Times 1 -ParameterFilter {$Name -eq 'PSGallery' -and $ErrorAction -eq 'SilentlyContinue'}
+        Assert-MockCalled Register-PSResourceRepository -Times 1 -ParameterFilter {$PSGallery}
+    }
+
+    It 'Initialize-PSGalleryRepository leaves the repository store alone when PSGallery is already registered' {
+        Mock Get-PSResourceRepositoryStoreDirectory {'/tmp/psresource-store'}
+        Mock Test-Path {$true} -ParameterFilter {$LiteralPath -eq '/tmp/psresource-store'}
+        Mock New-Item {}
+        Mock Get-PSResourceRepository {[pscustomobject]@{Name = 'PSGallery'}}
+        Mock Register-PSResourceRepository {}
+
+        Initialize-PSGalleryRepository
+
+        Assert-MockCalled New-Item -Times 0
+        Assert-MockCalled Register-PSResourceRepository -Times 0
+    }
+
+    It 'Publish-ToPSGallery bootstraps semantic-release support before publishing to PSGallery' {
+        $scriptPath = Join-Path $PSScriptRoot '..' 'scripts' 'release' 'Publish-ToPSGallery.ps1'
+        $scriptText = Get-Content -LiteralPath $scriptPath -Raw
+
+        $scriptText | Should -Match 'SemanticReleaseSupport\.ps1'
+        $scriptText | Should -Match 'Initialize-PSGalleryRepository'
+        $scriptText | Should -Match '\$ErrorActionPreference = ''Stop'''
+        $scriptText | Should -Match 'Publish-PSResource .* -ErrorAction Stop'
     }
 }


### PR DESCRIPTION
## Summary

- Fix release automation around the prerelease handoff and PowerShell Gallery publishing.
  - `Update-NovaModuleVersion -ContinuousIntegration` now falls back to a patch bump when `HEAD` already matches the
	latest tag, so the publish workflow can prepare the next prerelease version without requiring an extra commit first.
  - The semantic-release PSGallery publish path now bootstraps the PSResourceGet repository store before calling
	`Publish-PSResource`, and the publish script now fails fast on publish errors.
- This change was needed because the current `main` release flow can legitimately hit `Cannot bump version because there
  are no commits since the latest tag.` after a release, and that should remain a normal error outside CI while still
  allowing the CI prerelease-seeding path to continue. It was also needed because fresh GitHub Actions runners can miss
  `PSResourceRepository.xml`, which caused the PSGallery publish step to fail before the repository store existed.
- Follow-up / context: `#140`.

## Affected area

- [ ] `nova` CLI or command routing
- [x] Public PowerShell cmdlet behavior
- [ ] Scaffolding or `project.json` handling
- [x] Build, test, analyzer, coverage, or CI helper flow
- [ ] Package, raw upload, or package metadata workflow
- [x] Publish, release, semantic-release, or GitHub Actions automation
- [ ] Self-update or notification preference behavior
- [x] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
- [ ] End-user docs (`docs/*.html`)
- [ ] Command help (`docs/NovaModuleTools/en-US/*.md`)
- [ ] `src/resources/example/`
- [ ] Dependency or manifest changes (`package.json`, workflow dependencies, release tooling)
- [ ] Security-sensitive change
- [ ] Documentation-only change
- [ ] Other

## Review guidance

- Start with the two main code paths:
  1. `src/private/release/GetNovaVersionLabelForBump.ps1` together with
	 `src/private/release/GetNovaVersionUpdateWorkflowContext.ps1` for the CI-only tagged-head bump fallback.
  2. `scripts/release/Publish-ToPSGallery.ps1`, `scripts/release/SemanticReleaseSupport.ps1`, and
	 `scripts/release/support/Initialize-PSGalleryRepository.ps1` for the semantic-release PSGallery bootstrap and
	 fail-fast behavior.
- Primary files changed:
  - `src/private/release/GetNovaVersionLabelForBump.ps1`
  - `src/private/release/GetNovaVersionUpdateWorkflowContext.ps1`
  - `scripts/release/Publish-ToPSGallery.ps1`
  - `scripts/release/SemanticReleaseSupport.ps1`
  - `scripts/release/support/Get-PSResourceRepositoryStoreDirectory.ps1`
  - `scripts/release/support/Initialize-PSGalleryRepository.ps1`
  - `tests/NovaCommandModel.BumpAndCli.Tests.ps1`
  - `tests/CoverageGaps.ReleaseInternals.Tests.ps1`
  - `tests/SemanticRelease.Tests.ps1`
  - `README.md`
  - `CHANGELOG.md`
- Trade-offs / limitations:
  - The no-commits-since-tag guard is still enforced for normal local use; the bypass applies only when CI is explicitly
	requested.
  - The workflow file still contains an explicit PSGallery bootstrap in the `develop` branch path, so there is now some
	duplication between workflow setup and the publish script hardening.

## Validation

- [x] `Invoke-NovaBuild`
- [x] `Test-NovaBuild`
- [ ] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [x] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
- [ ] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`, `% nova publish`,
  `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
- [ ] Docs/example only; executable validation not needed

Validation notes:

```text
Focused validation:
- pwsh -NoLogo -NoProfile -Command 'Import-Module NovaModuleTools -Force; Invoke-NovaBuild; Invoke-Pester ./tests/NovaCommandModel.BumpAndCli.Tests.ps1,./tests/CoverageGaps.ReleaseInternals.Tests.ps1,./tests/SemanticRelease.Tests.ps1 -Output Detailed'
  => Tests Passed: 102, Failed: 0

- pwsh -NoLogo -NoProfile -Command 'Import-Module NovaModuleTools -Force; Invoke-NovaBuild; Invoke-Pester ./tests/SemanticRelease.Tests.ps1 -Output Detailed'
  => Tests Passed: 7, Failed: 0

Full validation:
- pwsh -NoLogo -NoProfile -Command 'Import-Module NovaModuleTools -Force; Invoke-NovaBuild; Test-NovaBuild'
  => Tests Passed: 628, Failed: 0

- pwsh -NoLogo -NoProfile -File ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1 -OutputDirectory ./artifacts/coverage-target
  => Tests Passed: 628, Failed: 0
  => Covered 99,94% / 75%. 3.156 analyzed Commands in 1 File.

If you need the exact failure being addressed, the relevant scenarios were:
- normal non-CI bump on tagged HEAD: still errors with 'Cannot bump version because there are no commits since the latest tag.'
- CI bump on tagged HEAD: now falls back to Patch and continues
- semantic-release PSGallery publish on a fresh runner: now bootstraps PSResourceGet repository state before Publish-PSResource
```

## Documentation and release follow-up

- [x] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
- [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
- [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [ ] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
- [ ] `docs/*.html` updated if end-user workflows or examples changed
- [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
  changed
- [ ] No documentation, changelog, or example updates were needed

## Maintainability, compatibility, and risk

- [x] Code Health / maintainability impact considered
- [x] No breaking change
- [ ] Breaking change
- [ ] Security-sensitive change
- [x] CI, workflow, or release-pipeline impact
- [ ] Dependency-review impact

Risk, rollout, or rollback notes:

```text
Compatibility impact is low and targeted:
- local/non-CI version bumps keep their existing tagged-head failure behavior
- CI/release automation gets the new fallback only when -ContinuousIntegration is explicitly requested
- PSGallery publishing now stops the release step immediately if Publish-PSResource fails

Rollback guidance:
- if the CI bump fallback is problematic, revert the Get-NovaVersionLabelForBump / Get-NovaVersionUpdateWorkflowContext change pair
- if the PSGallery bootstrap is problematic, revert the Publish-ToPSGallery / SemanticReleaseSupport / support-helper changes together

Maintainer follow-up:
- consider removing duplicated PSGallery bootstrap logic from .github/workflows/Publish.yml now that the publish script is self-bootstrapping
```

> [!IMPORTANT]
> Do not use a public pull request to disclose a vulnerability before coordinated handling.
> Use the private reporting path in `SECURITY.md` for new security issues.

