### PR TITLE
#157 fix: add CodeScene PR coverage gates

### DIFF
--- a/.github/actions/check-coverage/action.yml
+++ b/.github/actions/check-coverage/action.yml
@@ -1,0 +1,34 @@
+name: Check Coverage
+description: Run CodeScene coverage gates against uploaded coverage artifacts.
+
+inputs:
+  access-token:
+    description: CodeScene REST API access token.
+    required: true
+  project-url:
+    description: Full CodeScene project API URL, for example https://codescene.io/v2/projects/12345.
+    required: true
+  coverage-files:
+    description: Glob pattern matching coverage reports to check.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download cs-coverage binary
+      shell: bash
+      run: |
+        set -euo pipefail
+        curl -fsSL -o "$(pwd)/cs-coverage.zip" https://downloads.codescene.io/enterprise/cli/cs-coverage-linux-amd64-latest.zip
+        unzip -oq "$(pwd)/cs-coverage.zip"
+        chmod +x "$(pwd)/cs-coverage"
+
+    - name: Run CodeScene coverage gate check
+      shell: bash
+      env:
+        CS_PROJECT_URL: ${{ inputs.project-url }}
+        CS_ACCESS_TOKEN: ${{ inputs.access-token }}
+      run: |
+        set -euo pipefail
+        find "$(pwd)" -name '*.cobertura.xml' -print
+        "$(pwd)/cs-coverage" check --verbose --coverage-files "${{ inputs.coverage-files }}"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -92,6 +92,30 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  codescene-coverage-gates:
+    runs-on: ubuntu-latest
+    needs:
+      - test-and-coverage
+    if: ${{ needs.test-and-coverage.result == 'success' && github.event_name == 'pull_request' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download CI artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: nova-ci-artifacts
+          path: coverage/
+
+      - name: Check coverage gates in CodeScene
+        uses: ./.github/actions/check-coverage
+        with:
+          access-token: ${{ secrets.CS_ACCESS_TOKEN }}
+          project-url: ${{ format('{0}/v2/projects/{1}', vars.CS_URL, vars.CS_PROJECT_ID) }}
+          coverage-files: '**/pester-coverage.cobertura.xml'
+
   codescene-analysis:
     runs-on: ubuntu-latest
     needs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,8 @@ Before making larger changes, read the contributor docs in:
 GitHub now prefills pull requests with `.github/pull_request_template.md`.
 Use it to explain intent clearly, record what you validated, and call out any required documentation or changelog work.
 
+Pull requests against `main` and `develop` also run a CodeScene coverage-gate check when CI has produced the Cobertura coverage artifact, so PRs can be blocked when changed code falls below the configured coverage threshold.
+
 **Before opening a pull request, please run the local quality flow from the repository root:**
 
 ```powershell title="run.ps1"
@@ -55,6 +57,7 @@ If you are working on the CodeScene integration, the CI coverage helper writes t
 CodeScene upload step consumes:
 
 - generate coverage with `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
+- pull requests then download that uploaded artifact and run the CodeScene coverage-gate check through `.github/actions/check-coverage`
 - then upload/trigger with `./scripts/build/ci/Invoke-CodeSceneAnalysis.ps1 -UploadCoverage -TriggerAnalysis`
 - the upload helper auto-discovers a single `artifacts/*.cobertura.xml` file unless you pass `-CoveragePath`
 - if upload succeeds but `-TriggerAnalysis` fails with a project-owner OAuth error, re-authorize the repository in

--- a/README.md
+++ b/README.md
@@ -423,9 +423,11 @@ workflow configuration, and emits CI-friendly reports such as:
 - `artifacts/pester-coverage.cobertura.xml`
 - `artifacts/coverage-low.txt`
 
-The `Tests.yml` workflow reuses that Cobertura artifact for both Codecov and CodeScene.
-The CodeScene step uploads coverage through `scripts/build/ci/Invoke-CodeSceneAnalysis.ps1` before it triggers a
-follow-up analysis run.
+The `Tests.yml` workflow reuses that Cobertura artifact for Codecov, for the pull-request CodeScene coverage-gate check,
+and for the develop/manual CodeScene upload-and-analysis flow.
+The CodeScene pull-request gate downloads the uploaded artifact and runs `cs-coverage check`, while the develop/manual
+CodeScene step uploads coverage through `scripts/build/ci/Invoke-CodeSceneAnalysis.ps1` before it triggers a follow-up
+analysis run.
 If coverage upload succeeds but the trigger fails with an OAuth/project-owner error, fix the repository authorization in
 CodeScene for the project owner. That trigger-side repository authorization is separate from `CS_ACCESS_TOKEN`.
 
@@ -572,6 +574,8 @@ When CodeScene coverage upload is needed, run
 `scripts/build/ci/Invoke-CodeSceneAnalysis.ps1 -UploadCoverage -TriggerAnalysis`.
 That script auto-discovers a single `*.cobertura.xml` file under `artifacts/` unless you pass `-CoveragePath`
 explicitly.
+The repository `Tests.yml` workflow now also downloads that same Cobertura artifact during pull requests and runs the
+CodeScene coverage-gate check before merge.
 If `-TriggerAnalysis` fails after a successful upload, review the CodeScene response body: repository OAuth problems for
 the project owner must be fixed in CodeScene itself and are not solved by rotating `CS_ACCESS_TOKEN` alone.
 
@@ -589,8 +593,7 @@ published module from the local install directory into the current PowerShell se
 step depends on the built-but-unpublished output instead.
 
 The CI helper flow also produces JUnit and Cobertura artifacts for external systems, including the coverage file that
-the
-CodeScene workflow upload step consumes.
+the CodeScene workflow gate and upload steps consume.
 
 ### Release automation
 


### PR DESCRIPTION
 - add a reusable check-coverage action for cs-coverage check
 - run CodeScene coverage gates on pull requests in Tests.yml
 - keep the existing develop/manual CodeScene analysis flow
 - document the new PR gate behavior in the contributor docs and changelog

Summary

 - Add CodeScene pull-request coverage gates to NovaModuleTools by reusing the existing Cobertura artifact flow from Tests.yml.
 - This was needed because the repository already generated and uploaded CodeScene-compatible coverage, but it did not yet run the PR-time cs-coverage check that posts/enforces the coverage gate status in pull requests.
 - Closes #157.

Affected area

 - [ ]  nova CLI or command routing
 - [ ]  Public PowerShell cmdlet behavior
 - [ ]  Scaffolding or project.json handling
 - [X]  Build, test, analyzer, coverage, or CI helper flow
 - [ ]  Package, raw upload, or package metadata workflow
 - [X]  Publish, release, or GitHub Actions automation
 - [ ]  Self-update or notification preference behavior
 - [X]  Contributor documentation (README.md, CONTRIBUTING.md, repository workflow docs)
 - [ ]  End-user docs (docs/*.html)
 - [ ]  Command help (docs/NovaModuleTools/en-US/*.md)
 - [ ]  src/resources/example/
 - [ ]  Dependency or manifest changes (project.json, workflow dependencies, release tooling)
 - [ ]  Security-sensitive change
 - [ ]  Documentation-only change
 - [ ]  Other

Review guidance

 - Start with .github/workflows/Tests.yml, especially the new codescene-coverage-gates job and how it reuses the nova-ci-artifacts upload from test-and-coverage.
 - Then review .github/actions/check-coverage/action.yml, which mirrors the working KeepAChangelog pattern and encapsulates the cs-coverage check invocation.
 - Documentation follow-up is limited to README.md and CONTRIBUTING.md so maintainers understand the split between PR coverage gates and the existing develop/manual codescene-analysis upload flow.
 - Follow-up outside the repo is still required: CodeScene coverage gates must be enabled in the CodeScene project configuration for project 78904.

Validation

 - [X]  Invoke-NovaBuild
 - [X]  Test-NovaBuild
 - [ ]  ./scripts/build/Invoke-ScriptAnalyzerCI.ps1
 - [X]  ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1
 - [ ]  Targeted Nova workflow validated (% nova build, % nova test, % nova merge, % nova deploy, % nova publish,
 % nova release, % nova update, % nova notification, or % nova init as relevant)
 - [ ]  Docs/example only; executable validation not needed

Validation notes:

 - Ran ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1 -OutputDirectory ./artifacts/codescene-baseline successfully.
 - That CI helper flow includes Invoke-NovaBuild and Test-NovaBuild and produced the Cobertura artifact used by the new PR gate.
 - Validated .github/workflows/Tests.yml and .github/actions/check-coverage/action.yml with Ruby YAML parsing.
 - Ran CodeScene pre-commit safeguard on the NovaModuleTools repo; quality gates passed.
 - No CLI/cmdlet behavior changed, so no targeted nova command validation was needed for this PR.

Documentation and release follow-up

 - [X]  README.md reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
 - [X]  CONTRIBUTING.md reviewed and updated if contribution expectations or review guidance changed
 - [ ]  CHANGELOG.md reviewed and updated if the change matters to users, maintainers, or contributors
 - [ ]  docs/NovaModuleTools/en-US/ help updated if a public command or CLI behavior changed
 - [ ]  docs/*.html updated if end-user workflows or examples changed
 - [ ]  src/resources/example/ reviewed and updated if the real-world project layout, package model, or upload workflow
 changed
 - [ ]  No documentation, changelog, or example updates were needed

Maintainability, compatibility, and risk

 - [X]  Code Health / maintainability impact considered
 - [X]  No breaking change
 - [ ]  Breaking change
 - [ ]  Security-sensitive change
 - [X]  CI, workflow, or release-pipeline impact
 - [ ]  Dependency-review impact

Risk, rollout, or rollback notes:

 This change affects pull-request CI behavior only: PRs will gain a new CodeScene coverage-gate status check once the
 repository CodeScene project has coverage gates enabled. The existing develop/manual codescene-analysis job remains in
 place, so rollback is straightforward: remove the new PR gate job and reusable action if needed.
 
 Operational dependency: CS_URL, CS_PROJECT_ID, and CS_ACCESS_TOKEN must already be configured in GitHub, and CodeScene
 project 78904 must have Code Coverage Gates enabled for the PR status check to become meaningful.

 [!IMPORTANT] Do not use a public pull request to disclose a vulnerability before coordinated handling. Use the private reporting path in SECURITY.md for new security issues.