### PR TITLE
Bug/149 bug nova build fails when docs contains non help markdown files

### DIFF
--- a/.github/prompts/markdown.promt.md
+++ b/.github/prompts/markdown.promt.md
@@ -3,5 +3,79 @@
 ## Purpose
 Force all output to be wrapped in a Markdown code block using the required format:
 
-~~~markdown
+~~~
 <content>
+~~~
+
+This is used when content must be copy-paste ready and consistently wrapped.
+
+---
+
+## Instructions
+
+When generating output:
+
+1. ALWAYS wrap the entire response in:
+
+~~~
+<content>
+~~~
+
+2. The first line MUST be exactly:~~~
+3. The last line MUST be exactly:~~~
+4. Inside the block:
+    - Write normal Markdown content
+    - Use triple backticks for any code examples
+    - Ensure proper indentation and formatting
+5. Do NOT:
+    - Add text before or after the wrapper
+    - Break the wrapper format
+    - Use alternative fencing styles
+
+---
+
+Inner code block rules
+
+When including code inside the Markdown:
+
+- Use triple backticks
+- Include language when relevant
+
+Example:
+
+```powershell
+PS> Invoke-NovaBuild
+```
+
+```zsh
+% nova build
+```
+
+---
+
+Output rules
+
+- Output ONLY the wrapped Markdown block
+- No explanations outside the block
+- No missing fences
+- No malformed structure
+
+---
+
+Example invocation
+
+Wrap the following content:
+
+* Explain how to run nova build
+* Include CLI and PowerShell examples
+
+---
+
+Expected behavior
+
+The output must:
+
+- Start with: ~~~
+- End with: ~~~
+- Contain valid Markdown inside
+- Be ready to copy directly without edits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `Invoke-NovaBuild` help discovery so it only scans `docs/<ProjectName>/` for PlatyPS markdown.
+    - Regular markdown elsewhere under `docs/` no longer breaks the help-generation step.
+    - When PlatyPS export does not create the expected help folder, Nova now raises a stable documentation error instead
+      of a raw rename-path failure.
+
 ### Security
 
 ## [2.1.0] - 2026-04-29

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,8 @@ Documentation ownership is intentionally split:
 
 - GitHub repository docs are for contributors and maintainers
 - GitHub Pages content under `docs/*.html` is for end users
-- command-help markdown under `docs/NovaModuleTools/en-US/` is build input, not general prose documentation
+- command-help markdown under `docs/<ProjectName>/` (for this repo `docs/NovaModuleTools/en-US/`) is build input
+- markdown elsewhere under `docs/` is allowed for non-help documentation because the build ignores it
 
 When updating documentation, write it for humans first. A reader should quickly understand:
 

--- a/README.md
+++ b/README.md
@@ -437,15 +437,18 @@ Test-NovaBuild
 
 ### Working on help and docs
 
-Command help markdown lives under `docs/NovaModuleTools/en-US/` and is consumed by `Invoke-NovaBuild`.
+Command help markdown lives under `docs/<ProjectName>/<Locale>/` and is consumed by `Invoke-NovaBuild`.
+
+In this repository, that means `docs/NovaModuleTools/en-US/`.
 
 Important distinction:
 
-- `docs/NovaModuleTools/en-US/*.md` → PlatyPS command-help source
+- `docs/<ProjectName>/**/*.md` → PlatyPS command-help source
 - `docs/*.html` → GitHub Pages end-user guides
 - `README.md` and `CONTRIBUTING.md` → contributor documentation
 
-Do not place general developer markdown under `docs/`, because the build scans `docs/**/*.md` when generating help.
+If you want build-generated PowerShell help, place it under `docs/<ProjectName>/`.
+Markdown elsewhere under `docs/` is ignored by help generation, so you can keep non-help docs there when needed.
 
 ## Repository structure and ownership
 
@@ -528,10 +531,10 @@ These are the top-level GitHub entry points for contributors and maintainers.
 This folder has two different responsibilities that must stay separated by file type:
 
 - `docs/*.html` → GitHub Pages end-user guides
