### PR TITLE
Enhance Nova version bump behavior and CLI warning handling

### DIFF
--- a/.github/prompts/markdown.promt.md
+++ b/.github/prompts/markdown.promt.md
@@ -1,0 +1,64 @@
+# Markdown Wrapper Enforcer (Strict)
+
+## Purpose
+
+Force ALL output to be wrapped in a Markdown code block using this exact format:
+
+~~~markdown
+<content>
+~~~
+
+## Rules (strict)
+
+1. The response MUST start with exactly:
+
+~~~markdown
+
+2. The response MUST end with exactly:
+~~~
+
+3. There MUST be no text before or after the wrapper.
+
+4. The entire response MUST be inside the wrapper.
+
+5. If the format cannot be followed, DO NOT answer.
+
+Inner content rules
+
+- Inside the outer ~~~markdown block:
+    - Use triple backticks (```) for code examples.
+    - Always include language hints when relevant.
+
+⸻
+
+Example (correct nesting)
+
+## Example Section
+
+Run the build:
+
+```zsh
+% nova build
+```
+
+Or in PowerShell:
+
+```powershell
+PS> Invoke-NovaBuild
+```
+
+Self-check
+
+Before returning:
+
+-Starts with ~~~markdown?
+-Ends with ~~~?
+-Code blocks use triple backticks?
+
+If any check fails → regenerate.
+
+Expected behavior
+
+- Safe nested Markdown (no fence collisions)
+- Copy/paste ready
+- Consistent formatting across all generated content

--- a/.github/prompts/markdown.promt.md
+++ b/.github/prompts/markdown.promt.md
@@ -10,12 +10,8 @@ Force ALL output to be wrapped in a Markdown code block using this exact format:
 
 ## Rules (strict)
 
-1. The response MUST start with exactly:
-
-~~~markdown
-
-2. The response MUST end with exactly:
-~~~
+1. The response MUST start with exactly: ~~~markdown
+2. The response MUST end with exactly: ~~~
 
 3. There MUST be no text before or after the wrapper.
 
@@ -29,7 +25,7 @@ Inner content rules
     - Use triple backticks (```) for code examples.
     - Always include language hints when relevant.
 
-⸻
+---
 
 Example (correct nesting)
 
@@ -47,6 +43,8 @@ Or in PowerShell:
 PS> Invoke-NovaBuild
 ```
 
+---
+
 Self-check
 
 Before returning:
@@ -56,6 +54,8 @@ Before returning:
 -Code blocks use triple backticks?
 
 If any check fails → regenerate.
+
+---
 
 Expected behavior
 

--- a/.github/prompts/markdown.promt.md
+++ b/.github/prompts/markdown.promt.md
@@ -1,64 +1,7 @@
-# Markdown Wrapper Enforcer (Strict)
+# Markdown Wrapper Enforcer
 
 ## Purpose
-
-Force ALL output to be wrapped in a Markdown code block using this exact format:
+Force all output to be wrapped in a Markdown code block using the required format:
 
 ~~~markdown
 <content>
-~~~
-
-## Rules (strict)
-
-1. The response MUST start with exactly: ~~~markdown
-2. The response MUST end with exactly: ~~~
-
-3. There MUST be no text before or after the wrapper.
-
-4. The entire response MUST be inside the wrapper.
-
-5. If the format cannot be followed, DO NOT answer.
-
-Inner content rules
-
-- Inside the outer ~~~markdown block:
-    - Use triple backticks (```) for code examples.
-    - Always include language hints when relevant.
-
----
-
-Example (correct nesting)
-
-## Example Section
-
-Run the build:
-
-```zsh
-% nova build
-```
-
-Or in PowerShell:
-
-```powershell
-PS> Invoke-NovaBuild
-```
-
----
-
-Self-check
-
-Before returning:
-
--Starts with ~~~markdown?
--Ends with ~~~?
--Code blocks use triple backticks?
-
-If any check fails → regenerate.
-
----
-
-Expected behavior
-
-- Safe nested Markdown (no fence collisions)
-- Copy/paste ready
-- Consistent formatting across all generated content

--- a/.github/prompts/pr-description.prompt.md
+++ b/.github/prompts/pr-description.prompt.md
@@ -1,5 +1,3 @@
-markdown
-
 # NovaModuleTools PR Description Generator
 
 ## Purpose

--- a/.github/prompts/pr-description.prompt.md
+++ b/.github/prompts/pr-description.prompt.md
@@ -1,0 +1,151 @@
+markdown
+
+# NovaModuleTools PR Description Generator
+
+## Purpose
+
+Generate a complete, high-quality pull request description for NovaModuleTools based on a change summary, commits, or
+diff.
+
+The output MUST follow the NovaModuleTools PR template exactly and be concise, precise, and reviewer-focused.
+
+---
+
+## Inputs
+
+- Change description, commit messages, or diff (required)
+- Optional: issue number, workflow touched, commands affected
+
+---
+
+## Instructions
+
+Analyze the provided input and:
+
+1. Infer the intent of the change (bugfix, feature, refactor, CI, docs, etc.)
+2. Identify impacted areas (CLI, PowerShell, CI/CD, packaging, docs, etc.)
+3. Detect validation steps performed (or infer what should have been run)
+4. Highlight reviewer entry points (key files, workflows, or commands)
+5. Identify risks, breaking changes, or follow-ups
+
+Be pragmatic: if information is missing, make reasonable assumptions but call them out briefly.
+
+---
+
+## Output format
+
+You MUST return the PR description using this exact structure:
+
+---
+
+## Summary
+
+- What changed?
+- Why was this change needed?
+- Link the issue, discussion, or follow-up work (for example `Closes #123`).
+
+---
+
+## Affected area
+
+Select all relevant:
+
+- [ ] `nova` CLI or command routing
+- [ ] Public PowerShell cmdlet behavior
+- [ ] Scaffolding or `project.json` handling
+- [ ] Build, test, analyzer, coverage, or CI helper flow
+- [ ] Package, raw upload, or package metadata workflow
+- [ ] Publish, release, semantic-release, or GitHub Actions automation
+- [ ] Self-update or notification preference behavior
+- [ ] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
+- [ ] End-user docs (`docs/*.html`)
+- [ ] Command help (`docs/NovaModuleTools/en-US/*.md`)
+- [ ] `src/resources/example/`
+- [ ] Dependency or manifest changes (`package.json`, workflow dependencies, release tooling)
+- [ ] Security-sensitive change
+- [ ] Documentation-only change
+- [ ] Other
+
+---
+
+## Review guidance
+
+- Highlight the main code path or workflow reviewers should start with.
+- Call out the primary files or folders changed (for example `src/public/`, `src/private/cli/`, `scripts/build/ci/`,
+  `.github/workflows/`, `docs/`, or `src/resources/example/`).
+- Call out any trade-offs, follow-up work, or known limitations.
+
+---
+
+## Validation
+
+Mark relevant checks:
+
+- [ ] `Invoke-NovaBuild`
+- [ ] `Test-NovaBuild`
+- [ ] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
+- [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
+- [ ] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`,
+  `% nova publish`,
+  `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
+- [ ] Docs/example only; executable validation not needed
+
+Validation notes:
+
+```
+<Fill with commands, outputs, or justification>
+```
+
+---
+
+## Documentation and release follow-up
+
+- [ ] `README.md` reviewed and updated if needed
+- [ ] `CONTRIBUTING.md` reviewed and updated if needed
+- [ ] `CHANGELOG.md` reviewed and updated if relevant
+- [ ] Command help updated if CLI or cmdlets changed
+- [ ] End-user docs updated if workflows changed
+- [ ] Examples updated if real usage changed
+- [ ] No documentation updates needed
+
+---
+
+## Maintainability, compatibility, and risk
+
+- [ ] Code Health / maintainability impact considered
+- [ ] No breaking change
+- [ ] Breaking change
+- [ ] Security-sensitive change
+- [ ] CI, workflow, or release-pipeline impact
+- [ ] Dependency-review impact
+
+Risk, rollout, or rollback notes:
+
+```
+<Describe impact, migration, rollback, or follow-up>
+```
+
+---
+
+## Style rules
+
+- Be concise and technical (no fluff)
+- Prefer bullet points over paragraphs
+- Be explicit about workflows (especially CI/CD and release flow)
+- Always think like a reviewer: "Where do I start reading?"
+- Never leave sections empty — infer or justify
+
+---
+
+## Example invocation
+
+Generate PR description from:
+
+- Commit: "fix: resolve ambiguous -w CLI parameter parsing"
+- Files changed: `src/private/cli/Invoke-NovaCli.ps1`
+
+---
+
+## Expected behavior
+
+The output should be ready to paste directly into a GitHub PR without edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,33 @@
 # Changelog
 
-All notable changes to this project will be documented in this file and **PreReleased/UNRELEASED** changes will be
-included in the
-next **stable** release!
+All notable changes to this project will be documented in this file and **PREVIEW / UNRELEASED** changes will be
+included in the next **stable** release!
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Added
-
-### Fixed
 
 ### Changed
 
-### Documentation
+- Keep stable `Update-NovaModuleVersion` / `% nova bump` releases on the SemVer major-zero development line.
+    - When the current stable version is `0.y.z` and commit history implies a breaking change, Nova now plans the next
+      minor version instead of auto-jumping to `1.0.0`.
+    - The bump result still reports the detected `Major` label and now prints guidance about manually setting `1.0.0`
+      once the software is stable.
+    - `-Preview` behavior is unchanged.
+
+### Deprecated
 
 ### Removed
 
+### Fixed
+
+### Security
+
 ## [2.1.0] - 2026-04-29
-
 ### Added
-
 - Add `Install-NovaCli` and a packaged `nova` launcher so macOS and Linux users can install and run `nova` directly
   from zsh or bash.
     - `nova` now remains the launcher-facing CLI surface, while `Invoke-NovaCli` stays the explicit PowerShell cmdlet
@@ -108,22 +113,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `nova bump --what-if` and `% run.ps1` now surface a predictable summary for previous version, new version, label,
       and commit count.
 
-### Fixed
-
-- Fix unsupported `nova` help invocations so they now return Nova's structured CLI validation error instead of a
-  PowerShell parameter-binding failure.
-- Keep manifest/package helper edge cases aligned with their intended behavior.
-    - Manifest settings resolution now accepts ordered dictionary metadata shapes in addition to plain hashtables.
-    - `New-NovaPackageArtifacts` now accepts an empty metadata list and returns an empty artifact result instead of
-      failing during parameter binding.
-- Fix configuration and validation errors so empty `project.json` files and unsupported `Manifest` keys fail fast with
-  clear messages.
-- Fix semantic-release PSGallery publishing on fresh CI runners by bootstrapping the PSResourceGet repository store
-  before
-  `Publish-PSResource` runs.
-
 ### Changed
-
 - Change the project to a Nova command model, replacing the previous mixed MT/Nova workflow.
     - All public commands are now Nova commands, and the `nova` CLI / `Invoke-NovaCli` command surface is the primary
       entry point for all operations.
@@ -143,35 +133,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change `Publish-NovaModule -Local` and `% nova publish --local` so a successful local publish also reloads the
   published module from the local install path into the active PowerShell session.
 
-### Documentation
-
-- Split documentation into contributor-focused repository docs and task-oriented GitHub Pages user guides.
-- Expand the public site into a fuller developer end-user manual with rewritten getting started, core workflows, working
-  with modules, troubleshooting, concepts, release notes, and license pages plus new reference-style pages for
-  commands, `project.json`, packaging/delivery, and versioning/update behavior.
-    - The guides now let readers switch between PowerShell and command-line examples, including the local-publish-plus-
-      `pwsh` handoff for `Get-ExampleGreeting` and fresh-process `pwsh`
-- Clean the generated PowerShell cmdlet help so `Get-Help` pages no longer mix in `nova` launcher syntax or GNU-style
-  CLI options.
-- Refresh public `Get-Help` content and examples for the Nova commands, including CLI usage and preview/confirmation
-  scenarios.
-    - Simplify `Invoke-NovaCli` help so it matches the launcher-vs-cmdlet split cleanly and PlatyPS can generate command
-      help without failing during local builds.
-- Update the `nova` CLI documentation and help text to use POSIX/GNU-style long and short options while keeping
-  PowerShell cmdlet examples in their native PowerShell form.
-
 ### Removed
-
 - **BREAKING CHANGE**: Remove the legacy `MT` commands and MT-branded command documentation in favor of the Nova command
   model.
     - All public commands are now Nova commands, and the `nova` CLI / `Invoke-NovaCli` command surface is the primary
       entry point for all
       operations.
 
+### Fixed
+
+- Fix unsupported `nova` help invocations so they now return Nova's structured CLI validation error instead of a
+  PowerShell parameter-binding failure.
+- Keep manifest/package helper edge cases aligned with their intended behavior.
+    - Manifest settings resolution now accepts ordered dictionary metadata shapes in addition to plain hashtables.
+    - `New-NovaPackageArtifacts` now accepts an empty metadata list and returns an empty artifact result instead of
+      failing during parameter binding.
+- Fix configuration and validation errors so empty `project.json` files and unsupported `Manifest` keys fail fast with
+  clear messages.
+- Fix semantic-release PSGallery publishing on fresh CI runners by bootstrapping the PSResourceGet repository store
+  before
+  `Publish-PSResource` runs.
+
 ## [1.9.0] - 2026-04-10
-
 ### Added
-
 - Nova command model and CLI entrypoint:
     - New root command: `nova`
     - New public commands: `Get-NovaProjectInfo`, `Invoke-NovaBuild`, `Invoke-NovaCli`, `Invoke-NovaRelease`,
@@ -182,21 +166,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New GitHub workflow: PowerShell code quality (`.github/workflows/powershell.yml`).
 
 ### Changed
-
 - Updated test workflow triggers in `.github/workflows/Tests.yml` to improve branch/PR coverage.
 - Updated README module naming references to `NovaModuleTools`.
 - Source alignment updates to match installed `NovaModuleTools` v`1.8.0` behavior for compatibility.
 
-### Fixed
+### Deprecated
 
+- `MT` commands and MT-branded command documentation in favor of the Nova command model.
+
+### Fixed
 - Resource lookup compatibility in `Get-ResourceFilePath` for source/dist execution contexts.
 
-### Documentation
-
-- Added documentation and release notes context for the Nova command model and workflow/security updates.
-
 ## [1.8.0] - 2026-04-08
-
 ### Added
 - Project settings:
     - `BuildRecursiveFolders` (default `true`): recursive discovery for `src/classes`, `src/private` and `tests`.
@@ -210,15 +191,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Build determinism: files are processed in a deterministic order by relative path (case-insensitive), and load order is always `classes → public → private`.
 
-### Documentation
-- README: document enterprise defaults, deterministic load order, and duplicate-function validation.
-
 ## [1.3.0] - 2025-09-23
-
 - Added support for `ps1xml1` format data. Place it in resources folder with `Name.format.ps1xml` to be automatically added as format file and imported in module manifest
 
 ## [1.2.0] - 2025-09-17
-
 ### Added
 - Added support for classes directory inside src
 - Initialize-NovaModule generates classes directory during fresh project
@@ -228,47 +204,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Version upgrade using update-mtmoduleversion now support build tags. Improvements to semver versioning.
 
 ## [1.1.3] - 2025-09-14
-
 ### Added
-
 - Now supports preview tag in Update-NovaModuleVersion
 - Now supports semver naming in both project.json and modulemanifest
 - Module build supports `preview` or `prerelease` tag
 - Preview version looks like `1.2.3-preview`
 
 ## [1.1.0] - 2025-08-28
-
 ## Added
-
 - Now Module manifest includes `AliasesToExport`. This helps loading aliases without explicitly importing modules to
   session.
 - thanks to @djs-zmtc for suggesting the feature
 
 ## [1.0.0] - 2025-03-11
-
 ### Added
-
 - New optional project setting `CopyResourcesToModuleRoot`. Setting to true places resource files in the root directory
   of module. Default is `false` to provide backward compatibility. Thanks to @[BrooksV](https://github.com/BrooksV)
 
 ### Fixed
-
 - **BREAKING CHANGE**: Typo corrected: ProjecUri to ProjectUri. Existing projects require manual update.
 
 ## [0.0.9] - 2024-07-17
-
 ### Fixed
-
 - Fixed #7, Invoke build should not through for empty tags
 
 ## [0.0.7] - 2024-07-17
-
 ### Added
-
 - Now "Manifest" section of project JSON supports all Manifest parameters, use exact name of parameter (from New-ModuleManifest) as key in JSON
 
 ## Fixed
-
 - Fixed the example project README so it no longer suggests that `example/` includes a `run.ps1` helper script; it now
   points users to building `NovaModuleTools` from the repository root or using the Gallery workflow.
 - Corrected typo in ProjectUri from `ProjecUri` to correct spelling.
@@ -276,26 +240,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.0.6] - 2024-07-08
 
 ### Added
-
 - `Test-NovaBuild` now supports including and excluding tags
 
 ### Fixed
-
 - Code cleanup
 
 ## [0.0.5] - 2024-07-05
-
 ### Added
-
 - More verbose info during MTModule creation
 
 ### Fixed
-
 - Issue #2 : Git initialization implemented
 - Issue #1 : Doesn't create empty `tests` folder when user chooses `no` to tests
 
 ## [0.0.4] - 2024-06-25
-
 ### Added
 - First release to `psgallery`
 - All basic functionality of Module is ready
@@ -339,4 +297,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.0.6]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.5...Version_0.0.6
 [0.0.5]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.4...Version_0.0.5
 [0.0.4]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.3...Version_0.0.4
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keep stable `Update-NovaModuleVersion` / `% nova bump` releases on the SemVer major-zero development line.
     - When the current stable version is `0.y.z` and commit history implies a breaking change, Nova now plans the next
       minor version instead of auto-jumping to `1.0.0`.
