### PR TITLE
fix(#148): improve interactive validation for nova init prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ Keep stable `Update-NovaModuleVersion` / `% nova bump` releases on the SemVer ma
 - Fix the repository `run.ps1` quality loop after the CI installer refactor introduced new ScriptAnalyzer warnings.
     - The internal CI installer helper now follows ScriptAnalyzer naming and `ShouldProcess` expectations.
     - `run.ps1` no longer stops in the analyzer step because of those helper warnings.
+- Fix interactive `nova init` / `nova init -e` scaffold validation so invalid answers retry immediately at the prompt.
+    - Invalid module names now show the validation message inline instead of failing after the full questionnaire.
+    - Standard and example scaffold flows now share the same retry-first validation behavior through the common prompt
+      path.
 
 ### Security
 

--- a/docs/NovaModuleTools/en-US/Initialize-NovaModule.md
+++ b/docs/NovaModuleTools/en-US/Initialize-NovaModule.md
@@ -30,6 +30,9 @@ PS> Initialize-NovaModule [-Path <string>] [-Example] [-WhatIf] [-Confirm] [<Com
 The command collects project details interactively, including the module name, description, version, author, minimum
 PowerShell version, Git initialization, and, for the standard scaffold, optional basic Pester support.
 
+If you enter an invalid answer during the interactive flow, `Initialize-NovaModule` reports the validation problem
+immediately and retries that prompt before it continues to the next question.
+
 Use this command when you want to start a new module in the NovaModuleTools structure without hand-creating the project
 layout.
 
@@ -38,7 +41,8 @@ supported.
 
 Use `-Example` when you want the scaffold to start from the packaged example project instead of the minimal default
 layout. The example flow keeps the example source, resource, and test files, skips the Pester enable/disable question,
-and applies the interactive metadata values to the copied `project.json`.
+and applies the interactive metadata values to the copied `project.json`. The standard and example flows share the same
+inline validation and retry behavior for interactive answers.
 
 This command supports `-WhatIf` and `-Confirm` through PowerShell `SupportsShouldProcess`. Use `-WhatIf` to preview the
 scaffold target after the interactive answers have been collected, without creating folders, writing `project.json`, or
@@ -53,6 +57,7 @@ PS> Initialize-NovaModule -Path ~/Work
 ```
 
 Starts the interactive scaffold flow and creates the new module under `~/Work`.
+Invalid interactive answers are retried immediately before the command continues.
 
 ### EXAMPLE 2
 
@@ -70,6 +75,7 @@ PS> Initialize-NovaModule -Example -Path ~/Work
 
 Creates a new project under `~/Work` from the packaged example template and applies the answers from the interactive
 prompt flow to the copied `project.json`.
+Invalid interactive answers are retried immediately here as well.
 
 ### EXAMPLE 4
 

--- a/src/private/cli/GetAwesomePromptFieldDescription.ps1
+++ b/src/private/cli/GetAwesomePromptFieldDescription.ps1
@@ -1,0 +1,15 @@
+function Get-AwesomePromptFieldDescription {
+    param([Parameter(Mandatory)][object]$Ask)
+
+    $fieldDescription = [System.Management.Automation.Host.FieldDescription]::new(
+            (Get-AwesomePromptValue -Ask $Ask -Name 'Prompt')
+    )
+    $defaultValue = Get-AwesomePromptValue -Ask $Ask -Name 'Default'
+    if ($defaultValue -ne 'MANDATORY') {
+        $fieldDescription.DefaultValue = $defaultValue
+    }
+
+    return $fieldDescription
+}
+
+

--- a/src/private/cli/GetAwesomePromptResult.ps1
+++ b/src/private/cli/GetAwesomePromptResult.ps1
@@ -1,11 +1,11 @@
 function Get-AwesomePromptResult {
     param(
-        [Parameter(Mandatory)][pscustomobject]$Ask,
+        [Parameter(Mandatory)][object]$Ask,
         [Parameter(Mandatory)][object]$Response
     )
 
     if ( [string]::IsNullOrEmpty($Response.Values)) {
-        return $Ask.Default
+        return Get-AwesomePromptValue -Ask $Ask -Name 'Default'
     }
 
     return $Response.Values

--- a/src/private/cli/GetAwesomePromptValidationFailure.ps1
+++ b/src/private/cli/GetAwesomePromptValidationFailure.ps1
@@ -1,0 +1,28 @@
+function Get-AwesomePromptValidationFailure {
+    param(
+        [Parameter(Mandatory)][object]$Ask,
+        [AllowNull()]$Value
+    )
+
+    $validation = Get-AwesomePromptValue -Ask $Ask -Name 'Validation'
+    if ($null -eq $validation) {
+        return $null
+    }
+
+    $validator = Get-AwesomePromptValue -Ask $validation -Name 'Test'
+    if ($null -eq $validator) {
+        return $null
+    }
+
+    if ([bool](& $validator $Value)) {
+        return $null
+    }
+
+    return [pscustomobject]@{
+        Message = Get-AwesomePromptValue -Ask $validation -Name 'Message'
+        ErrorId = Get-AwesomePromptValue -Ask $validation -Name 'ErrorId'
+        Category = Get-AwesomePromptValue -Ask $validation -Name 'Category'
+        TargetObject = $Value
+    }
+}
+

--- a/src/private/cli/GetAwesomePromptValue.ps1
+++ b/src/private/cli/GetAwesomePromptValue.ps1
@@ -1,0 +1,22 @@
+function Get-AwesomePromptValue {
+    param(
+        [Parameter(Mandatory)][object]$Ask,
+        [Parameter(Mandatory)][string]$Name
+    )
+
+    if ($Ask -is [System.Collections.IDictionary]) {
+        if ( $Ask.Contains($Name)) {
+            return $Ask[$Name]
+        }
+
+        return $null
+    }
+
+    $property = $Ask.PSObject.Properties[$Name]
+    if ($null -eq $property) {
+        return $null
+    }
+
+    return $property.Value
+}
+

--- a/src/private/cli/ReadAwesomeChoicePrompt.ps1
+++ b/src/private/cli/ReadAwesomeChoicePrompt.ps1
@@ -1,12 +1,17 @@
 function Read-AwesomeChoicePrompt {
     param(
-        [Parameter(Mandatory)][pscustomobject]$Ask,
+        [Parameter(Mandatory)][object]$Ask,
         [Parameter(Mandatory)][object]$HostUi
     )
 
-    $options = Get-AwesomeChoiceOptionList -Choice $Ask.Choice
-    $defaultIndex = $options.Label.IndexOf('&' + $Ask.Default)
-    $response = $HostUi.PromptForChoice($Ask.Caption, $Ask.Message, $options, $defaultIndex)
+    $options = Get-AwesomeChoiceOptionList -Choice (Get-AwesomePromptValue -Ask $Ask -Name 'Choice')
+    $defaultIndex = $options.Label.IndexOf('&' + (Get-AwesomePromptValue -Ask $Ask -Name 'Default'))
+    $response = $HostUi.PromptForChoice(
+            (Get-AwesomePromptValue -Ask $Ask -Name 'Caption'),
+            (Get-AwesomePromptValue -Ask $Ask -Name 'Message'),
+            $options,
+            $defaultIndex
+    )
 
     return $options.Label[$response] -replace '&'
 }

--- a/src/private/cli/ReadAwesomeStandardPrompt.ps1
+++ b/src/private/cli/ReadAwesomeStandardPrompt.ps1
@@ -1,16 +1,21 @@
 function Read-AwesomeStandardPrompt {
     param(
-        [Parameter(Mandatory)][pscustomobject]$Ask,
+        [Parameter(Mandatory)][object]$Ask,
         [Parameter(Mandatory)][object]$HostUi
     )
 
-    $fieldDescription = [System.Management.Automation.Host.FieldDescription]::new($Ask.Prompt)
-    if ($Ask.Default -ne 'MANDATORY') {
-        $fieldDescription.DefaultValue = $Ask.Default
-    }
+    $fieldDescription = Get-AwesomePromptFieldDescription -Ask $Ask
 
     do {
-        $response = $HostUi.Prompt($Ask.Caption, $Ask.Message, @($fieldDescription))
+        $response = $HostUi.Prompt(
+                (Get-AwesomePromptValue -Ask $Ask -Name 'Caption'),
+                (Get-AwesomePromptValue -Ask $Ask -Name 'Message'),
+                @($fieldDescription)
+        )
+
+        if (Test-AwesomePromptRequiresRetry -Ask $Ask -Response $response) {
+            Write-AwesomePromptRetryMessage -Ask $Ask -Response $response
+        }
     } while (Test-AwesomePromptRequiresRetry -Ask $Ask -Response $response)
 
     return Get-AwesomePromptResult -Ask $Ask -Response $response

--- a/src/private/cli/TestAwesomePromptRequiresRetry.ps1
+++ b/src/private/cli/TestAwesomePromptRequiresRetry.ps1
@@ -1,8 +1,13 @@
 function Test-AwesomePromptRequiresRetry {
     param(
-        [Parameter(Mandatory)][pscustomobject]$Ask,
+        [Parameter(Mandatory)][object]$Ask,
         [Parameter(Mandatory)][object]$Response
     )
 
-    return $Ask.Default -eq 'MANDATORY' -and [string]::IsNullOrEmpty($Response.Values)
+    if ((Get-AwesomePromptValue -Ask $Ask -Name 'Default') -eq 'MANDATORY' -and [string]::IsNullOrEmpty($Response.Values)) {
+        return $true
+    }
+
+    $value = Get-AwesomePromptResult -Ask $Ask -Response $Response
+    return $null -ne (Get-AwesomePromptValidationFailure -Ask $Ask -Value $value)
 }

--- a/src/private/cli/WriteAwesomePromptRetryMessage.ps1
+++ b/src/private/cli/WriteAwesomePromptRetryMessage.ps1
@@ -1,0 +1,15 @@
+function Write-AwesomePromptRetryMessage {
+    param(
+        [Parameter(Mandatory)][object]$Ask,
+        [Parameter(Mandatory)][object]$Response
+    )
+
+    $value = Get-AwesomePromptResult -Ask $Ask -Response $Response
+    $failure = Get-AwesomePromptValidationFailure -Ask $Ask -Value $value
+    if ($null -eq $failure) {
+        return
+    }
+
+    Write-Message -Text $failure.Message -color Yello
+}
+

--- a/src/private/scaffold/AssertNovaModuleQuestionAnswerValid.ps1
+++ b/src/private/scaffold/AssertNovaModuleQuestionAnswerValid.ps1
@@ -1,0 +1,14 @@
+function Assert-NovaModuleQuestionAnswerValid {
+    param(
+        [Parameter(Mandatory)][object]$Question,
+        [AllowNull()]$Value
+    )
+
+    $validationFailure = Get-AwesomePromptValidationFailure -Ask $Question -Value $Value
+    if ($null -eq $validationFailure) {
+        return
+    }
+
+    Stop-NovaOperation -Message $validationFailure.Message -ErrorId $validationFailure.ErrorId -Category $validationFailure.Category -TargetObject $validationFailure.TargetObject
+}
+

--- a/src/private/scaffold/GetNovaModuleQuestions.ps1
+++ b/src/private/scaffold/GetNovaModuleQuestions.ps1
@@ -1,15 +1,24 @@
-function Get-NovaModuleQuestionSet {
-    [CmdletBinding()]
-    param(
-        [switch]$Example
-    )
+function Get-NovaModuleProjectNameValidation {
+    return @{
+        Test = {
+            param($Value)
 
-    $questions = [ordered]@{
+            return $Value -match '^[A-Za-z][A-Za-z0-9_.]*$'
+        }
+        Message = 'Module name is invalid. Use a single word that starts with a letter and contains only letters, numbers, underscores, or periods.'
+        ErrorId = 'Nova.Validation.ScaffoldProjectNameInvalid'
+        Category = [System.Management.Automation.ErrorCategory]::InvalidData
+    }
+}
+
+function Get-NovaModuleBaseQuestionSet {
+    return [ordered]@{
         ProjectName = @{
             Caption = 'Module Name'
             Message = 'Enter Module name of your choice, should be single word with no special characters'
             Prompt = 'Name'
             Default = 'MANDATORY'
+            Validation = Get-NovaModuleProjectNameValidation
         }
         Description = @{
             Caption = 'Module Description'
@@ -46,18 +55,31 @@ function Get-NovaModuleQuestionSet {
             }
         }
     }
+}
+
+function Get-NovaModulePesterQuestion {
+    return @{
+        Caption = 'Pester Testing'
+        Message = 'Do you want to enable basic Pester Testing'
+        Prompt = 'EnablePester'
+        Default = 'No'
+        Choice = [ordered]@{
+            Yes = 'Enable pester to perform testing'
+            No = 'Skip pester testing'
+        }
+    }
+}
+
+function Get-NovaModuleQuestionSet {
+    [CmdletBinding()]
+    param(
+        [switch]$Example
+    )
+
+    $questions = Get-NovaModuleBaseQuestionSet
 
     if (-not $Example) {
-        $questions.EnablePester = @{
-            Caption = 'Pester Testing'
-            Message = 'Do you want to enable basic Pester Testing'
-            Prompt = 'EnablePester'
-            Default = 'No'
-            Choice = [ordered]@{
-                Yes = 'Enable pester to perform testing'
-                No = 'Skip pester testing'
-            }
-        }
+        $questions.EnablePester = Get-NovaModulePesterQuestion
     }
 
     return $questions

--- a/src/private/scaffold/ReadNovaModuleAnswers.ps1
+++ b/src/private/scaffold/ReadNovaModuleAnswers.ps1
@@ -7,10 +7,7 @@ function Read-NovaModuleAnswerSet {
     $answer = [ordered]@{}
     foreach ($question in $Questions.GetEnumerator()) {
         $answer[$question.Key] = Read-AwesomeHost -Ask $question.Value
-    }
-
-    if ($answer.ProjectName -notmatch '^[A-Za-z][A-Za-z0-9_.]*$') {
-        Stop-NovaOperation -Message 'Module name is invalid. Use a single word that starts with a letter and contains only letters, numbers, underscores, or periods.' -ErrorId 'Nova.Validation.ScaffoldProjectNameInvalid' -Category InvalidData -TargetObject $answer.ProjectName
+        Assert-NovaModuleQuestionAnswerValid -Question $question.Value -Value $answer[$question.Key]
     }
 
     return $answer

--- a/src/resources/cli/help/init.psd1
+++ b/src/resources/cli/help/init.psd1
@@ -5,6 +5,7 @@
     Description = @(
         'Create a new Nova module scaffold.',
         'Run without options for the interactive flow, or pass an explicit destination path when you want a non-interactive target.',
+        'When an interactive answer is invalid, Nova shows the validation message immediately and retries that prompt before moving on.',
         'For more information, documentation, and examples, visit:',
         'https://www.novamoduletools.com/core-workflows.html#scaffold'
     )
@@ -25,7 +26,7 @@
     Examples = @(
         @{
             Command = 'nova init'
-            Description = 'Start the interactive scaffold flow.'
+            Description = 'Start the interactive scaffold flow with immediate inline retry for invalid answers.'
         },
         @{
             Command = 'nova init --path ~/Work'
@@ -33,7 +34,7 @@
         },
         @{
             Command = 'nova init --example --path ~/Work'
-            Description = 'Create the packaged example scaffold at an explicit destination.'
+            Description = 'Create the packaged example scaffold at an explicit destination with the same inline validation behavior.'
         }
     )
 }

--- a/tests/CoverageCompletion.Tests.ps1
+++ b/tests/CoverageCompletion.Tests.ps1
@@ -170,6 +170,20 @@ Describe 'Coverage completion for remaining low-coverage helpers' {
             }
             ExpectedValidationMessage = 'Module name is invalid. Use a single word that starts with a letter and contains only letters, numbers, underscores, or periods.'
         }
+        @{
+            Name = 'validation metadata without validator'
+            Caption = 'Module Name'
+            Message = 'Enter module name'
+            Prompt = 'Name'
+            Default = 'MANDATORY'
+            Responses = @('NovaModuleTools')
+            Expected = 'NovaModuleTools'
+            ExpectedPromptCalls = 1
+            Validation = @{
+                Message = 'Unused validation message'
+            }
+            ExpectedValidationMessage = $null
+        }
     ) {
         $hostUi = New-TestPromptHostUi {
             param($CallCount)

--- a/tests/CoverageCompletion.Tests.ps1
+++ b/tests/CoverageCompletion.Tests.ps1
@@ -124,6 +124,8 @@ Describe 'Coverage completion for remaining low-coverage helpers' {
             Responses = @('NovaModuleTools')
             Expected = 'NovaModuleTools'
             ExpectedPromptCalls = 1
+            Validation = $null
+            ExpectedValidationMessage = $null
         }
         @{
             Name = 'mandatory retry'
@@ -134,6 +136,8 @@ Describe 'Coverage completion for remaining low-coverage helpers' {
             Responses = @($null, 'NovaModuleTools')
             Expected = 'NovaModuleTools'
             ExpectedPromptCalls = 2
+            Validation = $null
+            ExpectedValidationMessage = $null
         }
         @{
             Name = 'default fallback'
@@ -144,6 +148,27 @@ Describe 'Coverage completion for remaining low-coverage helpers' {
             Responses = @('')
             Expected = '0.0.1'
             ExpectedPromptCalls = 1
+            Validation = $null
+            ExpectedValidationMessage = $null
+        }
+        @{
+            Name = 'validation retry'
+            Caption = 'Module Name'
+            Message = 'Enter module name'
+            Prompt = 'Name'
+            Default = 'MANDATORY'
+            Responses = @('bad name', 'NovaModuleTools')
+            Expected = 'NovaModuleTools'
+            ExpectedPromptCalls = 2
+            Validation = @{
+                Test = {
+                    param($Value)
+
+                    return $Value -match '^[A-Za-z][A-Za-z0-9_.]*$'
+                }
+                Message = 'Module name is invalid. Use a single word that starts with a letter and contains only letters, numbers, underscores, or periods.'
+            }
+            ExpectedValidationMessage = 'Module name is invalid. Use a single word that starts with a letter and contains only letters, numbers, underscores, or periods.'
         }
     ) {
         $hostUi = New-TestPromptHostUi {
@@ -156,6 +181,7 @@ Describe 'Coverage completion for remaining low-coverage helpers' {
             param($HostUi, $PromptCase)
 
             Mock Get-AwesomeHostUi {$HostUi}
+            Mock Write-Message {}
 
             Read-AwesomeHost -Ask ([pscustomobject]@{
                 Caption = $PromptCase.Caption
@@ -163,7 +189,17 @@ Describe 'Coverage completion for remaining low-coverage helpers' {
                 Prompt = $PromptCase.Prompt
                 Default = $PromptCase.Default
                 Choice = $null
+                Validation = $PromptCase.Validation
             })
+
+            if ($null -ne $PromptCase.ExpectedValidationMessage) {
+                Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
+                    $Text -eq $PromptCase.ExpectedValidationMessage -and $color -eq 'Yello'
+                }
+            }
+            else {
+                Assert-MockCalled Write-Message -Times 0
+            }
         }
 
         $result | Should -Be $Expected
@@ -179,6 +215,45 @@ Describe 'Coverage completion for remaining low-coverage helpers' {
         else {
             $hostUi.State.FieldDescriptions[0].DefaultValue | Should -Be $Default
         }
+    }
+
+    It 'Read-AwesomeHost retries invalid hashtable-based scaffold answers inline' {
+        $hostUi = New-TestPromptHostUi {
+            param($CallCount)
+
+            return [pscustomobject]@{Values = @('bad name', 'NovaModuleTools')[$CallCount - 1]}
+        }
+
+        $result = InModuleScope $script:moduleName -Parameters @{HostUi = $hostUi} {
+            param($HostUi)
+
+            Mock Get-AwesomeHostUi {$HostUi}
+            Mock Write-Message {}
+
+            $answer = Read-AwesomeHost -Ask @{
+                Caption = 'Module Name'
+                Message = 'Enter module name'
+                Prompt = 'Name'
+                Default = 'MANDATORY'
+                Validation = @{
+                    Test = {
+                        param($Value)
+
+                        return $Value -match '^[A-Za-z][A-Za-z0-9_.]*$'
+                    }
+                    Message = 'Module name is invalid. Use a single word that starts with a letter and contains only letters, numbers, underscores, or periods.'
+                }
+            }
+
+            Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
+                $Text -eq 'Module name is invalid. Use a single word that starts with a letter and contains only letters, numbers, underscores, or periods.' -and $color -eq 'Yello'
+            }
+
+            return $answer
+        }
+
+        $result | Should -Be 'NovaModuleTools'
+        $hostUi.State.PromptCalls | Should -Be 2
     }
 
     It 'Read-AwesomeHost returns the selected label for choice prompts' {

--- a/tests/CoverageGaps.Tests.ps1
+++ b/tests/CoverageGaps.Tests.ps1
@@ -47,12 +47,15 @@ Describe 'Coverage gaps for scaffold internals' {
                 'EnablePester'
             )
             $questions.ProjectName.Default | Should -Be 'MANDATORY'
+            $questions.ProjectName.Validation.Message | Should -Be 'Module name is invalid. Use a single word that starts with a letter and contains only letters, numbers, underscores, or periods.'
+            (& $questions.ProjectName.Validation.Test 'NovaSample') | Should -BeTrue
+            (& $questions.ProjectName.Validation.Test 'bad name') | Should -BeFalse
             $questions.EnableGit.Choice.Yes | Should -Be 'Enable Git'
             $questions.EnablePester.Choice.No | Should -Be 'Skip pester testing'
         }
     }
 
-    It 'Get-NovaModuleQuestionSet omits the Pester prompt for the example flow' {
+    It 'Get-NovaModuleQuestionSet omits the Pester prompt for the example flow and keeps ProjectName validation' {
         InModuleScope $script:moduleName {
             $questions = Get-NovaModuleQuestionSet -Example
 
@@ -65,6 +68,7 @@ Describe 'Coverage gaps for scaffold internals' {
                 'EnableGit'
             )
             $questions.Contains('EnablePester') | Should -BeFalse
+            $questions.ProjectName.Validation.ErrorId | Should -Be 'Nova.Validation.ScaffoldProjectNameInvalid'
         }
     }
 
@@ -174,37 +178,10 @@ Describe 'Coverage gaps for scaffold internals' {
         }
     }
 
-    It 'Read-NovaModuleAnswerSet rejects invalid project names' {
+    It 'Read-NovaModuleAnswerSet retains a defensive invalid project name guard when prompt validation is bypassed' {
         InModuleScope $script:moduleName {
-            $questions = Get-NovaModuleQuestionSet
-            Mock Read-AwesomeHost {
-                switch ($Ask.Caption) {
-                    'Module Name' {
-                        'bad name'
-                    }
-                    'Module Description' {
-                        'Sample module'
-                    }
-                    'Semantic Version' {
-                        '1.2.3'
-                    }
-                    'Module Author' {
-                        'Tester'
-                    }
-                    'Supported PowerShell Version' {
-                        '7.4'
-                    }
-                    'Git Version Control' {
-                        'No'
-                    }
-                    'Pester Testing' {
-                        'No'
-                    }
-                    default {
-                        throw "Unexpected prompt: $( $Ask.Caption )"
-                    }
-                }
-            }
+            $questions = [ordered]@{ProjectName = (Get-NovaModuleQuestionSet).ProjectName}
+            Mock Read-AwesomeHost {'bad name'}
 
             $thrown = $null
             try {
@@ -219,6 +196,7 @@ Describe 'Coverage gaps for scaffold internals' {
             $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Validation.ScaffoldProjectNameInvalid'
             $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidData)
             $thrown.TargetObject | Should -Be 'bad name'
+            Assert-MockCalled Read-AwesomeHost -Times 1
         }
     }
 
@@ -596,13 +574,13 @@ Describe 'Coverage gaps for scaffold internals' {
         }
     }
 
-    It 'Read-NovaModuleAnswerSet rejects invalid module names with a terminating error' {
+    It 'Assert-NovaModuleQuestionAnswerValid uses prompt validation metadata for terminating fallback errors' {
         InModuleScope $script:moduleName {
-            Mock Read-AwesomeHost {'invalid name!'}
+            $question = (Get-NovaModuleQuestionSet).ProjectName
 
             $thrown = $null
             try {
-                Read-NovaModuleAnswerSet -Questions @{ProjectName = @{Prompt = 'Name?'}}
+                Assert-NovaModuleQuestionAnswerValid -Question $question -Value 'invalid name!'
             }
             catch {
                 $thrown = $_


### PR DESCRIPTION
## Summary

- Add inline validation and retry behavior to the interactive `nova init` / `nova init -e` scaffold flow so invalid answers are rejected at the prompt where they are entered instead of after the full questionnaire.
- Move scaffold validation into prompt metadata, extend the shared standard prompt loop to retry invalid non-empty answers with an inline message, and keep a defensive fallback for callers that bypass prompt-level validation.
- No linked issue. Follow-up work is not currently required.

## Affected area

- [ ] `nova` CLI or command routing
- [ ] Public PowerShell cmdlet behavior
- [x] Scaffolding or `project.json` handling
- [ ] Build, test, analyzer, coverage, or CI helper flow
- [ ] Package, raw upload, or package metadata workflow
- [ ] Publish, release, or GitHub Actions automation
- [ ] Self-update or notification preference behavior
- [ ] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
- [ ] End-user docs (`docs/*.html`)
- [x] Command help (`docs/NovaModuleTools/en-US/*.md`)
- [ ] `src/resources/example/`
- [ ] Dependency or manifest changes (`project.json`, workflow dependencies, release tooling)
- [ ] Security-sensitive change
- [ ] Documentation-only change
- [x] Other

## Review guidance

- Start with the shared prompt path in `src/private/cli/ReadAwesomeStandardPrompt.ps1` and `src/private/cli/TestAwesomePromptRequiresRetry.ps1`, because that is where mandatory retries and validation retries now converge.
- Then review `src/private/scaffold/GetNovaModuleQuestions.ps1` and `src/private/scaffold/ReadNovaModuleAnswers.ps1` to see how `ProjectName` validation moved from a late hard-coded check into per-question metadata plus a defensive fallback.
- Primary files to review: `src/private/cli/`, `src/private/scaffold/`, `tests/CoverageCompletion.Tests.ps1`, `tests/CoverageGaps.Tests.ps1`, `src/resources/cli/help/init.psd1`, and `docs/NovaModuleTools/en-US/Initialize-NovaModule.md`.
- Trade-off: this intentionally validates only the prompt values that define validation metadata today, starting with `ProjectName`, so the new inline retry behavior stays shared and incremental.

## Validation

- [x] `Invoke-NovaBuild`
- [x] `Test-NovaBuild`
- [x] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
- [x] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`,
  `% nova publish`,
  `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
- [ ] Docs/example only; executable validation not needed

Validation notes:

```text
Targeted prompt/scaffold validation:
- Invoke-NovaBuild
- Invoke-Pester -Path ./tests/CoverageCompletion.Tests.ps1,./tests/CoverageGaps.Tests.ps1 -Output Detailed
- Result: 43 passed, 0 failed

Repository analyzer validation:
- ./scripts/build/Invoke-ScriptAnalyzerCI.ps1
- Result: PSScriptAnalyzer: no findings.
- Artifact: ./artifacts/scriptanalyzer.txt

Full local quality loop:
- ./run.ps1
- Captured log: ./artifacts/run-ps1-inline-validation.log
- Result tail: Tests Passed: 648, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 0

Workflow exercised:
- Interactive init prompt path via the shared scaffold question reader and prompt-loop tests
- Both standard and example scaffold flows covered by updated tests
```

## Documentation and release follow-up

- [ ] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
- [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
- [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [x] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
- [ ] `docs/*.html` updated if end-user workflows or examples changed
- [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
  changed
- [ ] No documentation, changelog, or example updates were needed

## Maintainability, compatibility, and risk

- [x] Code Health / maintainability impact considered
- [x] No breaking change
- [ ] Breaking change
- [ ] Security-sensitive change
- [ ] CI, workflow, or release-pipeline impact
- [ ] Dependency-review impact

Risk, rollout, or rollback notes:

```text
Low risk: this is a UX-focused change in the shared interactive scaffold prompt path and does not change CLI syntax or parameter contracts.

Compatibility impact is limited to interactive behavior: invalid scaffold answers now retry immediately instead of allowing the questionnaire to complete and then failing on ProjectName validation.

Rollback is straightforward: revert the prompt-validation metadata, the shared prompt retry helpers, and the updated scaffold tests/docs to restore the previous late-validation behavior.
```

> [!IMPORTANT]
> Do not use a public pull request to disclose a vulnerability before coordinated handling.
> Use the private reporting path in `SECURITY.md` for new security issues.