-- `docs/NovaModuleTools/en-US/*.md` → PlatyPS command-help source
+- `docs/<ProjectName>/**/*.md` → PlatyPS command-help source for the current project
 
-The build treats markdown under `docs/` as help input, so general-purpose developer documentation should not be added
-there.
+The build only treats markdown under `docs/<ProjectName>/` as help input.
+Markdown elsewhere under `docs/` can be used for other documentation without affecting help generation.
 
 ### Scripts and automation
 
@@ -635,7 +638,7 @@ When you change CI, build, or release behavior:
 
 - Keep contributor workflow, architecture, and automation documentation in `README.md`
 - Keep `CONTRIBUTING.md` focused on contribution expectations and review checklist items
-- Keep `docs/NovaModuleTools/en-US/*.md` focused on command-help source material
+- Keep `docs/<ProjectName>/**/*.md` focused on command-help source material for the current project
 - Keep `docs/*.html` focused on end-user guides
 - Do not duplicate the same workflow or setup prose across multiple contributor documents
 

--- a/docs/NovaModuleTools/en-US/Invoke-NovaBuild.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaBuild.md
@@ -39,7 +39,7 @@ The command:
 2. generates the module `.psm1`
 3. validates duplicate top-level function names when enabled
 4. writes the module manifest
-5. builds external help from the Markdown files in `docs/`
+5. builds external help from the Markdown files under `docs/<ProjectName>/`
 6. copies project resources into the built module output
 
 To update the installed `NovaModuleTools` module itself, use `Update-NovaModuleTool` (alias:
@@ -147,7 +147,7 @@ This cmdlet does not emit an output object.
 
 ## NOTES
 
-Run this command from the project root so `project.json`, `src/`, `docs/`, and `tests/` resolve correctly.
+Run this command from the project root so `project.json`, `src/`, `docs/<ProjectName>/`, and `tests/` resolve correctly.
 
 `Invoke-NovaBuild` uses `SupportsShouldProcess`, so `Get-Help Invoke-NovaBuild -Full` shows the native `-WhatIf` and
 `-Confirm` behavior.

--- a/src/private/build/BuildHelp.ps1
+++ b/src/private/build/BuildHelp.ps1
@@ -6,28 +6,102 @@ function Build-Help {
     Write-Verbose 'Running Help update'
 
     $data = Get-NovaBuildProjectInfo -ProjectInfo $ProjectInfo
-    $helpMarkdownFiles = Get-ChildItem -Path $data.DocsDir -Filter '*.md' -Recurse
+    $helpMarkdownFiles = @(Get-NovaHelpMarkdownItem -BuildProjectInfo $data)
 
     if (-not $helpMarkdownFiles) {
-        Write-Verbose 'No help markdown files in docs directory, skipping building help' 
         return
     }
-    
+
+    Assert-NovaPlatyPSAvailable
+
+    $helpContext = Get-NovaHelpBuildContext -BuildProjectInfo $data -HelpMarkdownFiles $helpMarkdownFiles
+    if (-not $helpContext) {
+        return
+    }
+
+    Export-NovaGeneratedHelp -BuildProjectInfo $data -HelpContext $helpContext
+}
+
+function Get-NovaHelpMarkdownItem {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$BuildProjectInfo
+    )
+
+    $helpDocsDir = Get-NovaHelpDocsDir -BuildProjectInfo $BuildProjectInfo
+    $helpMarkdownFiles = @(Get-ChildItem -LiteralPath $helpDocsDir -Filter '*.md' -File -Recurse -ErrorAction SilentlyContinue)
+    if (-not $helpMarkdownFiles) {
+        Write-Verbose "No help markdown files in $helpDocsDir, skipping building help"
+    }
+
+    return $helpMarkdownFiles
+}
+
+function Get-NovaHelpBuildContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$BuildProjectInfo,
+        [Parameter(Mandatory)][System.IO.FileInfo[]]$HelpMarkdownFiles
+    )
+
+    $commandHelpFiles = @($HelpMarkdownFiles | Measure-PlatyPSMarkdown | Where-Object FileType -Match CommandHelp)
+    if (-not $commandHelpFiles) {
+        Write-Verbose "No PlatyPS command help markdown files found in $( Get-NovaHelpDocsDir -BuildProjectInfo $BuildProjectInfo ), skipping building help"
+        return $null
+    }
+
+    return [pscustomobject]@{
+        HelpMarkdownFiles = $HelpMarkdownFiles
+        CommandHelpFiles = $commandHelpFiles
+        Locale = Get-NovaHelpLocale -HelpMarkdownFiles $HelpMarkdownFiles
+    }
+}
+
+function Export-NovaGeneratedHelp {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$BuildProjectInfo,
+        [Parameter(Mandatory)][pscustomobject]$HelpContext
+    )
+
+    $HelpContext.CommandHelpFiles | Import-MarkdownCommandHelp -Path {$_.FilePath} |
+            Export-MamlCommandHelp -OutputFolder $BuildProjectInfo.OutputModuleDir | Out-Null
+
+    Rename-NovaGeneratedHelpFolder -BuildProjectInfo $BuildProjectInfo -Locale $HelpContext.Locale
+}
+
+function Rename-NovaGeneratedHelpFolder {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$BuildProjectInfo,
+        [Parameter(Mandatory)][string]$Locale
+    )
+
+    $helpDirOld = Join-Path $BuildProjectInfo.OutputModuleDir $BuildProjectInfo.ProjectName
+    if (-not (Test-Path -LiteralPath $helpDirOld)) {
+        $helpDocsDir = Get-NovaHelpDocsDir -BuildProjectInfo $BuildProjectInfo
+        Stop-NovaOperation -Message "Expected generated help directory was not created: $helpDirOld. Verify that the Markdown files under '$helpDocsDir' are valid PlatyPS command help." -ErrorId 'Nova.Environment.GeneratedHelpDirectoryNotFound' -Category ObjectNotFound -TargetObject $helpDirOld
+    }
+
+    $helpDirNew = Join-Path $BuildProjectInfo.OutputModuleDir $Locale
+    Write-Verbose "Renamed folder to locale: $Locale"
+    Rename-Item -Path $helpDirOld -NewName $helpDirNew
+}
+
+function Get-NovaHelpDocsDir {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$BuildProjectInfo
+    )
+
+    return [System.IO.Path]::Join($BuildProjectInfo.DocsDir, $BuildProjectInfo.ProjectName)
+}
+
+function Assert-NovaPlatyPSAvailable {
+    [CmdletBinding()]
+    param()
+
     if (-not (Get-Module -Name Microsoft.PowerShell.PlatyPS -ListAvailable)) {
         Stop-NovaOperation -Message 'The module Microsoft.PowerShell.PlatyPS must be installed for Markdown documentation to be generated.' -ErrorId 'Nova.Dependency.BuildHelpDependencyMissing' -Category ResourceUnavailable -TargetObject 'Microsoft.PowerShell.PlatyPS'
     }
-
-    $AllCommandHelpFiles = $helpMarkdownFiles | Measure-PlatyPSMarkdown | Where-Object FileType -Match CommandHelp
-
-    # Export to Dist folder    
-    $AllCommandHelpFiles | Import-MarkdownCommandHelp -Path { $_.FilePath } |
-    Export-MamlCommandHelp -OutputFolder $data.OutputModuleDir | Out-Null
-
-    # Rename the directory to match locale
-    $HelpDirOld = Join-Path $data.OutputModuleDir $Data.ProjectName
-    $languageLocale = Get-NovaHelpLocale -HelpMarkdownFiles $helpMarkdownFiles
-    $HelpDirNew = Join-Path $data.OutputModuleDir $languageLocale
-    Write-Verbose "Renamed folder to locale: $languageLocale"
-
-    Rename-Item -Path $HelpDirOld -NewName $HelpDirNew
 }