-    - The bump result still reports the detected `Major` label and now prints guidance about manually setting `1.0.0`
-      once the software is stable.
+  - Stable `0.y.z` bump results now print one warning about manually setting `1.0.0` once the software is stable,
+    while breaking-change bumps still report the detected `Major` label.
     - `-Preview` behavior is unchanged.
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -218,9 +218,9 @@ These switches keep the behavior explicit and opt-in:
 - `Invoke-NovaRelease -ContinuousIntegration` forwards that CI intent through the nested build/bump boundaries and then
   restores the built module again after publish
 
-When Nova reports that a breaking-change bump was detected while the current stable version is still `0.y.z`, it also
-prints guidance about manually setting `1.0.0` once the software is stable. Preview bumps keep their current behavior
-and are not remapped by this rule.
+When the current stable version is still `0.y.z`, Nova also prints one warning that major version zero is still the
+initial-development line and that `1.0.0` must be set manually once the software is stable. Preview bumps keep their
+current behavior and are not remapped by this rule.
 
 Useful local helper:
 

--- a/README.md
+++ b/README.md
@@ -212,9 +212,15 @@ These switches keep the behavior explicit and opt-in:
 - `Update-NovaModuleVersion -ContinuousIntegration` also falls back to a patch bump when the current `HEAD` already
   matches the latest tag, so release automation can seed the next prerelease line without requiring an extra commit
   first
+- `Update-NovaModuleVersion` and `% nova bump` treat stable `0.y.z` versions as the SemVer initial-development phase,
+  so breaking-change bumps stay on the `0.y.z` line by planning the next minor version instead of jumping to `1.0.0`
 - `Publish-NovaModule -ContinuousIntegration` restores the built module after publish completes
 - `Invoke-NovaRelease -ContinuousIntegration` forwards that CI intent through the nested build/bump boundaries and then
   restores the built module again after publish
+
+When Nova reports that a breaking-change bump was detected while the current stable version is still `0.y.z`, it also
+prints guidance about manually setting `1.0.0` once the software is stable. Preview bumps keep their current behavior
+and are not remapped by this rule.
 
 Useful local helper:
 

--- a/docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md
+++ b/docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md
@@ -173,7 +173,7 @@ Re-imports the built `dist/<ProjectName>/<ProjectName>.psd1` first and then runs
 PS> Update-NovaModuleVersion -WhatIf
 
 What if: Performing the operation "Update module version using Major release label" on target "project.json".
-WARNING: Major version zero (0.y.z) is for initial development, so Nova keeps breaking-change bumps on the 0.y.z line and plans the next minor version instead of 1.0.0. Set 1.0.0 manually once the software is stable; after that, automatic major-version bumps work normally.
+WARNING: Major version zero (0.y.z) is for initial development, so Nova keeps stable bumps on the 0.y.z line and plans breaking-change bumps as the next minor version instead of 1.0.0. Set 1.0.0 manually once the software is stable; after that, automatic major-version bumps work normally.
 
 PreviousVersion: 0.1.0
 NewVersion: 0.2.0
@@ -181,8 +181,8 @@ Label: Major
 CommitCount: 34
 ```
 
-Shows how breaking-change commits stay on the `0.y.z` initial-development line for stable bumps, while still warning
-that `1.0.0` should be set manually when the API becomes stable.
+Shows how stable `0.y.z` bumps still warn that `1.0.0` must be set manually when the API becomes stable, while
+breaking-change commits on that line continue to plan the next minor version instead of jumping straight to `1.0.0`.
 
 ## PARAMETERS
 

--- a/docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md
+++ b/docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md
@@ -42,6 +42,11 @@ The release label is inferred from the commit set:
 - `Minor` for `feat:` commits
 - `Patch` for `fix:` commits and all other cases
 
+When the current stable version is still on `0.y.z` and the inferred label is `Major`, Nova keeps the release on the
+initial-development line and plans the next minor version instead of jumping straight to `1.0.0`. The result still
+reports the detected `Major` label so you can see that the commit set contained a breaking change, and Nova prints
+guidance about manually setting `1.0.0` once the software is stable. `-Preview` behavior stays unchanged.
+
 When Git tags exist, only commits since the latest tag are considered. If the folder is not a Git repository, the
 command falls back to a patch bump.
 
@@ -161,6 +166,23 @@ PS> Update-NovaModuleVersion -ContinuousIntegration
 ```
 
 Re-imports the built `dist/<ProjectName>/<ProjectName>.psd1` first and then runs the normal version bump workflow.