--- a/tests/CoverageGaps.BuildInternals.Tests.ps1
+++ b/tests/CoverageGaps.BuildInternals.Tests.ps1
@@ -167,7 +167,7 @@ Describe 'Coverage gaps for build and duplicate-analysis internals' {
         }
     }
 
-    It 'Build-Help only searches for help markdown under docs/<ProjectName>' {
+    It 'Build-Help only searches for help markdown under the project help docs folder' {
         InModuleScope $script:moduleName {
             Mock Get-NovaBuildProjectInfo {[pscustomobject]@{DocsDir = '/tmp/docs'; ProjectName = 'NovaModuleTools'}}
             Mock Get-ChildItem {@()}

--- a/tests/CoverageGaps.BuildInternals.Tests.ps1
+++ b/tests/CoverageGaps.BuildInternals.Tests.ps1
@@ -167,22 +167,23 @@ Describe 'Coverage gaps for build and duplicate-analysis internals' {
         }
     }
 
-    It 'Build-Help skips when no markdown files exist' {
+    It 'Build-Help only searches for help markdown under docs/<ProjectName>' {
         InModuleScope $script:moduleName {
-            Mock Get-NovaBuildProjectInfo {[pscustomobject]@{DocsDir = '/tmp/docs'}}
+            Mock Get-NovaBuildProjectInfo {[pscustomobject]@{DocsDir = '/tmp/docs'; ProjectName = 'NovaModuleTools'}}
             Mock Get-ChildItem {@()}
             Mock Get-Module {}
 
             Build-Help
 
+            Assert-MockCalled Get-ChildItem -Times 1 -ParameterFilter {$LiteralPath -eq '/tmp/docs/NovaModuleTools'}
             Assert-MockCalled Get-Module -Times 0
         }
     }
 
     It 'Build-Help throws when PlatyPS is unavailable and docs exist' {
         InModuleScope $script:moduleName {
-            Mock Get-NovaBuildProjectInfo {[pscustomobject]@{DocsDir = '/tmp/docs'}}
-            Mock Get-ChildItem {@([pscustomobject]@{FullName = '/tmp/docs/Invoke-NovaBuild.md'})}
+            Mock Get-NovaBuildProjectInfo {[pscustomobject]@{DocsDir = '/tmp/docs'; ProjectName = 'NovaModuleTools'}}
+            Mock Get-ChildItem {@([pscustomobject]@{FullName = '/tmp/docs/NovaModuleTools/Invoke-NovaBuild.md'})}
             Mock Get-Module {$null}
 
             $thrown = $null
@@ -202,7 +203,8 @@ Describe 'Coverage gaps for build and duplicate-analysis internals' {
 
     It 'Build-Help imports markdown help and renames the generated locale folder' {
         InModuleScope $script:moduleName {
-            $docPath = Join-Path $TestDrive 'Invoke-NovaBuild.md'
+            $docPath = Join-Path $TestDrive 'NovaModuleTools/en-US/Invoke-NovaBuild.md'
+            New-Item -ItemType Directory -Path (Split-Path -Parent $docPath) -Force | Out-Null
             Set-Content -LiteralPath $docPath -Value "---`nLocale: da-DK`n---"
 
             Mock Get-NovaBuildProjectInfo {
@@ -216,6 +218,7 @@ Describe 'Coverage gaps for build and duplicate-analysis internals' {
             Mock Get-Module {[pscustomobject]@{Name = 'Microsoft.PowerShell.PlatyPS'}}
             Mock Measure-PlatyPSMarkdown {[pscustomobject]@{FileType = 'CommandHelp'; FilePath = '/tmp/docs/Invoke-NovaBuild.md'}}
             Mock Get-NovaHelpLocale {'da-DK'}
+            Mock Test-Path {$true} -ParameterFilter {$LiteralPath -eq '/tmp/dist/NovaModuleTools'}
             Mock Rename-Item {}
 
             $script:buildHelpExportOutputFolder = $null
@@ -256,7 +259,115 @@ Describe 'Coverage gaps for build and duplicate-analysis internals' {
             }
 
             $script:buildHelpExportOutputFolder | Should -Be '/tmp/dist'
+            Assert-MockCalled Get-ChildItem -Times 1 -ParameterFilter {$LiteralPath -eq '/tmp/docs/NovaModuleTools'}
             Assert-MockCalled Rename-Item -Times 1 -ParameterFilter {$Path -eq '/tmp/dist/NovaModuleTools' -and $NewName -eq '/tmp/dist/da-DK'}
+        }
+    }
+
+    It 'Build-Help skips when scoped markdown files are not PlatyPS command help' {
+        InModuleScope $script:moduleName {
+            $docPath = Join-Path $TestDrive 'NovaModuleTools/notes.md'
+            New-Item -ItemType Directory -Path (Split-Path -Parent $docPath) -Force | Out-Null
+            Set-Content -LiteralPath $docPath -Value '# Notes'
+
+            Mock Get-NovaBuildProjectInfo {
+                [pscustomobject]@{
+                    DocsDir = '/tmp/docs'
+                    ProjectName = 'NovaModuleTools'
+                }
+            }
+            Mock Get-ChildItem {@(Get-Item -LiteralPath $docPath)}
+            Mock Get-Module {[pscustomobject]@{Name = 'Microsoft.PowerShell.PlatyPS'}}
+            Mock Measure-PlatyPSMarkdown {[pscustomobject]@{FileType = 'Other'; FilePath = $docPath}}
+            Mock Get-NovaHelpLocale {throw 'should not resolve locale without command help'}
+            Mock Test-Path {throw 'should not inspect output without command help'}
+            Mock Rename-Item {throw 'should not rename without command help'}
+
+            function Import-MarkdownCommandHelp {
+                throw 'should not import without command help'
+            }
+            function Export-MamlCommandHelp {
+                throw 'should not export without command help'
+            }
+
+            try {
+                {Build-Help} | Should -Not -Throw
+                Assert-MockCalled Get-NovaHelpLocale -Times 0
+                Assert-MockCalled Rename-Item -Times 0
+            }
+            finally {
+                Remove-Item function:Import-MarkdownCommandHelp -ErrorAction SilentlyContinue
+                Remove-Item function:Export-MamlCommandHelp -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    It 'Build-Help throws a stable error when PlatyPS export does not create the expected help folder' {
+        InModuleScope $script:moduleName {
+            $docPath = Join-Path $TestDrive 'NovaModuleTools/en-US/Invoke-NovaBuild.md'
+            New-Item -ItemType Directory -Path (Split-Path -Parent $docPath) -Force | Out-Null
+            Set-Content -LiteralPath $docPath -Value "---`nLocale: en-US`n---"
+
+            Mock Get-NovaBuildProjectInfo {
+                [pscustomobject]@{
+                    DocsDir = '/tmp/docs'
+                    OutputModuleDir = '/tmp/dist'
+                    ProjectName = 'NovaModuleTools'
+                }
+            }
+            Mock Get-ChildItem {@(Get-Item -LiteralPath $docPath)}
+            Mock Get-Module {[pscustomobject]@{Name = 'Microsoft.PowerShell.PlatyPS'}}
+            Mock Measure-PlatyPSMarkdown {[pscustomobject]@{FileType = 'CommandHelp'; FilePath = $docPath}}
+            Mock Get-NovaHelpLocale {'en-US'}
+            Mock Test-Path {$false} -ParameterFilter {$LiteralPath -eq '/tmp/dist/NovaModuleTools'}
+            Mock Rename-Item {throw 'should not rename missing output folder'}
+
+            function Import-MarkdownCommandHelp {
+                [CmdletBinding()]
+                param(
+                    [Parameter(ValueFromPipeline)]
+                    [object]$InputObject,
+
+                    [object]$Path
+                )
+
+                process {
+                    [pscustomobject]@{Name = 'Invoke-NovaBuild'}
+                }
+            }
+
+            function Export-MamlCommandHelp {
+                [CmdletBinding()]
+                param(
+                    [Parameter(ValueFromPipeline)]
+                    [object]$InputObject,
+
+                    [string]$OutputFolder
+                )
+
+                process {
+                }
+            }
+
+            try {
+                $thrown = $null
+                try {
+                    Build-Help
+                }
+                catch {
+                    $thrown = $_
+                }
+
+                $thrown.Exception.Message | Should -BeLike 'Expected generated help directory was not created:*'
+                $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Environment.GeneratedHelpDirectoryNotFound'
+                $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::ObjectNotFound)
+                $thrown.TargetObject | Should -Be '/tmp/dist/NovaModuleTools'
+                Assert-MockCalled Rename-Item -Times 0
+            }
+            finally {
+                Remove-Item function:Import-MarkdownCommandHelp -ErrorAction SilentlyContinue
+                Remove-Item function:Export-MamlCommandHelp -ErrorAction SilentlyContinue
+            }
         }
     }
 

--- a/tests/NovaCommandModel.TestSupport/TextAndHelp.ps1
+++ b/tests/NovaCommandModel.TestSupport/TextAndHelp.ps1
@@ -84,10 +84,10 @@ function Get-CommandHelpActivationTestCase {
 function Get-CommandHelpActivationTestCases {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][string]$DocsDir
+        [Parameter(Mandatory)][string]$HelpDocsDir
     )
 
-    $helpMarkdownFiles = Get-ChildItem -LiteralPath $DocsDir -Filter '*.md' -Recurse
+    $helpMarkdownFiles = Get-ChildItem -LiteralPath $HelpDocsDir -Filter '*.md' -File -Recurse -ErrorAction SilentlyContinue
     return @(
     $helpMarkdownFiles |
             ForEach-Object {Get-CommandHelpActivationTestCase -File $_} |

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -42,10 +42,11 @@ BeforeAll {
     }
 
     $helpMetadata = & {
-        $helpMarkdownFiles = Get-ChildItem -LiteralPath $script:projectInfo.DocsDir -Filter '*.md' -Recurse
+        $script:helpDocsDir = [System.IO.Path]::Join($script:projectInfo.DocsDir, $script:moduleName)
+        $helpMarkdownFiles = Get-ChildItem -LiteralPath $script:helpDocsDir -Filter '*.md' -File -Recurse
         [pscustomobject]@{
             HelpLocale = Get-TestHelpLocaleFromMarkdownFiles -Files $helpMarkdownFiles
-            HelpActivationTestCases = Get-CommandHelpActivationTestCases -DocsDir $script:projectInfo.DocsDir
+            HelpActivationTestCases = Get-CommandHelpActivationTestCases -HelpDocsDir $script:helpDocsDir
         }
     }
 
@@ -465,7 +466,7 @@ Describe 'Nova command model - project, help, and build behavior' {
     }
 
     It 'PowerShell help markdown stays free of launcher syntax and GNU-style options' {
-        $helpMarkdownFiles = Get-ChildItem -LiteralPath $script:projectInfo.DocsDir -Filter '*.md' -Recurse
+        $helpMarkdownFiles = Get-ChildItem -LiteralPath $script:helpDocsDir -Filter '*.md' -File -Recurse
 
         foreach ($file in $helpMarkdownFiles) {
             $content = Get-Content -LiteralPath $file.FullName -Raw


### PR DESCRIPTION
## Summary

- Scope build-help discovery to `docs/<ProjectName>/` so regular markdown elsewhere under `docs/` no longer gets treated as PlatyPS input.
- Make `Build-Help` skip cleanly when the scoped folder contains no PlatyPS command-help markdown and surface a stable Nova error if PlatyPS export does not create the expected help output folder.
- Update regression tests, contributor docs, command help, and the changelog to reflect the new help-folder boundary.
- No issue number was provided, but this addresses the reported `nova build` failure caused by non-help markdown under `docs/`.

## Affected area

- [x] `nova` CLI or command routing
- [x] Public PowerShell cmdlet behavior
- [ ] Scaffolding or `project.json` handling
- [x] Build, test, analyzer, coverage, or CI helper flow
- [ ] Package, raw upload, or package metadata workflow
- [ ] Publish, release, semantic-release, or GitHub Actions automation
- [ ] Self-update or notification preference behavior
- [x] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
- [ ] End-user docs (`docs/*.html`)
- [x] Command help (`docs/NovaModuleTools/en-US/*.md`)
- [ ] `src/resources/example/`
- [ ] Dependency or manifest changes (`package.json`, workflow dependencies, release tooling)
- [ ] Security-sensitive change
- [ ] Documentation-only change
- [ ] Other

## Review guidance

- Start with `src/private/build/BuildHelp.ps1`.
  - `Get-NovaHelpDocsDir` now scopes discovery to `docs/<ProjectName>/`.
  - `Get-NovaHelpBuildContext` now skips non-command markdown safely.
  - `Rename-NovaGeneratedHelpFolder` now throws a stable Nova error instead of leaking a raw rename-path failure.
- Then review the regression coverage in `tests/CoverageGaps.BuildInternals.Tests.ps1`, `tests/NovaCommandModel.TestSupport/TextAndHelp.ps1`, and `tests/NovaCommandModel.Tests.ps1`.
- Finally review the documentation alignment in `README.md`, `CONTRIBUTING.md`, `docs/NovaModuleTools/en-US/Invoke-NovaBuild.md`, and `CHANGELOG.md`.
- Trade-off: Nova now deliberately ignores markdown outside `docs/<ProjectName>/` during help generation so projects can keep other docs under `docs/` without affecting the build.

## Validation

- [x] `Invoke-NovaBuild`
- [x] `Test-NovaBuild`
- [x] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
- [ ] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`,
  `% nova publish`,
  `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
- [ ] Docs/example only; executable validation not needed

Validation notes:

```text
- Rebuilt the module with Invoke-NovaBuild after the Build-Help changes.
- Ran focused regression suites:
  pwsh -NoLogo -NoProfile -Command 'Import-Module ./dist/NovaModuleTools -Force; Invoke-Pester ./tests/CoverageGaps.BuildInternals.Tests.ps1,./tests/NovaCommandModel.Tests.ps1 -CI'
  Result: 62 tests passed, 0 failed.
- Reproduced the reported scenario by creating docs/specs/01-iteration-1-scope.md and running Invoke-NovaBuild; build completed successfully.
- Ran the full repository test workflow with Test-NovaBuild.
- Ran ./scripts/build/Invoke-ScriptAnalyzerCI.ps1; result: PSScriptAnalyzer: no findings.
- Code Health checks run for the touched code: BuildHelp.ps1 remained at 10.0 and the pre-commit safeguard passed.
- Branch-level analyze_change_set against main still reports pre-existing degradations in unrelated test files outside this change.
- ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1 and the launcher form % nova build were not run separately.
```

## Documentation and release follow-up

- [x] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
- [x] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
- [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [x] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
- [ ] `docs/*.html` updated if end-user workflows or examples changed
- [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
- [ ] No documentation, changelog, or example updates were needed

## Maintainability, compatibility, and risk

- [x] Code Health / maintainability impact considered
- [x] No breaking change
- [ ] Breaking change
- [ ] Security-sensitive change
- [x] CI, workflow, or release-pipeline impact
- [ ] Dependency-review impact

Risk, rollout, or rollback notes:

```text
Compatibility impact is low and intended: help generation now only considers docs/<ProjectName>/ as the PlatyPS source root.

Projects that previously relied on markdown directly under docs/ for help input must move those files under docs/<ProjectName>/.
That is the new documented contract and matches the repository's existing help layout.

Rollback is straightforward: revert the Build-Help scoping change and the related tests/docs if maintainers want to restore the old docs/**/*.md behavior.
```