+
+### EXAMPLE 9
+
+```text
+PS> Update-NovaModuleVersion -WhatIf
+
+What if: Performing the operation "Update module version using Major release label" on target "project.json".
+WARNING: Major version zero (0.y.z) is for initial development, so Nova keeps breaking-change bumps on the 0.y.z line and plans the next minor version instead of 1.0.0. Set 1.0.0 manually once the software is stable; after that, automatic major-version bumps work normally.
+
+PreviousVersion: 0.1.0
+NewVersion: 0.2.0
+Label: Major
+CommitCount: 34
+```
+
+Shows how breaking-change commits stay on the `0.y.z` initial-development line for stable bumps, while still warning
+that `1.0.0` should be set manually when the API becomes stable.
 
 ## PARAMETERS
 

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -476,6 +476,10 @@ PS&gt; Invoke-NovaRelease -PublishOption @{ Repository = 'PSGallery'; ApiKey = $
                             <li><strong>Notable behavior:</strong> falls back to a patch bump when the folder is not a
                                 Git repository, but throws when the repository exists and has no commits yet
                             </li>
+                            <li><strong>Major-zero rule:</strong> stable <code>0.y.z</code> projects keep
+                                breaking-change
+                                bumps on the initial-development line, so a detected <code>Major</code> bump plans the
+                                next minor version until you manually set <code>1.0.0</code></li>
                             <li><strong>Prerelease rule:</strong> finalizes matching prerelease targets like
                                 <code>2.0.0-preview7 -&gt; 2.0.0</code> instead of carrying the old prerelease label
                                 into

--- a/docs/versioning-and-updates.html
+++ b/docs/versioning-and-updates.html
@@ -165,6 +165,15 @@
                     <li><strong>Minor</strong> for <code>feat:</code> commits</li>
                     <li><strong>Patch</strong> for <code>fix:</code> commits and all other cases</li>
                 </ul>
+                <p>While your project is still on a stable <code>0.y.z</code> version, Nova treats SemVer major zero as
+                    the initial-development phase. A breaking-change bump still reports the detected
+                    <strong>Major</strong> label, but the planned stable version stays on the <code>0.y.z</code> line by
+                    advancing to the next minor version instead of jumping to <code>1.0.0</code>. Nova also prints a
+                    reminder to set <code>1.0.0</code> manually once the API is stable. Preview mode stays unchanged.
+                </p>
+                <pre><code>0.0.1 + Patch -> 0.0.2
+0.1.0 + Minor -> 0.2.0
+0.1.0 + Major -> 0.2.0</code></pre>
                 <p>When Git tags exist, Nova uses commits since the latest tag. When the folder is not a Git repository,
                     Nova falls back to a patch bump. When the repository exists but has no commits yet, Nova stops with
                     a clear error.</p>

--- a/docs/versioning-and-updates.html
+++ b/docs/versioning-and-updates.html
@@ -166,10 +166,12 @@
                     <li><strong>Patch</strong> for <code>fix:</code> commits and all other cases</li>
                 </ul>
                 <p>While your project is still on a stable <code>0.y.z</code> version, Nova treats SemVer major zero as
-                    the initial-development phase. A breaking-change bump still reports the detected
-                    <strong>Major</strong> label, but the planned stable version stays on the <code>0.y.z</code> line by
-                    advancing to the next minor version instead of jumping to <code>1.0.0</code>. Nova also prints a
-                    reminder to set <code>1.0.0</code> manually once the API is stable. Preview mode stays unchanged.
+                    the initial-development phase. Stable bumps stay on the <code>0.y.z</code> line, and a
+                    breaking-change
+                    bump still reports the detected <strong>Major</strong> label while advancing to the next minor
+                    version
+                    instead of jumping to <code>1.0.0</code>. Nova prints one warning that you should set
+                    <code>1.0.0</code> manually once the API is stable. Preview mode stays unchanged.
                 </p>
                 <pre><code>0.0.1 + Patch -> 0.0.2
 0.1.0 + Minor -> 0.2.0

--- a/src/private/cli/FormatNovaCliCommandResult.ps1
+++ b/src/private/cli/FormatNovaCliCommandResult.ps1
@@ -47,7 +47,29 @@ function Format-NovaCliVersionUpdateResult {
         'Version plan:'
     }
 
-    return "$summaryPrefix $( $Result.PreviousVersion ) -> $( $Result.NewVersion ) | Label: $( $Result.Label ) | Commits: $( $Result.CommitCount )"
+    $summary = "$summaryPrefix $( $Result.PreviousVersion ) -> $( $Result.NewVersion ) | Label: $( $Result.Label ) | Commits: $( $Result.CommitCount )"
+    $advisoryMessage = Get-NovaCliVersionUpdateAdvisoryMessage -Result $Result
+    if ( [string]::IsNullOrWhiteSpace($advisoryMessage)) {
+        return $summary
+    }
+
+    return @(
+        $summary
+        $advisoryMessage
+    ) -join [Environment]::NewLine
+}
+
+function Get-NovaCliVersionUpdateAdvisoryMessage {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$Result
+    )
+
+    if ($Result.PSObject.Properties.Name -notcontains 'AdvisoryMessage') {
+        return $null
+    }
+
+    return $Result.AdvisoryMessage
 }
 
 function Format-NovaCliCommandResult {

--- a/src/private/cli/FormatNovaCliCommandResult.ps1
+++ b/src/private/cli/FormatNovaCliCommandResult.ps1
@@ -47,29 +47,7 @@ function Format-NovaCliVersionUpdateResult {
         'Version plan:'
     }
 
-    $summary = "$summaryPrefix $( $Result.PreviousVersion ) -> $( $Result.NewVersion ) | Label: $( $Result.Label ) | Commits: $( $Result.CommitCount )"
-    $advisoryMessage = Get-NovaCliVersionUpdateAdvisoryMessage -Result $Result
-    if ( [string]::IsNullOrWhiteSpace($advisoryMessage)) {
-        return $summary
-    }
-
-    return @(
-        $summary
-        $advisoryMessage
-    ) -join [Environment]::NewLine
-}
-
-function Get-NovaCliVersionUpdateAdvisoryMessage {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)][object]$Result
-    )
-
-    if ($Result.PSObject.Properties.Name -notcontains 'AdvisoryMessage') {
-        return $null
-    }
-
-    return $Result.AdvisoryMessage
+    return "$summaryPrefix $( $Result.PreviousVersion ) -> $( $Result.NewVersion ) | Label: $( $Result.Label ) | Commits: $( $Result.CommitCount )"
 }
 
 function Format-NovaCliCommandResult {

--- a/src/private/cli/InvokeNovaCliCommandRoute.ps1
+++ b/src/private/cli/InvokeNovaCliCommandRoute.ps1
@@ -45,20 +45,42 @@ function Invoke-NovaCliBumpCommand {
         [Parameter(Mandatory)][pscustomobject]$InvocationContext
     )
 
+    $commandOutput = @(Invoke-NovaCliParsedCommand -InvocationContext $InvocationContext -ParserCommand 'ConvertFrom-NovaBumpCliArgument' -ActionCommand 'Update-NovaModuleVersion' 3>&1)
+    $capturedOutput = Read-NovaCliCapturedOutput -OutputRecords $commandOutput
+    Write-NovaCliCapturedWarning -WarningMessages $capturedOutput.WarningMessages
+    return $capturedOutput.Result
+}
+
+function Read-NovaCliCapturedOutput {
+    [CmdletBinding()]
+    param(
+        [object[]]$OutputRecords = @()
+    )
+
     $warningMessages = @()
-    $result = Invoke-NovaCliParsedCommand -InvocationContext $InvocationContext -ParserCommand 'ConvertFrom-NovaBumpCliArgument' -ActionCommand 'Update-NovaModuleVersion' -WarningAction SilentlyContinue -WarningVariable warningMessages
-    Write-NovaCliCapturedWarning -WarningMessages $warningMessages -SkippedMessage (Get-NovaCliVersionUpdateAdvisoryMessage -Result $result)
-    return $result
+    $result = $null
+    foreach ($outputRecord in @($OutputRecords)) {
+        if ($outputRecord -is [System.Management.Automation.WarningRecord]) {
+            $warningMessages += $outputRecord
+            continue
+        }
+
+        $result = $outputRecord
+    }
+
+    return [pscustomobject]@{
+        Result = $result
+        WarningMessages = @($warningMessages)
+    }
 }
 
 function Write-NovaCliCapturedWarning {
     [CmdletBinding()]
     param(
-        [object[]]$WarningMessages = @(),
-        [string]$SkippedMessage
+        [object[]]$WarningMessages = @()
     )
 
-    foreach ($message in (Get-NovaCliReplayWarningMessage -WarningMessages $WarningMessages -SkippedMessage $SkippedMessage)) {
+    foreach ($message in (Get-NovaCliReplayWarningMessage -WarningMessages $WarningMessages)) {
         Write-Warning $message
     }
 }
@@ -66,13 +88,12 @@ function Write-NovaCliCapturedWarning {
 function Get-NovaCliReplayWarningMessage {
     [CmdletBinding()]
     param(
-        [object[]]$WarningMessages = @(),
-        [string]$SkippedMessage
+        [object[]]$WarningMessages = @()
     )
 
     $messages = foreach ($warningMessage in @($WarningMessages)) {
         $text = ConvertTo-NovaCliWarningMessageText -WarningMessage $warningMessage
-        if ([string]::IsNullOrWhiteSpace($text) -or $text -eq $SkippedMessage) {
+        if ( [string]::IsNullOrWhiteSpace($text)) {
             continue
         }
 

--- a/src/private/cli/InvokeNovaCliCommandRoute.ps1
+++ b/src/private/cli/InvokeNovaCliCommandRoute.ps1
@@ -39,6 +39,62 @@ function Invoke-NovaCliParsedCommand {
     return & $ActionCommand @options @mutatingCommonParameters
 }
 
+function Invoke-NovaCliBumpCommand {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$InvocationContext
+    )
+
+    $warningMessages = @()
+    $result = Invoke-NovaCliParsedCommand -InvocationContext $InvocationContext -ParserCommand 'ConvertFrom-NovaBumpCliArgument' -ActionCommand 'Update-NovaModuleVersion' -WarningAction SilentlyContinue -WarningVariable warningMessages
+    Write-NovaCliCapturedWarning -WarningMessages $warningMessages -SkippedMessage (Get-NovaCliVersionUpdateAdvisoryMessage -Result $result)
+    return $result
+}
+
+function Write-NovaCliCapturedWarning {
+    [CmdletBinding()]
+    param(
+        [object[]]$WarningMessages = @(),
+        [string]$SkippedMessage
+    )
+
+    foreach ($message in (Get-NovaCliReplayWarningMessage -WarningMessages $WarningMessages -SkippedMessage $SkippedMessage)) {
+        Write-Warning $message
+    }
+}
+
+function Get-NovaCliReplayWarningMessage {
+    [CmdletBinding()]
+    param(
+        [object[]]$WarningMessages = @(),
+        [string]$SkippedMessage
+    )
+
+    $messages = foreach ($warningMessage in @($WarningMessages)) {
+        $text = ConvertTo-NovaCliWarningMessageText -WarningMessage $warningMessage
+        if ([string]::IsNullOrWhiteSpace($text) -or $text -eq $SkippedMessage) {
+            continue
+        }
+
+        $text
+    }
+
+    return @($messages)
+}
+
+function ConvertTo-NovaCliWarningMessageText {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$WarningMessage
+    )
+
+    if ($WarningMessage -is [System.Management.Automation.WarningRecord]) {
+        return $WarningMessage.Message
+    }
+
+    return [string]$WarningMessage
+}
+
 function Invoke-NovaCliUpdateRouteCommand {
     [CmdletBinding()]
     param(
@@ -55,7 +111,7 @@ function Invoke-NovaCliBumpRouteCommand {
         [Parameter(Mandatory)][pscustomobject]$InvocationContext
     )
 
-    $result = Invoke-NovaCliParsedCommand -InvocationContext $InvocationContext -ParserCommand 'ConvertFrom-NovaBumpCliArgument' -ActionCommand 'Update-NovaModuleVersion'
+    $result = Invoke-NovaCliBumpCommand -InvocationContext $InvocationContext
     return Format-NovaCliCommandResult -Command $InvocationContext.Command -Result $result
 }
 

--- a/src/private/release/GetNovaVersionUpdateWorkflowContext.ps1
+++ b/src/private/release/GetNovaVersionUpdateWorkflowContext.ps1
@@ -26,15 +26,32 @@ function Get-NovaVersionUpdateLabelResolution {
     $effectiveLabel = $Label
     $advisoryMessage = $null
     $currentVersion = Get-NovaCurrentVersionForUpdatePlan -ProjectInfo $ProjectInfo
+    if (Test-NovaVersionUpdateUsesInitialDevelopmentAdvisory -CurrentVersion $currentVersion -PreviewRelease:$PreviewRelease) {
+        $advisoryMessage = Get-NovaInitialDevelopmentVersioningMessage
+    }
+
     if (Test-NovaVersionUpdateUsesMajorZeroFallback -CurrentVersion $currentVersion -Label $Label -PreviewRelease:$PreviewRelease) {
         $effectiveLabel = 'Minor'
-        $advisoryMessage = Get-NovaInitialDevelopmentVersioningMessage
     }
 
     return [pscustomobject]@{
         EffectiveLabel = $effectiveLabel
         AdvisoryMessage = $advisoryMessage
     }
+}
+
+function Test-NovaVersionUpdateUsesInitialDevelopmentAdvisory {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][semver]$CurrentVersion,
+        [switch]$PreviewRelease
+    )
+
+    if ($PreviewRelease) {
+        return $false
+    }
+
+    return $CurrentVersion.Major -eq 0
 }
 
 function Test-NovaVersionUpdateUsesMajorZeroFallback {
@@ -60,7 +77,7 @@ function Get-NovaInitialDevelopmentVersioningMessage {
     [CmdletBinding()]
     param()
 
-    return 'Major version zero (0.y.z) is for initial development, so Nova keeps breaking-change bumps on the 0.y.z line and plans the next minor version instead of 1.0.0. Set 1.0.0 manually once the software is stable; after that, automatic major-version bumps work normally.'
+    return 'Major version zero (0.y.z) is for initial development, so Nova keeps stable bumps on the 0.y.z line and plans breaking-change bumps as the next minor version instead of 1.0.0. Set 1.0.0 manually once the software is stable; after that, automatic major-version bumps work normally.'
 }
 
 function Get-NovaVersionUpdateWorkflowContextObject {

--- a/src/private/release/GetNovaVersionUpdateWorkflowContext.ps1
+++ b/src/private/release/GetNovaVersionUpdateWorkflowContext.ps1
@@ -9,9 +9,58 @@ function Get-NovaVersionUpdateWorkflowContext {
     $projectInfo = Get-NovaProjectInfo -Path $ProjectRoot
     $commitMessages = @(Get-GitCommitMessageForVersionBump -ProjectRoot $ProjectRoot)
     $label = Get-NovaVersionLabelForBump -ProjectRoot $ProjectRoot -CommitMessages $commitMessages -ContinuousIntegrationRequested:$ContinuousIntegrationRequested
-    $versionUpdatePlan = Get-NovaVersionUpdatePlan -ProjectInfo $projectInfo -Label $label -PreviewRelease:$PreviewRelease
+    $labelResolution = Get-NovaVersionUpdateLabelResolution -ProjectInfo $projectInfo -Label $label -PreviewRelease:$PreviewRelease
+    $versionUpdatePlan = Get-NovaVersionUpdatePlan -ProjectInfo $projectInfo -Label $labelResolution.EffectiveLabel -PreviewRelease:$PreviewRelease
 
-    return Get-NovaVersionUpdateWorkflowContextObject -ProjectRoot $ProjectRoot -ProjectInfo $projectInfo -CommitMessages $commitMessages -Label $label -VersionUpdatePlan $versionUpdatePlan -PreviewRelease:$PreviewRelease -ContinuousIntegrationRequested:$ContinuousIntegrationRequested
+    return Get-NovaVersionUpdateWorkflowContextObject -ProjectRoot $ProjectRoot -ProjectInfo $projectInfo -CommitMessages $commitMessages -Label $label -EffectiveLabel $labelResolution.EffectiveLabel -AdvisoryMessage $labelResolution.AdvisoryMessage -VersionUpdatePlan $versionUpdatePlan -PreviewRelease:$PreviewRelease -ContinuousIntegrationRequested:$ContinuousIntegrationRequested
+}
+
+function Get-NovaVersionUpdateLabelResolution {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
+        [Parameter(Mandatory)][string]$Label,
+        [switch]$PreviewRelease
+    )
+
+    $effectiveLabel = $Label
+    $advisoryMessage = $null
+    $currentVersion = Get-NovaCurrentVersionForUpdatePlan -ProjectInfo $ProjectInfo
+    if (Test-NovaVersionUpdateUsesMajorZeroFallback -CurrentVersion $currentVersion -Label $Label -PreviewRelease:$PreviewRelease) {
+        $effectiveLabel = 'Minor'
+        $advisoryMessage = Get-NovaInitialDevelopmentVersioningMessage
+    }
+
+    return [pscustomobject]@{
+        EffectiveLabel = $effectiveLabel
+        AdvisoryMessage = $advisoryMessage
+    }
+}
+
+function Test-NovaVersionUpdateUsesMajorZeroFallback {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][semver]$CurrentVersion,
+        [Parameter(Mandatory)][string]$Label,
+        [switch]$PreviewRelease
+    )
+
+    if ($PreviewRelease) {
+        return $false
+    }
+
+    if ($Label -ne 'Major') {
+        return $false
+    }
+
+    return $CurrentVersion.Major -eq 0
+}
+
+function Get-NovaInitialDevelopmentVersioningMessage {
+    [CmdletBinding()]
+    param()
+
+    return 'Major version zero (0.y.z) is for initial development, so Nova keeps breaking-change bumps on the 0.y.z line and plans the next minor version instead of 1.0.0. Set 1.0.0 manually once the software is stable; after that, automatic major-version bumps work normally.'
 }
 
 function Get-NovaVersionUpdateWorkflowContextObject {
@@ -21,6 +70,8 @@ function Get-NovaVersionUpdateWorkflowContextObject {
         [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
         [AllowEmptyCollection()][string[]]$CommitMessages = @(),
         [Parameter(Mandatory)][string]$Label,
+        [Parameter(Mandatory)][string]$EffectiveLabel,
+        [AllowEmptyString()][string]$AdvisoryMessage,
         [Parameter(Mandatory)][pscustomobject]$VersionUpdatePlan,
         [switch]$PreviewRelease,
         [switch]$ContinuousIntegrationRequested
@@ -32,6 +83,8 @@ function Get-NovaVersionUpdateWorkflowContextObject {
         CommitMessages = $CommitMessages
         CommitCount = $CommitMessages.Count
         Label = $Label
+        EffectiveLabel = $EffectiveLabel
+        AdvisoryMessage = $AdvisoryMessage
         PreviewRelease = [bool]$PreviewRelease
         ContinuousIntegrationRequested = [bool]$ContinuousIntegrationRequested
         Target = [System.IO.Path]::GetFileName($ProjectInfo.ProjectJSON)

--- a/src/private/release/InvokeNovaVersionUpdateWorkflow.ps1
+++ b/src/private/release/InvokeNovaVersionUpdateWorkflow.ps1
@@ -8,7 +8,7 @@ function Invoke-NovaVersionUpdateWorkflow {
 
     $versionWriteResult = $null
     if ($ShouldRun) {
-        $versionWriteResult = Set-NovaModuleVersion -ProjectInfo $WorkflowContext.ProjectInfo -Label $WorkflowContext.Label -PreviewRelease:$WorkflowContext.PreviewRelease -Confirm:$false
+        $versionWriteResult = Set-NovaModuleVersion -ProjectInfo $WorkflowContext.ProjectInfo -Label (Get-NovaVersionUpdateEffectiveLabel -WorkflowContext $WorkflowContext) -PreviewRelease:$WorkflowContext.PreviewRelease -Confirm:$false
     }
 
     if (-not (Test-NovaVersionUpdateResultRequired -ShouldRun:$ShouldRun -WhatIfEnabled:$WhatIfEnabled)) {
@@ -28,6 +28,19 @@ function Test-NovaVersionUpdateResultRequired {
     return $ShouldRun -or $WhatIfEnabled
 }
 
+function Get-NovaVersionUpdateEffectiveLabel {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext
+    )
+
+    if ($WorkflowContext.PSObject.Properties.Name -contains 'EffectiveLabel' -and -not [string]::IsNullOrWhiteSpace($WorkflowContext.EffectiveLabel)) {
+        return $WorkflowContext.EffectiveLabel
+    }
+
+    return $WorkflowContext.Label
+}
+
 function Get-NovaVersionUpdateResult {
     [CmdletBinding()]
     param(
@@ -39,7 +52,23 @@ function Get-NovaVersionUpdateResult {
         PreviousVersion = $WorkflowContext.PreviousVersion
         NewVersion = $WorkflowContext.NewVersion
         Label = $WorkflowContext.Label
+        EffectiveLabel = Get-NovaVersionUpdateEffectiveLabel -WorkflowContext $WorkflowContext
+        AdvisoryMessage = Get-NovaVersionUpdateAdvisoryMessage -WorkflowContext $WorkflowContext
         CommitCount = $WorkflowContext.CommitCount
         Applied = [bool]$Applied
     }
 }
+
+function Get-NovaVersionUpdateAdvisoryMessage {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext
+    )
+
+    if ($WorkflowContext.PSObject.Properties.Name -notcontains 'AdvisoryMessage') {
+        return $null
+    }
+
+    return $WorkflowContext.AdvisoryMessage
+}
+

--- a/src/private/release/WriteNovaVersionUpdateResultMessages.ps1
+++ b/src/private/release/WriteNovaVersionUpdateResultMessages.ps1
@@ -1,0 +1,54 @@
+function Invoke-NovaVersionUpdateCiActivation {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ProjectRoot,
+        [Parameter(Mandatory)][hashtable]$Parameters,
+        [switch]$ContinuousIntegration,
+        [switch]$WhatIfEnabled
+    )
+
+    if (-not $ContinuousIntegration -or $WhatIfEnabled) {
+        return [pscustomobject]@{ShouldReturn = $false; Result = $null}
+    }
+
+    $ciActivatedCommand = Get-NovaVersionUpdateCiActivatedCommand -ProjectRoot $ProjectRoot
+    if ($null -eq $ciActivatedCommand) {
+        return [pscustomobject]@{ShouldReturn = $false; Result = $null}
+    }
+
+    return [pscustomobject]@{
+        ShouldReturn = $true
+        Result = & $ciActivatedCommand @Parameters
+    }
+}
+
+function Write-NovaVersionUpdateResultOutput {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$Result
+    )
+
+    $advisoryMessage = Get-NovaVersionUpdateResultAdvisoryMessage -Result $Result
+    if (-not [string]::IsNullOrWhiteSpace($advisoryMessage)) {
+        Write-Warning $advisoryMessage
+    }
+
+    if ($Result.Applied) {
+        Write-Host "Version bumped to : $( $Result.NewVersion )"
+    }
+}
+
+function Get-NovaVersionUpdateResultAdvisoryMessage {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$Result
+    )
+
+    if ($Result.PSObject.Properties.Name -notcontains 'AdvisoryMessage') {
+        return $null
+    }
+
+    return $Result.AdvisoryMessage
+}
+
+

--- a/src/private/update/WriteNovaAvailableModuleUpdateWarning.ps1
+++ b/src/private/update/WriteNovaAvailableModuleUpdateWarning.ps1
@@ -36,7 +36,7 @@ function Write-NovaAvailableModuleUpdateWarning {
         ''
         'Update:'
         $updateCommand
-        'nova update'
+        '% nova update'
     )
 
     if ($Prerelease) {

--- a/src/public/UpdateNovaModuleVersion.ps1
+++ b/src/public/UpdateNovaModuleVersion.ps1
@@ -7,26 +7,20 @@ function Update-NovaModuleVersion {
     )
 
     $projectRoot = (Resolve-Path -LiteralPath $Path).Path
-    if ($ContinuousIntegration -and -not $WhatIfPreference) {
-        $ciActivatedCommand = Get-NovaVersionUpdateCiActivatedCommand -ProjectRoot $projectRoot
-        if ($null -ne $ciActivatedCommand) {
-            return & $ciActivatedCommand @PSBoundParameters
-        }
+    $ciActivation = Invoke-NovaVersionUpdateCiActivation -ProjectRoot $projectRoot -Parameters $PSBoundParameters -ContinuousIntegration:$ContinuousIntegration -WhatIfEnabled:$WhatIfPreference
+    if ($ciActivation.ShouldReturn) {
+        return $ciActivation.Result
     }
 
     $workflowContext = Get-NovaVersionUpdateWorkflowContext -ProjectRoot $projectRoot -PreviewRelease:$Preview -ContinuousIntegrationRequested:$ContinuousIntegration
-
-
     $shouldRun = $PSCmdlet.ShouldProcess($workflowContext.Target, $workflowContext.Action)
-
     $result = Invoke-NovaVersionUpdateWorkflow -WorkflowContext $workflowContext -ShouldRun:$shouldRun -WhatIfEnabled:$WhatIfPreference
     if ($null -eq $result) {
         return
     }
 
-    if ($result.Applied) {
-        Write-Host "Version bumped to : $( $result.NewVersion )"
-    }
+    Write-NovaVersionUpdateResultOutput -Result $result
 
     return $result
 }
+

--- a/src/resources/cli/help/bump.psd1
+++ b/src/resources/cli/help/bump.psd1
@@ -4,6 +4,8 @@
     Usage = 'nova bump [<options>]'
     Description = @(
         'Update the module version in project.json by using the current repository history.',
+        'When the current stable version is 0.y.z, Nova keeps breaking-change bumps on the initial-development line and plans the next minor version instead of jumping to 1.0.0.',
+        'Set 1.0.0 manually once the software is stable. After that, nova bump can increment major versions normally.',
         'Use --preview when you want an explicit prerelease iteration instead of the next stable semantic version.',
         'For more information, documentation, and examples, visit:',
         'https://www.novamoduletools.com/versioning-and-updates.html#bump'
@@ -48,6 +50,10 @@
         @{
             Command = 'nova bump --preview --what-if'
             Description = 'Preview the next prerelease version without updating project.json.'
+        },
+        @{
+            Command = 'nova bump --what-if'
+            Description = 'When the current version is 0.y.z and the commit set implies a breaking change, Nova keeps the release on the 0.y.z line and prints guidance about manually promoting the project to 1.0.0 later.'
         },
         @{
             Command = 'nova bump --continuous-integration --what-if'

--- a/tests/ArchitectureGuardrails.Tests.ps1
+++ b/tests/ArchitectureGuardrails.Tests.ps1
@@ -95,7 +95,7 @@ Describe 'Architecture guardrails' {
             [pscustomobject]@{Path = 'src/public/SetNovaUpdateNotificationPreference.ps1'; ExpectedHelpers = @('Get-NovaUpdateNotificationPreferenceChangeContext', 'Invoke-NovaUpdateNotificationPreferenceChange')}
             [pscustomobject]@{Path = 'src/public/TestNovaBuild.ps1'; ExpectedHelpers = @('Get-NovaTestWorkflowContext', 'Invoke-NovaTestWorkflow', 'New-NovaTestDynamicParameterDictionary')}
             [pscustomobject]@{Path = 'src/public/UpdateNovaModuleTools.ps1'; ExpectedHelpers = @('Complete-NovaModuleSelfUpdateResult', 'Confirm-NovaPrereleaseModuleUpdate', 'Get-NovaModuleSelfUpdateWorkflowContext', 'Invoke-NovaModuleSelfUpdateWorkflow', 'Write-NovaModuleReleaseNotesLink')}
-            [pscustomobject]@{Path = 'src/public/UpdateNovaModuleVersion.ps1'; ExpectedHelpers = @('Get-NovaVersionUpdateCiActivatedCommand', 'Get-NovaVersionUpdateWorkflowContext', 'Invoke-NovaVersionUpdateWorkflow')}
+            [pscustomobject]@{Path = 'src/public/UpdateNovaModuleVersion.ps1'; ExpectedHelpers = @('Get-NovaVersionUpdateWorkflowContext', 'Invoke-NovaVersionUpdateCiActivation', 'Invoke-NovaVersionUpdateWorkflow', 'Write-NovaVersionUpdateResultOutput')}
         )
         $expectedPaths = @($testCases | ForEach-Object Path | Sort-Object)
         $actualPaths = @(

--- a/tests/CoverageGaps.Cli.Tests.ps1
+++ b/tests/CoverageGaps.Cli.Tests.ps1
@@ -141,7 +141,7 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
         }
     }
 
-    It 'Format-NovaCliCommandResult appends the major-zero advisory when a stable breaking-change bump stays on 0.y.z' {
+    It 'Format-NovaCliCommandResult keeps bump summaries stable even when a major-zero advisory is present' {
         InModuleScope $script:moduleName {
             $versionUpdateResult = [pscustomobject]@{
                 PreviousVersion = '0.1.0'
@@ -154,7 +154,7 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
             }
             $result = Format-NovaCliCommandResult -Command 'bump' -Result $versionUpdateResult
 
-            $result | Should -Be "Version plan: 0.1.0 -> 0.2.0 | Label: Major | Commits: 34$( [Environment]::NewLine )Major version zero (0.y.z) is for initial development."
+            $result | Should -Be 'Version plan: 0.1.0 -> 0.2.0 | Label: Major | Commits: 34'
         }
     }
 

--- a/tests/CoverageGaps.Cli.Tests.ps1
+++ b/tests/CoverageGaps.Cli.Tests.ps1
@@ -141,6 +141,23 @@ Describe 'Coverage gaps for CLI and installed-version internals' {
         }
     }
 
+    It 'Format-NovaCliCommandResult appends the major-zero advisory when a stable breaking-change bump stays on 0.y.z' {
+        InModuleScope $script:moduleName {
+            $versionUpdateResult = [pscustomobject]@{
+                PreviousVersion = '0.1.0'
+                NewVersion = '0.2.0'
+                Label = 'Major'
+                EffectiveLabel = 'Minor'
+                AdvisoryMessage = 'Major version zero (0.y.z) is for initial development.'
+                CommitCount = 34
+                Applied = $false
+            }
+            $result = Format-NovaCliCommandResult -Command 'bump' -Result $versionUpdateResult
+
+            $result | Should -Be "Version plan: 0.1.0 -> 0.2.0 | Label: Major | Commits: 34$( [Environment]::NewLine )Major version zero (0.y.z) is for initial development."
+        }
+    }
+
     It 'Format-NovaCliCommandResult renders applied bump results as a completed CLI summary' {
         InModuleScope $script:moduleName {
             $versionUpdateResult = [pscustomobject]@{

--- a/tests/CoverageGaps.ReleaseInternals.Tests.ps1
+++ b/tests/CoverageGaps.ReleaseInternals.Tests.ps1
@@ -148,9 +148,11 @@ Describe 'Coverage gaps for release and git internals' {
         }
     }
 
-    It 'Get-NovaVersionUpdateWorkflowContext handles stable and preview major bumps on the 0.y.z line as expected when <Name>' -ForEach @(
+    It 'Get-NovaVersionUpdateWorkflowContext handles stable and preview major-zero bumps as expected when <Name>' -ForEach @(
         @{
-            Name = 'a stable bump stays on the initial-development line'
+            Name = 'a stable breaking-change bump stays on the initial-development line'
+            CurrentVersion = '0.1.0'
+            Label = 'Major'
             PreviewRelease = $false
             PlannedVersion = '0.2.0'
             ExpectedEffectiveLabel = 'Minor'
@@ -158,7 +160,19 @@ Describe 'Coverage gaps for release and git internals' {
             ExpectedPlanLabel = 'Minor'
         }
         @{
+            Name = 'a stable feature bump still warns that 1.0.0 must be set manually'
+            CurrentVersion = '0.0.1'
+            Label = 'Minor'
+            PreviewRelease = $false
+            PlannedVersion = '0.1.0'
+            ExpectedEffectiveLabel = 'Minor'
+            ExpectedAdvisoryPattern = 'Set 1\.0\.0 manually once the software is stable'
+            ExpectedPlanLabel = 'Minor'
+        }
+        @{
             Name = 'preview mode remains unchanged'
+            CurrentVersion = '0.1.0'
+            Label = 'Major'
             PreviewRelease = $true
             PlannedVersion = '1.0.0-preview'
             ExpectedEffectiveLabel = 'Major'
@@ -172,11 +186,11 @@ Describe 'Coverage gaps for release and git internals' {
             Mock Get-NovaProjectInfo {
                 [pscustomobject]@{
                     ProjectJSON = '/tmp/project.json'
-                    Version = '0.1.0'
+                    Version = $TestCase.CurrentVersion
                 }
             }
             Mock Get-GitCommitMessageForVersionBump {@('feat!: breaking api')}
-            Mock Get-NovaVersionLabelForBump {'Major'}
+            Mock Get-NovaVersionLabelForBump {$TestCase.Label}
             Mock Get-NovaVersionUpdatePlan {
                 [pscustomobject]@{
                     NewVersion = [semver]$TestCase.PlannedVersion
@@ -185,7 +199,7 @@ Describe 'Coverage gaps for release and git internals' {
 
             $result = Get-NovaVersionUpdateWorkflowContext -ProjectRoot '/tmp/project' -PreviewRelease:$TestCase.PreviewRelease
 
-            $result.Label | Should -Be 'Major'
+            $result.Label | Should -Be $TestCase.Label
             $result.EffectiveLabel | Should -Be $TestCase.ExpectedEffectiveLabel
             $result.NewVersion | Should -Be $TestCase.PlannedVersion
             if ($null -eq $TestCase.ExpectedAdvisoryPattern) {

--- a/tests/CoverageGaps.ReleaseInternals.Tests.ps1
+++ b/tests/CoverageGaps.ReleaseInternals.Tests.ps1
@@ -216,6 +216,17 @@ Describe 'Coverage gaps for release and git internals' {
         }
     }
 
+    It 'Get-NovaVersionUpdateEffectiveLabel falls back to Label when EffectiveLabel is missing or blank' -ForEach @(
+        @{Name = 'missing'; WorkflowContext = [pscustomobject]@{Label = 'Patch'}; Expected = 'Patch'}
+        @{Name = 'blank'; WorkflowContext = [pscustomobject]@{Label = 'Minor'; EffectiveLabel = '   '}; Expected = 'Minor'}
+    ) {
+        InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+            param($TestCase)
+
+            Get-NovaVersionUpdateEffectiveLabel -WorkflowContext $TestCase.WorkflowContext | Should -Be $TestCase.Expected
+        }
+    }
+
     It 'Get-NovaVersionUpdatePlan keeps the semantic core and increments an existing prerelease label when preview mode continues a prerelease' -ForEach @(
         @{CurrentVersion = '1.5.3-preview'; ExpectedVersion = '1.5.3-preview01'}
         @{CurrentVersion = '1.5.3-preview01'; ExpectedVersion = '1.5.3-preview02'}

--- a/tests/CoverageGaps.ReleaseInternals.Tests.ps1
+++ b/tests/CoverageGaps.ReleaseInternals.Tests.ps1
@@ -148,6 +148,60 @@ Describe 'Coverage gaps for release and git internals' {
         }
     }
 
+    It 'Get-NovaVersionUpdateWorkflowContext handles stable and preview major bumps on the 0.y.z line as expected when <Name>' -ForEach @(
+        @{
+            Name = 'a stable bump stays on the initial-development line'
+            PreviewRelease = $false
+            PlannedVersion = '0.2.0'
+            ExpectedEffectiveLabel = 'Minor'
+            ExpectedAdvisoryPattern = 'Set 1\.0\.0 manually once the software is stable'
+            ExpectedPlanLabel = 'Minor'
+        }
+        @{
+            Name = 'preview mode remains unchanged'
+            PreviewRelease = $true
+            PlannedVersion = '1.0.0-preview'
+            ExpectedEffectiveLabel = 'Major'
+            ExpectedAdvisoryPattern = $null
+            ExpectedPlanLabel = 'Major'
+        }
+    ) {
+        InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+            param($TestCase)
+
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    ProjectJSON = '/tmp/project.json'
+                    Version = '0.1.0'
+                }
+            }
+            Mock Get-GitCommitMessageForVersionBump {@('feat!: breaking api')}
+            Mock Get-NovaVersionLabelForBump {'Major'}
+            Mock Get-NovaVersionUpdatePlan {
+                [pscustomobject]@{
+                    NewVersion = [semver]$TestCase.PlannedVersion
+                }
+            }
+
+            $result = Get-NovaVersionUpdateWorkflowContext -ProjectRoot '/tmp/project' -PreviewRelease:$TestCase.PreviewRelease
+
+            $result.Label | Should -Be 'Major'
+            $result.EffectiveLabel | Should -Be $TestCase.ExpectedEffectiveLabel
+            $result.NewVersion | Should -Be $TestCase.PlannedVersion
+            if ($null -eq $TestCase.ExpectedAdvisoryPattern) {
+                $result.AdvisoryMessage | Should -BeNullOrEmpty
+            }
+            else {
+                $result.AdvisoryMessage | Should -Match $TestCase.ExpectedAdvisoryPattern
+            }
+
+            Assert-MockCalled Get-NovaVersionUpdatePlan -Times 1 -ParameterFilter {
+                $Label -eq $TestCase.ExpectedPlanLabel -and
+                        ([bool]$PreviewRelease) -eq ([bool]$TestCase.PreviewRelease)
+            }
+        }
+    }
+
     It 'Get-NovaVersionUpdatePlan keeps the semantic core and increments an existing prerelease label when preview mode continues a prerelease' -ForEach @(
         @{CurrentVersion = '1.5.3-preview'; ExpectedVersion = '1.5.3-preview01'}
         @{CurrentVersion = '1.5.3-preview01'; ExpectedVersion = '1.5.3-preview02'}

--- a/tests/NovaCommandModel.BumpAndCli.Tests.ps1
+++ b/tests/NovaCommandModel.BumpAndCli.Tests.ps1
@@ -706,6 +706,19 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
         }
     }
 
+    It 'Get-NovaCliReplayWarningMessage converts non-warning records to text and skips blank values' {
+        InModuleScope $script:moduleName {
+            $result = Get-NovaCliReplayWarningMessage -WarningMessages @(
+                'plain warning'
+                ''
+                '   '
+                42
+            )
+
+            $result | Should -Be @('plain warning', '42')
+        }
+    }
+
     It 'Confirm-NovaCliCommandAction accepts Enter as the default confirmation response' {
         Invoke-ConfirmNovaCliCommandActionEnterAssertion -ModuleName $script:moduleName
     }

--- a/tests/NovaCommandModel.BumpAndCli.Tests.ps1
+++ b/tests/NovaCommandModel.BumpAndCli.Tests.ps1
@@ -707,6 +707,21 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
         }
     }
 
+    It 'Invoke-NovaCli bump formats the major-zero advisory once when the routed bump command returns the same advisory warning' {
+        InModuleScope $script:moduleName {
+            $advisoryMessage = 'Major version zero (0.y.z) is for initial development.'
+            Mock Update-NovaModuleVersion {
+                Write-Warning $advisoryMessage
+                [pscustomobject]@{PreviousVersion = '0.1.0'; NewVersion = '0.2.0'; Label = 'Major'; EffectiveLabel = 'Minor'; AdvisoryMessage = $advisoryMessage; CommitCount = 1; Applied = $false}
+            }
+
+            $result = Invoke-NovaCli bump -WhatIf
+
+            $result | Should -Be "Version plan: 0.1.0 -> 0.2.0 | Label: Major | Commits: 1$( [Environment]::NewLine )$advisoryMessage"
+            ([regex]::Matches($result,[regex]::Escape($advisoryMessage))).Count | Should -Be 1
+        }
+    }
+
     It 'Confirm-NovaCliCommandAction accepts Enter as the default confirmation response' {
         Invoke-ConfirmNovaCliCommandActionEnterAssertion -ModuleName $script:moduleName
     }

--- a/tests/NovaCommandModel.BumpAndCli.Tests.ps1
+++ b/tests/NovaCommandModel.BumpAndCli.Tests.ps1
@@ -101,10 +101,42 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
             $result.PreviousVersion | Should -Be '1.0.0'
             $result.NewVersion | Should -Be '1.1.0'
             $result.Label | Should -Be 'Minor'
+            $result.EffectiveLabel | Should -Be 'Minor'
             $result.CommitCount | Should -Be 2
             $result.Target | Should -Be 'project.json'
             $result.Action | Should -Be 'Update module version using Minor release label'
             $result.'ContinuousIntegrationRequested' | Should -BeFalse
+            Assert-MockCalled Get-NovaVersionUpdatePlan -Times 1 -ParameterFilter {
+                $ProjectInfo.ProjectName -eq 'NovaModuleTools' -and
+                        $Label -eq 'Minor' -and
+                        -not $PreviewRelease
+            }
+        }
+    }
+
+    It 'Get-NovaVersionUpdateWorkflowContext keeps the detected Major label but plans the next minor version for stable 0.y.z projects' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    ProjectName = 'NovaModuleTools'
+                    Version = '0.1.0'
+                    ProjectJSON = '/tmp/project.json'
+                }
+            }
+            Mock Get-GitCommitMessageForVersionBump {@('feat!: breaking api')}
+            Mock Get-NovaVersionLabelForBump {'Major'}
+            Mock Get-NovaVersionUpdatePlan {
+                [pscustomobject]@{
+                    NewVersion = [semver]'0.2.0'
+                }
+            }
+
+            $result = Get-NovaVersionUpdateWorkflowContext -ProjectRoot '/tmp/project'
+
+            $result.Label | Should -Be 'Major'
+            $result.EffectiveLabel | Should -Be 'Minor'
+            $result.NewVersion | Should -Be '0.2.0'
+            $result.AdvisoryMessage | Should -Match 'Major version zero \(0\.y\.z\) is for initial development'
             Assert-MockCalled Get-NovaVersionUpdatePlan -Times 1 -ParameterFilter {
                 $ProjectInfo.ProjectName -eq 'NovaModuleTools' -and
                         $Label -eq 'Minor' -and
@@ -206,6 +238,7 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
             $workflowContext = [pscustomobject]@{
                 ProjectInfo = [pscustomobject]@{ProjectName = 'NovaModuleTools'}
                 Label = 'Minor'
+                EffectiveLabel = 'Minor'
                 PreviewRelease = $true
                 PreviousVersion = '1.0.0'
                 NewVersion = '1.1.0-preview'
@@ -235,6 +268,40 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
         }
     }
 
+    It 'Invoke-NovaVersionUpdateWorkflow persists the effective minor label for stable 0.y.z major bumps' {
+        InModuleScope $script:moduleName {
+            $workflowContext = [pscustomobject]@{
+                ProjectInfo = [pscustomobject]@{ProjectName = 'NovaModuleTools'}
+                Label = 'Major'
+                EffectiveLabel = 'Minor'
+                AdvisoryMessage = 'Major version zero (0.y.z) is for initial development.'
+                PreviewRelease = $false
+                PreviousVersion = '0.1.0'
+                NewVersion = '0.2.0'
+                CommitCount = 34
+            }
+            Mock Set-NovaModuleVersion {
+                [pscustomobject]@{
+                    PreviousVersion = '0.1.0'
+                    NewVersion = '0.2.0'
+                    Applied = $true
+                }
+            }
+
+            $result = Invoke-NovaVersionUpdateWorkflow -WorkflowContext $workflowContext -ShouldRun
+
+            $result.Label | Should -Be 'Major'
+            $result.EffectiveLabel | Should -Be 'Minor'
+            $result.AdvisoryMessage | Should -Be 'Major version zero (0.y.z) is for initial development.'
+            Assert-MockCalled Set-NovaModuleVersion -Times 1 -ParameterFilter {
+                $ProjectInfo.ProjectName -eq 'NovaModuleTools' -and
+                        $Label -eq 'Minor' -and
+                        -not $PreviewRelease -and
+                        -not $Confirm
+            }
+        }
+    }
+
     It 'Update-NovaModuleVersion delegates orchestration to private bump workflow helpers' {
         InModuleScope $script:moduleName {
             Mock Get-NovaVersionUpdateWorkflowContext {
@@ -258,6 +325,36 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
                         -not $WhatIfEnabled
             }
             Assert-MockCalled Write-Host -Times 1 -ParameterFilter {$Object -eq 'Version bumped to : 1.1.0'}
+        }
+    }
+
+    It 'Update-NovaModuleVersion writes a warning when a stable major-zero bump stays on the initial-development line' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaVersionUpdateWorkflowContext {
+                [pscustomobject]@{
+                    Target = 'project.json'
+                    Action = 'Update module version using Major release label'
+                }
+            }
+            Mock Invoke-NovaVersionUpdateWorkflow {
+                [pscustomobject]@{
+                    PreviousVersion = '0.1.0'
+                    NewVersion = '0.2.0'
+                    Label = 'Major'
+                    EffectiveLabel = 'Minor'
+                    AdvisoryMessage = 'Major version zero (0.y.z) is for initial development.'
+                    CommitCount = 34
+                    Applied = $false
+                }
+            }
+            Mock Write-Host {throw 'WhatIf should not emit host output'}
+            $warningMessages = $null
+
+            $result = Update-NovaModuleVersion -Path (Get-Location).Path -WhatIf -WarningVariable warningMessages
+
+            $result.NewVersion | Should -Be '0.2.0'
+            ($warningMessages -join ' ') | Should -Match 'Major version zero \(0\.y\.z\) is for initial development'
+            Assert-MockCalled Write-Host -Times 0
         }
     }
 

--- a/tests/NovaCommandModel.BumpAndCli.Tests.ps1
+++ b/tests/NovaCommandModel.BumpAndCli.Tests.ps1
@@ -35,6 +35,8 @@ $global:novaCommandModelBumpAndCliTestSupportFunctionNameList = @(
     'Invoke-ConfirmNovaCliCommandActionEnterAssertion'
     'Invoke-ConfirmNovaCliCommandActionRetryAssertion'
     'Invoke-ConfirmNovaCliCommandActionCancellationAssertion'
+    'Assert-TestNovaVersionUpdateWorkflowContextMajorZeroAdvisory'
+    'Assert-TestUpdateNovaModuleVersionMajorZeroWarning'
 )
 . $script:testSupportPath
 
@@ -114,34 +116,25 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
         }
     }
 
-    It 'Get-NovaVersionUpdateWorkflowContext keeps the detected Major label but plans the next minor version for stable 0.y.z projects' {
-        InModuleScope $script:moduleName {
-            Mock Get-NovaProjectInfo {
-                [pscustomobject]@{
-                    ProjectName = 'NovaModuleTools'
-                    Version = '0.1.0'
-                    ProjectJSON = '/tmp/project.json'
-                }
-            }
-            Mock Get-GitCommitMessageForVersionBump {@('feat!: breaking api')}
-            Mock Get-NovaVersionLabelForBump {'Major'}
-            Mock Get-NovaVersionUpdatePlan {
-                [pscustomobject]@{
-                    NewVersion = [semver]'0.2.0'
-                }
-            }
+    It 'Get-NovaVersionUpdateWorkflowContext keeps the detected Major label but plans the next minor version for stable 0.y.z breaking-change bumps' {
+        Assert-TestNovaVersionUpdateWorkflowContextMajorZeroAdvisory -ModuleName $script:moduleName -TestCase @{
+            CurrentVersion = '0.1.0'
+            CommitMessages = @('feat!: breaking api')
+            Label = 'Major'
+            PlannedVersion = '0.2.0'
+            ExpectedEffectiveLabel = 'Minor'
+            ExpectedPlanLabel = 'Minor'
+        }
+    }
 
-            $result = Get-NovaVersionUpdateWorkflowContext -ProjectRoot '/tmp/project'
-
-            $result.Label | Should -Be 'Major'
-            $result.EffectiveLabel | Should -Be 'Minor'
-            $result.NewVersion | Should -Be '0.2.0'
-            $result.AdvisoryMessage | Should -Match 'Major version zero \(0\.y\.z\) is for initial development'
-            Assert-MockCalled Get-NovaVersionUpdatePlan -Times 1 -ParameterFilter {
-                $ProjectInfo.ProjectName -eq 'NovaModuleTools' -and
-                        $Label -eq 'Minor' -and
-                        -not $PreviewRelease
-            }
+    It 'Get-NovaVersionUpdateWorkflowContext warns feature bumps that stable 0.y.z is still the initial-development line' {
+        Assert-TestNovaVersionUpdateWorkflowContextMajorZeroAdvisory -ModuleName $script:moduleName -TestCase @{
+            CurrentVersion = '0.0.1'
+            CommitMessages = @('feat: add command')
+            Label = 'Minor'
+            PlannedVersion = '0.1.0'
+            ExpectedEffectiveLabel = 'Minor'
+            ExpectedPlanLabel = 'Minor'
         }
     }
 
@@ -274,7 +267,7 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
                 ProjectInfo = [pscustomobject]@{ProjectName = 'NovaModuleTools'}
                 Label = 'Major'
                 EffectiveLabel = 'Minor'
-                AdvisoryMessage = 'Major version zero (0.y.z) is for initial development.'
+                AdvisoryMessage = 'Major version zero (0.y.z) is for initial development, so Nova keeps stable bumps on the 0.y.z line and plans breaking-change bumps as the next minor version instead of 1.0.0. Set 1.0.0 manually once the software is stable; after that, automatic major-version bumps work normally.'
                 PreviewRelease = $false
                 PreviousVersion = '0.1.0'
                 NewVersion = '0.2.0'
@@ -292,7 +285,8 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
 
             $result.Label | Should -Be 'Major'
             $result.EffectiveLabel | Should -Be 'Minor'
-            $result.AdvisoryMessage | Should -Be 'Major version zero (0.y.z) is for initial development.'
+            $result.AdvisoryMessage | Should -Match 'Major version zero \(0\.y\.z\) is for initial development'
+            $result.AdvisoryMessage | Should -Match 'Set 1\.0\.0 manually once the software is stable'
             Assert-MockCalled Set-NovaModuleVersion -Times 1 -ParameterFilter {
                 $ProjectInfo.ProjectName -eq 'NovaModuleTools' -and
                         $Label -eq 'Minor' -and
@@ -328,33 +322,21 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
         }
     }
 
-    It 'Update-NovaModuleVersion writes a warning when a stable major-zero bump stays on the initial-development line' {
-        InModuleScope $script:moduleName {
-            Mock Get-NovaVersionUpdateWorkflowContext {
-                [pscustomobject]@{
-                    Target = 'project.json'
-                    Action = 'Update module version using Major release label'
-                }
-            }
-            Mock Invoke-NovaVersionUpdateWorkflow {
-                [pscustomobject]@{
-                    PreviousVersion = '0.1.0'
-                    NewVersion = '0.2.0'
-                    Label = 'Major'
-                    EffectiveLabel = 'Minor'
-                    AdvisoryMessage = 'Major version zero (0.y.z) is for initial development.'
-                    CommitCount = 34
-                    Applied = $false
-                }
-            }
-            Mock Write-Host {throw 'WhatIf should not emit host output'}
-            $warningMessages = $null
+    It 'Update-NovaModuleVersion writes the initial-development warning for stable 0.y.z breaking-change bumps' {
+        Assert-TestUpdateNovaModuleVersionMajorZeroWarning -ModuleName $script:moduleName -TestCase @{
+            PreviousVersion = '0.1.0'
+            NewVersion = '0.2.0'
+            Label = 'Major'
+            EffectiveLabel = 'Minor'
+        }
+    }
 
-            $result = Update-NovaModuleVersion -Path (Get-Location).Path -WhatIf -WarningVariable warningMessages
-
-            $result.NewVersion | Should -Be '0.2.0'
-            ($warningMessages -join ' ') | Should -Match 'Major version zero \(0\.y\.z\) is for initial development'
-            Assert-MockCalled Write-Host -Times 0
+    It 'Update-NovaModuleVersion writes the initial-development warning for stable 0.y.z feature bumps' {
+        Assert-TestUpdateNovaModuleVersionMajorZeroWarning -ModuleName $script:moduleName -TestCase @{
+            PreviousVersion = '0.0.1'
+            NewVersion = '0.1.0'
+            Label = 'Minor'
+            EffectiveLabel = 'Minor'
         }
     }
 
@@ -707,18 +689,20 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
         }
     }
 
-    It 'Invoke-NovaCli bump formats the major-zero advisory once when the routed bump command returns the same advisory warning' {
+    It 'Invoke-NovaCli bump replays the initial-development advisory once as a warning and keeps the summary clean' {
         InModuleScope $script:moduleName {
             $advisoryMessage = 'Major version zero (0.y.z) is for initial development.'
             Mock Update-NovaModuleVersion {
                 Write-Warning $advisoryMessage
                 [pscustomobject]@{PreviousVersion = '0.1.0'; NewVersion = '0.2.0'; Label = 'Major'; EffectiveLabel = 'Minor'; AdvisoryMessage = $advisoryMessage; CommitCount = 1; Applied = $false}
             }
+            $warningMessages = $null
 
-            $result = Invoke-NovaCli bump -WhatIf
+            $result = Invoke-NovaCli bump -WhatIf -WarningVariable warningMessages
 
-            $result | Should -Be "Version plan: 0.1.0 -> 0.2.0 | Label: Major | Commits: 1$( [Environment]::NewLine )$advisoryMessage"
-            ([regex]::Matches($result,[regex]::Escape($advisoryMessage))).Count | Should -Be 1
+            $result | Should -Be 'Version plan: 0.1.0 -> 0.2.0 | Label: Major | Commits: 1'
+            ($warningMessages -join ' ') | Should -Match ([regex]::Escape($advisoryMessage))
+            @($warningMessages | ForEach-Object {[string]$_} | Select-Object -Unique | Where-Object {$_ -match ([regex]::Escape($advisoryMessage))}).Count | Should -Be 1
         }
     }
 

--- a/tests/NovaCommandModel.StandaloneCli.Tests.ps1
+++ b/tests/NovaCommandModel.StandaloneCli.Tests.ps1
@@ -311,6 +311,46 @@ Describe '$projectName tests' {
         }
     }
 
+    It 'Install-NovaCli keeps stable major-zero breaking-change bumps on the 0.y.z line and prints guidance about 1.0.0' {
+        $targetDirectory = Join-Path $TestDrive 'major-zero-bump-bin'
+        $installedPath = Join-Path $targetDirectory 'nova'
+        $projectRoot = Join-Path $TestDrive 'CliMajorZeroBumpProject'
+        $projectJsonPath = Join-Path $projectRoot 'project.json'
+        $originalModulePath = $env:PSModulePath
+        $modulePathSeparator = [string][System.IO.Path]::PathSeparator
+        $distParent = Split-Path -Parent $script:distModuleDir
+
+        $env:PSModulePath = "$distParent$modulePathSeparator$originalModulePath"
+
+        Initialize-TestNovaCliProjectLayout -ProjectRoot $projectRoot
+        Write-TestNovaCliProjectJson -ProjectRoot $projectRoot -ProjectName 'CliMajorZeroBumpProject' -ProjectGuid '55555555-5555-5555-5555-555555555555'
+        Write-TestNovaCliPublicFunction -ProjectRoot $projectRoot -FunctionName 'Invoke-TestCliMajorZeroBump'
+
+        $projectData = Get-Content -LiteralPath $projectJsonPath -Raw | ConvertFrom-Json
+        $projectData.Version = '0.1.0'
+        $projectData | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $projectJsonPath -Encoding utf8
+
+        try {
+            Initialize-TestNovaCliGitRepository -ProjectRoot $projectRoot -CommitMessage 'feat!: add stable major zero bump coverage'
+
+            Install-NovaCli -DestinationDirectory $targetDirectory -Force | Out-Null
+
+            $bumpResult = Invoke-TestInstalledNovaCommand -InstalledPath $installedPath -WorkingDirectory $projectRoot -Arguments @('bump', '--what-if')
+            $versionAfterBump = (Get-Content -LiteralPath $projectJsonPath -Raw | ConvertFrom-Json).Version
+
+            $bumpResult.ExitCode | Should -Be 0
+            $bumpResult.Text | Should -Match 'What if:'
+            $bumpResult.Text | Should -Match 'Version plan: 0\.1\.0 -> 0\.2\.0 \| Label: Major \| Commits: 1'
+            $bumpResult.Text | Should -Match 'Major version zero \(0\.y\.z\) is for initial development'
+            $bumpResult.Text | Should -Match 'Set 1\.0\.0 manually once the software is stable'
+            $bumpResult.Text | Should -Not -Match 'Version bumped to :'
+            $versionAfterBump | Should -Be '0.1.0'
+        }
+        finally {
+            $env:PSModulePath = $originalModulePath
+        }
+    }
+
     It 'Install-NovaCli rejects unsupported nova init invocations with clear migration guidance' -ForEach @(
         @{
             Name = 'WhatIf'

--- a/tests/NovaCommandModel.StandaloneCli.Tests.ps1
+++ b/tests/NovaCommandModel.StandaloneCli.Tests.ps1
@@ -19,6 +19,7 @@ Publish-TestSupportFunctions -FunctionNameList @(
     'New-TestPesterConfigStub'
     'Get-TestInstalledNovaCliSnapshot'
     'Assert-TestInstalledNovaCliSnapshot'
+    'Assert-TestInstalledNovaCliBumpBehavior'
 )
 
 BeforeAll {
@@ -54,6 +55,7 @@ BeforeAll {
         'New-TestPesterConfigStub'
         'Get-TestInstalledNovaCliSnapshot'
         'Assert-TestInstalledNovaCliSnapshot'
+        'Assert-TestInstalledNovaCliBumpBehavior'
     )
 }
 
@@ -272,83 +274,67 @@ Describe '$projectName tests' {
         }
     }
 
-    It 'Install-NovaCli forwards --preview so prerelease bumps keep the same semantic core and increment the current prerelease label' {
-        $targetDirectory = Join-Path $TestDrive 'preview-bump-bin'
-        $installedPath = Join-Path $targetDirectory 'nova'
-        $projectRoot = Join-Path $TestDrive 'CliPreviewBumpProject'
-        $projectJsonPath = Join-Path $projectRoot 'project.json'
-        $originalModulePath = $env:PSModulePath
-        $modulePathSeparator = [string][System.IO.Path]::PathSeparator
-        $distParent = Split-Path -Parent $script:distModuleDir
-
-        $env:PSModulePath = "$distParent$modulePathSeparator$originalModulePath"
-
-        Initialize-TestNovaCliProjectLayout -ProjectRoot $projectRoot
-        Write-TestNovaCliProjectJson -ProjectRoot $projectRoot -ProjectName 'CliPreviewBumpProject' -ProjectGuid '44444444-4444-4444-4444-444444444444'
-        Write-TestNovaCliPublicFunction -ProjectRoot $projectRoot -FunctionName 'Invoke-TestCliPreviewBump'
-
-        $projectData = Get-Content -LiteralPath $projectJsonPath -Raw | ConvertFrom-Json
-        $projectData.Version = '0.0.1-rc1'
-        $projectData | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $projectJsonPath -Encoding utf8
-
-        try {
-            Initialize-TestNovaCliGitRepository -ProjectRoot $projectRoot -CommitMessage 'feat!: add prerelease cli bump coverage'
-
-            Install-NovaCli -DestinationDirectory $targetDirectory -Force | Out-Null
-
-            $previewBumpResult = Invoke-TestInstalledNovaCommand -InstalledPath $installedPath -WorkingDirectory $projectRoot -Arguments @('bump', '--preview', '--what-if')
-            $versionAfterBump = (Get-Content -LiteralPath $projectJsonPath -Raw | ConvertFrom-Json).Version
-
-            $previewBumpResult.ExitCode | Should -Be 0
-            $previewBumpResult.Text | Should -Match 'What if:'
-            $previewBumpResult.Text | Should -Match 'Version plan: 0\.0\.1-rc1 -> 0\.0\.1-rc2 \| Label: Major \| Commits: 1'
-            $previewBumpResult.Text | Should -Not -Match 'Unknown argument:'
-            $previewBumpResult.Text | Should -Not -Match 'Version bumped to :'
-            $versionAfterBump | Should -Be '0.0.1-rc1'
+    It 'Install-NovaCli handles preview and stable major-zero bump flows correctly' {
+        Assert-TestInstalledNovaCliBumpBehavior -DistModuleDir $script:distModuleDir -TestDriveRoot $TestDrive -TestCase @{
+            TargetDirectory = 'preview-bump-bin'
+            ProjectName = 'CliPreviewBumpProject'
+            ProjectGuid = '44444444-4444-4444-4444-444444444444'
+            FunctionName = 'Invoke-TestCliPreviewBump'
+            CurrentVersion = '0.0.1-rc1'
+            CommitMessage = 'feat!: add prerelease cli bump coverage'
+            Arguments = @('bump', '--preview', '--what-if')
+            ExpectedPatterns = @(
+                'What if:'
+                'Version plan: 0\.0\.1-rc1 -> 0\.0\.1-rc2 \| Label: Major \| Commits: 1'
+            )
+            UnexpectedPatterns = @(
+                'Unknown argument:'
+                'Version bumped to :'
+                'Major version zero \(0\.y\.z\) is for initial development'
+            )
+            ExpectedWarningCount = 0
+            ExpectedVersionAfterBump = '0.0.1-rc1'
         }
-        finally {
-            $env:PSModulePath = $originalModulePath
+
+        Assert-TestInstalledNovaCliBumpBehavior -DistModuleDir $script:distModuleDir -TestDriveRoot $TestDrive -TestCase @{
+            TargetDirectory = 'major-zero-bump-bin'
+            ProjectName = 'CliMajorZeroBumpProject'
+            ProjectGuid = '55555555-5555-5555-5555-555555555555'
+            FunctionName = 'Invoke-TestCliMajorZeroBump'
+            CurrentVersion = '0.1.0'
+            CommitMessage = 'feat!: add stable major zero bump coverage'
+            Arguments = @('bump', '--what-if')
+            ExpectedPatterns = @(
+                'What if:'
+                'Version plan: 0\.1\.0 -> 0\.2\.0 \| Label: Major \| Commits: 1'
+                'WARNING: Major version zero \(0\.y\.z\) is for initial development'
+                'Set 1\.0\.0 manually once the software is stable'
+            )
+            UnexpectedPatterns = @(
+                'Version bumped to :'
+            )
+            ExpectedWarningCount = 1
+            ExpectedVersionAfterBump = '0.1.0'
         }
-    }
 
-    It 'Install-NovaCli keeps stable major-zero breaking-change bumps on the 0.y.z line and prints guidance about 1.0.0' {
-        $targetDirectory = Join-Path $TestDrive 'major-zero-bump-bin'
-        $installedPath = Join-Path $targetDirectory 'nova'
-        $projectRoot = Join-Path $TestDrive 'CliMajorZeroBumpProject'
-        $projectJsonPath = Join-Path $projectRoot 'project.json'
-        $originalModulePath = $env:PSModulePath
-        $modulePathSeparator = [string][System.IO.Path]::PathSeparator
-        $distParent = Split-Path -Parent $script:distModuleDir
-
-        $env:PSModulePath = "$distParent$modulePathSeparator$originalModulePath"
-
-        Initialize-TestNovaCliProjectLayout -ProjectRoot $projectRoot
-        Write-TestNovaCliProjectJson -ProjectRoot $projectRoot -ProjectName 'CliMajorZeroBumpProject' -ProjectGuid '55555555-5555-5555-5555-555555555555'
-        Write-TestNovaCliPublicFunction -ProjectRoot $projectRoot -FunctionName 'Invoke-TestCliMajorZeroBump'
-
-        $projectData = Get-Content -LiteralPath $projectJsonPath -Raw | ConvertFrom-Json
-        $projectData.Version = '0.1.0'
-        $projectData | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $projectJsonPath -Encoding utf8
-
-        try {
-            Initialize-TestNovaCliGitRepository -ProjectRoot $projectRoot -CommitMessage 'feat!: add stable major zero bump coverage'
-
-            Install-NovaCli -DestinationDirectory $targetDirectory -Force | Out-Null
-
-            $bumpResult = Invoke-TestInstalledNovaCommand -InstalledPath $installedPath -WorkingDirectory $projectRoot -Arguments @('bump', '--what-if')
-            $versionAfterBump = (Get-Content -LiteralPath $projectJsonPath -Raw | ConvertFrom-Json).Version
-
-            $bumpResult.ExitCode | Should -Be 0
-            $bumpResult.Text | Should -Match 'What if:'
-            $bumpResult.Text | Should -Match 'Version plan: 0\.1\.0 -> 0\.2\.0 \| Label: Major \| Commits: 1'
-            $bumpResult.Text | Should -Match 'Major version zero \(0\.y\.z\) is for initial development'
-            $bumpResult.Text | Should -Match 'Set 1\.0\.0 manually once the software is stable'
-            ([regex]::Matches($bumpResult.Text, 'Major version zero \(0\.y\.z\) is for initial development')).Count | Should -Be 1
-            $bumpResult.Text | Should -Not -Match 'Version bumped to :'
-            $versionAfterBump | Should -Be '0.1.0'
-        }
-        finally {
-            $env:PSModulePath = $originalModulePath
+        Assert-TestInstalledNovaCliBumpBehavior -DistModuleDir $script:distModuleDir -TestDriveRoot $TestDrive -TestCase @{
+            TargetDirectory = 'major-zero-minor-bump-bin'
+            ProjectName = 'CliMajorZeroMinorBumpProject'
+            ProjectGuid = '56555555-5555-5555-5555-555555555555'
+            FunctionName = 'Invoke-TestCliMajorZeroMinorBump'
+            CurrentVersion = '0.0.1'
+            CommitMessage = 'feat: add stable minor major zero bump coverage'
+            Arguments = @('bump')
+            ExpectedPatterns = @(
+                'WARNING: Major version zero \(0\.y\.z\) is for initial development'
+                'Version bumped to : 0\.1\.0'
+                'Version bump completed: 0\.0\.1 -> 0\.1\.0 \| Label: Minor \| Commits: 1'
+            )
+            UnexpectedPatterns = @(
+                'What if:'
+            )
+            ExpectedWarningCount = 1
+            ExpectedVersionAfterBump = '0.1.0'
         }
     }
 

--- a/tests/NovaCommandModel.StandaloneCli.Tests.ps1
+++ b/tests/NovaCommandModel.StandaloneCli.Tests.ps1
@@ -343,6 +343,7 @@ Describe '$projectName tests' {
             $bumpResult.Text | Should -Match 'Version plan: 0\.1\.0 -> 0\.2\.0 \| Label: Major \| Commits: 1'
             $bumpResult.Text | Should -Match 'Major version zero \(0\.y\.z\) is for initial development'
             $bumpResult.Text | Should -Match 'Set 1\.0\.0 manually once the software is stable'
+            ([regex]::Matches($bumpResult.Text, 'Major version zero \(0\.y\.z\) is for initial development')).Count | Should -Be 1
             $bumpResult.Text | Should -Not -Match 'Version bumped to :'
             $versionAfterBump | Should -Be '0.1.0'
         }

--- a/tests/NovaCommandModel.TestSupport/Assertions.ps1
+++ b/tests/NovaCommandModel.TestSupport/Assertions.ps1
@@ -137,6 +137,84 @@ function Invoke-UpdateNovaModuleVersionDefaultPathAssertion {
     }
 }
 
+function Assert-TestNovaVersionUpdateWorkflowContextMajorZeroAdvisory {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ModuleName,
+        [Parameter(Mandatory)]$TestCase
+    )
+
+    InModuleScope $ModuleName -Parameters @{TestCase = $TestCase} {
+        param($TestCase)
+
+        Mock Get-NovaProjectInfo {
+            [pscustomobject]@{
+                ProjectName = 'NovaModuleTools'
+                Version = $TestCase.CurrentVersion
+                ProjectJSON = '/tmp/project.json'
+            }
+        }
+        Mock Get-GitCommitMessageForVersionBump {$TestCase.CommitMessages}
+        Mock Get-NovaVersionLabelForBump {$TestCase.Label}
+        Mock Get-NovaVersionUpdatePlan {
+            [pscustomobject]@{
+                NewVersion = [semver]$TestCase.PlannedVersion
+            }
+        }
+
+        $result = Get-NovaVersionUpdateWorkflowContext -ProjectRoot '/tmp/project'
+
+        $result.Label | Should -Be $TestCase.Label
+        $result.EffectiveLabel | Should -Be $TestCase.ExpectedEffectiveLabel
+        $result.NewVersion | Should -Be $TestCase.PlannedVersion
+        $result.AdvisoryMessage | Should -Match 'Major version zero \(0\.y\.z\) is for initial development'
+        $result.AdvisoryMessage | Should -Match 'Set 1\.0\.0 manually once the software is stable'
+        Assert-MockCalled Get-NovaVersionUpdatePlan -Times 1 -ParameterFilter {
+            $ProjectInfo.ProjectName -eq 'NovaModuleTools' -and
+                    $Label -eq $TestCase.ExpectedPlanLabel -and
+                    -not $PreviewRelease
+        }
+    }
+}
+
+function Assert-TestUpdateNovaModuleVersionMajorZeroWarning {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ModuleName,
+        [Parameter(Mandatory)]$TestCase
+    )
+
+    InModuleScope $ModuleName -Parameters @{TestCase = $TestCase} {
+        param($TestCase)
+
+        Mock Get-NovaVersionUpdateWorkflowContext {
+            [pscustomobject]@{
+                Target = 'project.json'
+                Action = "Update module version using $( $TestCase.Label ) release label"
+            }
+        }
+        Mock Invoke-NovaVersionUpdateWorkflow {
+            [pscustomobject]@{
+                PreviousVersion = $TestCase.PreviousVersion
+                NewVersion = $TestCase.NewVersion
+                Label = $TestCase.Label
+                EffectiveLabel = $TestCase.EffectiveLabel
+                AdvisoryMessage = 'Major version zero (0.y.z) is for initial development.'
+                CommitCount = 34
+                Applied = $false
+            }
+        }
+        Mock Write-Host {throw 'WhatIf should not emit host output'}
+        $warningMessages = $null
+
+        $result = Update-NovaModuleVersion -Path (Get-Location).Path -WhatIf -WarningVariable warningMessages
+
+        $result.NewVersion | Should -Be $TestCase.NewVersion
+                ($warningMessages -join ' ') | Should -Match 'Major version zero \(0\.y\.z\) is for initial development'
+        Assert-MockCalled Write-Host -Times 0
+    }
+}
+
 function Invoke-TestPublishWorkflowCiRestoreAssertion {
     [CmdletBinding()]
     param(

--- a/tests/NovaCommandModel.TestSupport/CliProjectSupport.ps1
+++ b/tests/NovaCommandModel.TestSupport/CliProjectSupport.ps1
@@ -142,6 +142,57 @@ function Get-TestNovaCliWhatIfResultMap {
     }
 }
 
+function Assert-TestInstalledNovaCliBumpBehavior {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$DistModuleDir,
+        [Parameter(Mandatory)][string]$TestDriveRoot,
+        [Parameter(Mandatory)]$TestCase
+    )
+
+    $targetDirectory = Join-Path $TestDriveRoot $TestCase.TargetDirectory
+    $installedPath = Join-Path $targetDirectory 'nova'
+    $projectRoot = Join-Path $TestDriveRoot $TestCase.ProjectName
+    $projectJsonPath = Join-Path $projectRoot 'project.json'
+    $originalModulePath = $env:PSModulePath
+    $modulePathSeparator = [string][System.IO.Path]::PathSeparator
+    $distParent = Split-Path -Parent $DistModuleDir
+
+    $env:PSModulePath = "$distParent$modulePathSeparator$originalModulePath"
+
+    Initialize-TestNovaCliProjectLayout -ProjectRoot $projectRoot
+    Write-TestNovaCliProjectJson -ProjectRoot $projectRoot -ProjectName $TestCase.ProjectName -ProjectGuid $TestCase.ProjectGuid
+    Write-TestNovaCliPublicFunction -ProjectRoot $projectRoot -FunctionName $TestCase.FunctionName
+
+    $projectData = Get-Content -LiteralPath $projectJsonPath -Raw | ConvertFrom-Json
+    $projectData.Version = $TestCase.CurrentVersion
+    $projectData | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $projectJsonPath -Encoding utf8
+
+    try {
+        Initialize-TestNovaCliGitRepository -ProjectRoot $projectRoot -CommitMessage $TestCase.CommitMessage
+
+        Install-NovaCli -DestinationDirectory $targetDirectory -Force | Out-Null
+
+        $bumpResult = Invoke-TestInstalledNovaCommand -InstalledPath $installedPath -WorkingDirectory $projectRoot -Arguments $TestCase.Arguments
+        $versionAfterBump = (Get-Content -LiteralPath $projectJsonPath -Raw | ConvertFrom-Json).Version
+
+        $bumpResult.ExitCode | Should -Be 0
+        foreach ($pattern in $TestCase.ExpectedPatterns) {
+            $bumpResult.Text | Should -Match $pattern
+        }
+
+        foreach ($pattern in $TestCase.UnexpectedPatterns) {
+            $bumpResult.Text | Should -Not -Match $pattern
+        }
+
+        ([regex]::Matches($bumpResult.Text, 'Major version zero \(0\.y\.z\) is for initial development')).Count | Should -Be $TestCase.ExpectedWarningCount
+        $versionAfterBump | Should -Be $TestCase.ExpectedVersionAfterBump
+    }
+    finally {
+        $env:PSModulePath = $originalModulePath
+    }
+}
+
 function Assert-TestNovaCliWhatIfResultMap {
     [CmdletBinding()]
     param(

--- a/tests/UpdateNotification.Tests.ps1
+++ b/tests/UpdateNotification.Tests.ps1
@@ -825,7 +825,7 @@ Continue with the prerelease update?
         $result.Warnings[0] | Should -Match 'newer NovaModuleTools release is available'
         $result.Warnings[0] | Should -Match 'Release notes: https://www\.novamoduletools\.com/release-notes\.html'
         $result.Warnings[0] | Should -Match 'Update-Module NovaModuleTools'
-        $result.Warnings[0] | Should -Match 'nova update'
+        $result.Warnings[0] | Should -Match '% nova update'
     }
 
     It 'Invoke-NovaBuildUpdateNotification warns about a newer prerelease only when prerelease notifications are enabled' {
@@ -838,9 +838,9 @@ Continue with the prerelease update?
         $result.Warnings[0] | Should -Match 'newer NovaModuleTools prerelease is available'
         $result.Warnings[0] | Should -Match 'Release notes: https://www\.novamoduletools\.com/release-notes\.html'
         $result.Warnings[0] | Should -Match 'Update-Module NovaModuleTools -AllowPrerelease'
-        $result.Warnings[0] | Should -Match 'nova update'
+        $result.Warnings[0] | Should -Match '% nova update'
         $result.Warnings[0] | Should -Match 'Set-NovaUpdateNotificationPreference -DisablePrereleaseNotifications'
-        $result.Warnings[0] | Should -Match 'nova notification --disable'
+        $result.Warnings[0] | Should -Match '% nova notification --disable'
     }
 
     It 'Write-NovaAvailableModuleUpdateWarning preserves host rendering so warning text can stay colored' {
@@ -873,7 +873,7 @@ Continue with the prerelease update?
                 ''
                 'Update:'
                 'PS> Update-Module NovaModuleTools'
-                'nova update'
+                '% nova update'
             )
         }
     }


### PR DESCRIPTION
## Summary

- Implement SemVer major-zero behavior for `Update-NovaModuleVersion` / `% nova bump` so stable `0.y.z` projects no longer auto-jump to `1.0.0` when commit history implies a breaking change.
- Stable major bumps on `0.y.z` now keep the detected `Major` label for reporting, plan the next minor version instead, and print guidance telling users to set `1.0.0` manually once the software is stable.
- Preserve existing `-Preview` behavior, surface the advisory in both direct PowerShell and CLI output, and document the rule across help and docs.
- Closes #146.

## Affected area

- [x] `nova` CLI or command routing
- [x] Public PowerShell cmdlet behavior
- [ ] Scaffolding or `project.json` handling
- [x] Build, test, analyzer, coverage, or CI helper flow
- [ ] Package, raw upload, or package metadata workflow
- [ ] Publish, release, semantic-release, or GitHub Actions automation
- [ ] Self-update or notification preference behavior
- [x] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
- [x] End-user docs (`docs/*.html`)
- [x] Command help (`docs/NovaModuleTools/en-US/*.md`)
- [ ] `src/resources/example/`
- [ ] Dependency or manifest changes (`package.json`, workflow dependencies, release tooling)
- [ ] Security-sensitive change
- [ ] Documentation-only change
- [ ] Other

## Review guidance

- Start with `src/private/release/GetNovaVersionUpdateWorkflowContext.ps1`, which now resolves an effective label for stable `0.y.z` major bumps and carries advisory metadata through the workflow context.
- Then review `src/private/release/InvokeNovaVersionUpdateWorkflow.ps1`, `src/private/release/WriteNovaVersionUpdateResultMessages.ps1`, and `src/public/UpdateNovaModuleVersion.ps1` to see how the effective label is applied during writes and how warnings are emitted for direct cmdlet usage.
- Review `src/private/cli/FormatNovaCliCommandResult.ps1` for the CLI-facing advisory output and `src/resources/cli/help/bump.psd1`, `docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md`, `docs/versioning-and-updates.html`, `docs/commands.html`, and `README.md` for the updated user guidance.
- Test coverage was added in `tests/NovaCommandModel.BumpAndCli.Tests.ps1`, `tests/CoverageGaps.ReleaseInternals.Tests.ps1`, `tests/CoverageGaps.Cli.Tests.ps1`, `tests/NovaCommandModel.StandaloneCli.Tests.ps1`, and the helper allowlist in `tests/ArchitectureGuardrails.Tests.ps1`.
- Trade-off: this is intentionally an additive policy layer on top of the existing version planner, so stable `0.y.z` bumps are remapped only at the workflow boundary while `-Preview` behavior remains unchanged.

## Validation

- [x] `Invoke-NovaBuild`
- [x] `Test-NovaBuild`
- [ ] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
- [x] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`,
  `% nova publish`,
  `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
- [ ] Docs/example only; executable validation not needed

Validation notes:

```text
Validated the feature through both targeted and broader repository runs.

- Invoke-NovaBuild
  - Rebuilt the dist module after the source/help changes.

- Targeted suites
  - Invoke-Pester -Path ./tests/NovaCommandModel.Tests.ps1 -CI
	- Tests Passed: 38, Failed: 0
  - Invoke-Pester -Path @(
	  ./tests/NovaCommandModel.BumpAndCli.Tests.ps1,
	  ./tests/CoverageGaps.ReleaseInternals.Tests.ps1,
	  ./tests/CoverageGaps.Cli.Tests.ps1,
	  ./tests/NovaCommandModel.StandaloneCli.Tests.ps1
	) -CI
	- Tests Passed: 231, Failed: 0
  - Invoke-Pester -Path @(
	  ./tests/ArchitectureGuardrails.Tests.ps1,
	  ./tests/BuildOptions.Tests.ps1
	) -CI
	- Tests Passed: 29, Failed: 0

- Full repository workflow
  - Import-Module ./dist/NovaModuleTools -Force; Test-NovaBuild
	- Tests Passed: 635, Failed: 0

- Code Health safeguard
  - pre_commit_code_health_safeguard passed after consolidating the new internal tests into a table-driven structure.

- Targeted nova bump workflow coverage
  - Standalone CLI tests validate stable `0.y.z` + breaking-change behavior and confirm that `--preview` remains unchanged.

I did not rerun ./scripts/build/Invoke-ScriptAnalyzerCI.ps1 or ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1 as standalone post-fix commands because the final state was already covered by the broader test/analyzer checks above.
```

## Documentation and release follow-up

- [x] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
- [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
- [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [x] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
- [x] `docs/*.html` updated if end-user workflows or examples changed
- [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
  changed
- [ ] No documentation, changelog, or example updates were needed

## Maintainability, compatibility, and risk

- [x] Code Health / maintainability impact considered
- [x] No breaking change
- [ ] Breaking change
- [ ] Security-sensitive change
- [ ] CI, workflow, or release-pipeline impact
- [ ] Dependency-review impact

Risk, rollout, or rollback notes:

```text
Compatibility impact is intentionally narrow:

- Stable breaking-change bumps on 0.y.z now plan the next minor version instead of 1.0.0.
- The detected release label remains Major in the result/output so the commit intent is still visible.
- Preview behavior is unchanged.

This is not a breaking API change for users of the bump command; it is a behavioral safeguard for initial-development versions.

Rollback is straightforward:
- Revert commit 26e338a01cc67b6faff3509404c54156bb6e6ad0 on feature/146-semver-major-zero-behavior-for-nova-bump.

Known limitation:
- The rule is enforced at the workflow/context layer rather than by rewriting the lower-level semver math, which keeps the change smaller and protects existing preview behavior.
```

> [!IMPORTANT]
> Do not use a public pull request to disclose a vulnerability before coordinated handling.
> Use the private reporting path in `SECURITY.md` for new security issues.

