### PR TITLE
fix(#152): enhance Get-NovaProjectInfo to include installed NovaModul…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Keep stable `Update-NovaModuleVersion` / `% nova bump` releases on the SemVer ma
 
 ### Fixed
 
+- Add a PowerShell installed-tool version view through `Get-NovaProjectInfo -Installed`.
+    - PowerShell now exposes the installed `NovaModuleTools` module name and version directly instead of requiring the
+      launcher-only `% nova --version` path.
+    - `Get-Help Get-NovaProjectInfo` now documents both the project-version and installed-tool-version views.
 - Stop build-driven workflows when a `src/public` file contains zero or multiple top-level functions.
     - This prevents helper functions from being exported accidentally just because they live in a public file.
     - `Invoke-NovaBuild`, `Test-NovaBuild -Build`, packaging, publishing, and release flows now surface the warning

--- a/README.md
+++ b/README.md
@@ -118,9 +118,11 @@ the
 installed module manifest. When `Invoke-NovaBuild` detects a newer `NovaModuleTools` version after a build, the update
 warning also includes that same release notes link.
 
-To compare the current project version with what is installed locally for that same module, use:
+To inspect the current project version, the installed version of the current project module, or the installed
+`NovaModuleTools` tool version, use:
 
 ```powershell
+PS> Get-NovaProjectInfo -Installed
 % nova version
 % nova version --installed
 % nova version -i
@@ -132,6 +134,7 @@ To compare the current project version with what is installed locally for that s
 - `% nova version --installed` / `% nova version -i` shows the locally installed version of the current project/module
   from
   the local module path
+- `Get-NovaProjectInfo -Installed` shows the installed `NovaModuleTools` module name and version from PowerShell
 - `% nova --version` / `% nova -v` shows the installed `NovaModuleTools` version
 
 ### CLI help

--- a/docs/NovaModuleTools/en-US/Get-NovaProjectInfo.md
+++ b/docs/NovaModuleTools/en-US/Get-NovaProjectInfo.md
@@ -4,7 +4,7 @@ external help file: NovaModuleTools-Help.xml
 HelpUri: ''
 Locale: en-US
 Module Name: NovaModuleTools
-ms.date: 04/25/2026
+ms.date: 05/06/2026
 PlatyPS schema version: 2024-05-01
 title: Get-NovaProjectInfo
 ---
@@ -13,14 +13,26 @@ title: Get-NovaProjectInfo
 
 ## SYNOPSIS
 
-Reads `project.json` and returns resolved NovaModuleTools project metadata.
+Reads `project.json` and returns resolved NovaModuleTools project metadata or a version-focused view.
 
 ## SYNTAX
 
-### __AllParameterSets
+### ProjectInfo
+
+```text
+PS> Get-NovaProjectInfo [[-Path] <string>] [<CommonParameters>]
+```
+
+### ProjectVersion
 
 ```text
 PS> Get-NovaProjectInfo [[-Path] <string>] [-Version] [<CommonParameters>]
+```
+
+### InstalledVersion
+
+```text
+PS> Get-NovaProjectInfo [-Installed] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -36,6 +48,9 @@ object with:
 Use this command from scripts, tests, or troubleshooting when you want one object that describes the current project.
 
 When you use `-Version`, the command returns only the project version string instead of the full project object.
+
+When you use `-Installed`, the command returns the installed `NovaModuleTools` module name and version string instead of
+project metadata.
 
 ## EXAMPLES
 
@@ -63,6 +78,14 @@ PS> Get-NovaProjectInfo -Version
 
 Returns only the version string from `project.json`.
 
+### EXAMPLE 4
+
+```text
+PS> Get-NovaProjectInfo -Installed
+```
+
+Returns the installed `NovaModuleTools` module name and version string.
+
 ## PARAMETERS
 
 ### -Path
@@ -75,12 +98,18 @@ DefaultValue: (Get-Location).Path
 SupportsWildcards: false
 Aliases: []
 ParameterSets:
-- Name: (All)
-  Position: 0
-  IsRequired: false
-  ValueFromPipeline: false
-  ValueFromPipelineByPropertyName: false
-  ValueFromRemainingArguments: false
+  - Name: ProjectInfo
+    Position: 0
+    IsRequired: false
+    ValueFromPipeline: false
+    ValueFromPipelineByPropertyName: false
+    ValueFromRemainingArguments: false
+  - Name: ProjectVersion
+    Position: 0
+    IsRequired: false
+    ValueFromPipeline: false
+    ValueFromPipelineByPropertyName: false
+    ValueFromRemainingArguments: false
 DontShow: false
 AcceptedValues: []
 HelpMessage: ''
@@ -96,12 +125,33 @@ DefaultValue: False
 SupportsWildcards: false
 Aliases: []
 ParameterSets:
-- Name: (All)
-  Position: Named
-  IsRequired: false
-  ValueFromPipeline: false
-  ValueFromPipelineByPropertyName: false
-  ValueFromRemainingArguments: false
+  - Name: ProjectVersion
+    Position: Named
+    IsRequired: false
+    ValueFromPipeline: false
+    ValueFromPipelineByPropertyName: false
+    ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Installed
+
+Return the installed `NovaModuleTools` module name and version string instead of project metadata.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+  - Name: InstalledVersion
+    Position: Named
+    IsRequired: false
+    ValueFromPipeline: false
+    ValueFromPipelineByPropertyName: false
+    ValueFromRemainingArguments: false
 DontShow: false
 AcceptedValues: []
 HelpMessage: ''
@@ -125,6 +175,10 @@ You can't pipe objects to this cmdlet.
 
 Returned when you use `-Version`.
 
+### System.String
+
+Returned when you use `-Installed`.
+
 ### PSCustomObject
 
 Returned by default. The object includes project metadata, defaulted build settings, and resolved paths.
@@ -132,6 +186,8 @@ Returned by default. The object includes project metadata, defaulted build setti
 ## NOTES
 
 This command throws a clear error when `project.json` is missing or empty.
+
+`-Installed` does not require a project path or a `project.json` file.
 
 ## RELATED LINKS
 

--- a/docs/NovaModuleTools/en-US/NovaModuleTools.md
+++ b/docs/NovaModuleTools/en-US/NovaModuleTools.md
@@ -24,7 +24,8 @@ manifest generation, external help generation, resource copying, and Pester-base
 
 ### `PS> Get-NovaProjectInfo`
 
-Reads `project.json` and returns resolved project metadata and paths.
+Reads `project.json` and returns resolved project metadata and paths, or returns the project/install version views when
+requested.
 
 ### `PS> Get-NovaUpdateNotificationPreference`
 

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -189,19 +189,23 @@ PS&gt; Initialize-NovaModule -Example -Path ~/Work</code></pre>
                         <ul class="plain-list">
                             <li><strong>Best for:</strong> scripts, troubleshooting, and understanding resolved paths
                             </li>
-                            <li><strong>Key parameters:</strong> <code>-Path</code>, <code>-Version</code></li>
+                            <li><strong>Key parameters:</strong> <code>-Path</code>, <code>-Version</code>, <code>-Installed</code>
+                            </li>
                             <li><strong>Output:</strong> a project object, or just the version string when you use
-                                <code>-Version</code></li>
+                                <code>-Version</code>, or the installed <code>NovaModuleTools</code> name and version
+                                string when you use
+                                <code>-Installed</code></li>
                         </ul>
                         <div class="surface-example" data-command-example>
                             <div class="surface-example__meta">
-                                <p class="surface-example__title">Inspect project metadata</p>
+                                <p class="surface-example__title">Inspect project metadata or version views</p>
                                 <p class="surface-example__status">Showing: <span
                                         data-command-surface-label>PowerShell</span></p>
                             </div>
                             <div class="surface-example__surface" data-command-surface="powershell">
                                 <pre><code>PS&gt; Get-NovaProjectInfo
-PS&gt; Get-NovaProjectInfo -Version</code></pre>
+PS&gt; Get-NovaProjectInfo -Version
+PS&gt; Get-NovaProjectInfo -Installed</code></pre>
                             </div>
                             <div class="surface-example__surface" data-command-surface="command-line" hidden>
                                 <pre><code>% nova info
@@ -534,7 +538,8 @@ PS&gt; Update-NovaModuleVersion -ContinuousIntegration</code></pre>
                                         data-command-surface-label>PowerShell</span></p>
                             </div>
                             <div class="surface-example__surface" data-command-surface="powershell">
-                                <pre><code>PS&gt; Get-NovaProjectInfo -Version</code></pre>
+                                <pre><code>PS&gt; Get-NovaProjectInfo -Version
+PS&gt; Get-NovaProjectInfo -Installed</code></pre>
                             </div>
                             <div class="surface-example__surface" data-command-surface="command-line" hidden>
                                 <pre><code>% nova version
@@ -545,9 +550,12 @@ PS&gt; Update-NovaModuleVersion -ContinuousIntegration</code></pre>
                             </div>
                         </div>
                         <div class="surface-note" data-command-visibility="powershell">
-                            <p><strong>PowerShell note:</strong> the cmdlet surface covers the project version directly.
-                                Installed-module and installed-tool version views stay on the launcher flow described in
-                                the linked guide.</p>
+                            <p><strong>PowerShell note:</strong> <code>Get-NovaProjectInfo -Version</code> covers the
+                                project version and
+                                <code>Get-NovaProjectInfo -Installed</code> covers the installed
+                                <code>NovaModuleTools</code> tool version.
+                                The installed current-project module view stays on the launcher flow described in the
+                                linked guide.</p>
                         </div>
                         <p><a class="text-link" href="./versioning-and-updates.html#version-views">See version view
                             differences</a></p>

--- a/docs/versioning-and-updates.html
+++ b/docs/versioning-and-updates.html
@@ -120,7 +120,7 @@
                             </td>
                         </tr>
                         <tr>
-                            <td><code>% nova --version</code></td>
+                            <td><code>Get-NovaProjectInfo -Installed</code> or <code>% nova --version</code></td>
                             <td>The installed NovaModuleTools version.</td>
                             <td>Use this when you are troubleshooting Nova itself or checking whether the tool needs an
                                 update.
@@ -136,7 +136,8 @@
                         </p>
                     </div>
                     <div class="surface-example__surface" data-command-surface="powershell">
-                        <pre><code>PS&gt; Get-NovaProjectInfo -Version</code></pre>
+                        <pre><code>PS&gt; Get-NovaProjectInfo -Version
+PS&gt; Get-NovaProjectInfo -Installed</code></pre>
                     </div>
                     <div class="surface-example__surface" data-command-surface="command-line" hidden>
                         <pre><code>% nova version
@@ -147,10 +148,10 @@
                     </div>
                 </div>
                 <div class="surface-note" data-command-visibility="powershell">
-                    <p><strong>PowerShell note:</strong> project version lookup has a direct cmdlet form. The installed
-                        module/tool version views remain launcher-oriented on this page, as shown in the comparison
-                        table
-                        above.</p>
+                    <p><strong>PowerShell note:</strong> project version lookup and installed-tool version lookup both
+                        have direct
+                        cmdlet forms. The installed current-project module view remains launcher-oriented on this page,
+                        as shown in the comparison table above.</p>
                 </div>
             </section>
 

--- a/src/private/cli/SetNovaCliExecutablePermission.ps1
+++ b/src/private/cli/SetNovaCliExecutablePermission.ps1
@@ -12,7 +12,7 @@ function Set-NovaCliExecutablePermission {
         return
     }
 
-    & chmod '+x' $Path
+    & chmod '+x' $Path 2> $null
     if ($LASTEXITCODE -ne 0) {
         Stop-NovaOperation -Message "Failed to make nova launcher executable: $Path" -ErrorId 'Nova.Dependency.CliLauncherPermissionUpdateFailed' -Category InvalidOperation -TargetObject $Path
     }

--- a/src/public/GetNovaProjectInfo.ps1
+++ b/src/public/GetNovaProjectInfo.ps1
@@ -1,10 +1,21 @@
 function Get-NovaProjectInfo {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'ProjectInfo')]
     param(
-        [Parameter(Position = 0)]
+        [Parameter(Position = 0, ParameterSetName = 'ProjectInfo')]
+        [Parameter(Position = 0, ParameterSetName = 'ProjectVersion')]
         [string]$Path = (Get-Location).Path,
-        [switch]$Version
+        [Parameter(ParameterSetName = 'ProjectVersion')]
+        [switch]$Version,
+        [Parameter(ParameterSetName = 'InstalledVersion')]
+        [switch]$Installed
     )
+
+    if ($Installed) {
+        $module = $ExecutionContext.SessionState.Module
+        $installedVersion = Get-NovaCliInstalledVersion -Module $module
+        return Format-NovaCliVersionString -Name $module.Name -Version $installedVersion
+    }
+
     $workflowContext = Get-NovaProjectInfoContext -Path $Path
     return Get-NovaProjectInfoResult -WorkflowContext $workflowContext -Version:$Version
 }

--- a/tests/ArchitectureGuardrails.Tests.ps1
+++ b/tests/ArchitectureGuardrails.Tests.ps1
@@ -83,7 +83,7 @@ Describe 'Architecture guardrails' {
     It 'public command files use only their approved Nova helper surface' {
         $testCases = @(
             [pscustomobject]@{Path = 'src/public/DeployNovaPackage.ps1'; ExpectedHelpers = @('Get-NovaPackageUploadWorkflowContext', 'Get-NovaProjectInfo', 'Invoke-NovaPackageUploadWorkflow', 'New-NovaPackageUploadDynamicParameterDictionary', 'New-NovaPackageUploadOption')}
-            [pscustomobject]@{Path = 'src/public/GetNovaProjectInfo.ps1'; ExpectedHelpers = @('Get-NovaProjectInfoContext', 'Get-NovaProjectInfoResult')}
+            [pscustomobject]@{Path = 'src/public/GetNovaProjectInfo.ps1'; ExpectedHelpers = @('Format-NovaCliVersionString', 'Get-NovaCliInstalledVersion', 'Get-NovaProjectInfoContext', 'Get-NovaProjectInfoResult')}
             [pscustomobject]@{Path = 'src/public/GetNovaUpdateNotificationPreference.ps1'; ExpectedHelpers = @('Get-NovaUpdateNotificationPreferenceStatus')}
             [pscustomobject]@{Path = 'src/public/InitializeNovaModule.ps1'; ExpectedHelpers = @('Get-NovaModuleInitializationWorkflowContext', 'Invoke-NovaModuleInitializationWorkflow')}
             [pscustomobject]@{Path = 'src/public/InstallNovaCli.ps1'; ExpectedHelpers = @('Get-NovaCliInstallWorkflowContext', 'Invoke-NovaCliInstallWorkflow', 'Write-NovaModuleReleaseNotesLink')}

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -113,6 +113,21 @@ Describe 'Nova command model - project, help, and build behavior' {
         }
     }
 
+    It 'Get-NovaProjectInfo -Installed returns the installed NovaModuleTools name and version without reading project.json' {
+        InModuleScope $script:moduleName -Parameters @{ExpectedModuleName = $script:moduleName} {
+            param($ExpectedModuleName)
+
+            Mock Get-NovaCliInstalledVersion {'9.9.9-preview'}
+            Mock Get-NovaProjectInfoContext {throw 'should not resolve project context'}
+            Mock Get-NovaProjectInfoResult {throw 'should not shape project output'}
+
+            Get-NovaProjectInfo -Installed | Should -Be "$ExpectedModuleName 9.9.9-preview"
+            Assert-MockCalled Get-NovaCliInstalledVersion -Times 1 -Scope It
+            Assert-MockCalled Get-NovaProjectInfoContext -Times 0 -Scope It
+            Assert-MockCalled Get-NovaProjectInfoResult -Times 0 -Scope It
+        }
+    }
+
     It 'Get-NovaProjectInfo delegates context resolution and result shaping to private helpers' {
         InModuleScope $script:moduleName {
             Mock Get-NovaProjectInfoContext {


### PR DESCRIPTION
## Summary

- Add `Get-NovaProjectInfo -Installed` so the PowerShell surface can report the installed `NovaModuleTools` module name and version directly, instead of requiring the launcher-only `% nova --version` path.
- Update the help/docs set (`README.md`, `docs/NovaModuleTools/en-US/Get-NovaProjectInfo.md`, `docs/NovaModuleTools/en-US/NovaModuleTools.md`, `docs/commands.html`, and `docs/versioning-and-updates.html`) so the project-version, installed-project-version, and installed-tool-version views are explained consistently.
- Closes #152.

## Affected area

- [ ] `nova` CLI or command routing
- [x] Public PowerShell cmdlet behavior
- [ ] Scaffolding or `project.json` handling
- [ ] Build, test, analyzer, coverage, or CI helper flow
- [ ] Package, raw upload, or package metadata workflow
- [ ] Publish, release, or GitHub Actions automation
- [ ] Self-update or notification preference behavior
- [x] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
- [x] End-user docs (`docs/*.html`)
- [x] Command help (`docs/NovaModuleTools/en-US/*.md`)
- [ ] `src/resources/example/`
- [ ] Dependency or manifest changes (`project.json`, workflow dependencies, release tooling)
- [ ] Security-sensitive change
- [ ] Documentation-only change
- [ ] Other

## Review guidance

- Start with `src/public/GetNovaProjectInfo.ps1`, because the change is intentionally small there: `-Installed` gets its own parameter set and returns the installed `NovaModuleTools` name/version without resolving `project.json`.
- Then review `tests/NovaCommandModel.Tests.ps1` and `tests/ArchitectureGuardrails.Tests.ps1` to confirm the new installed-version path is covered and the approved helper surface was updated for the cmdlet.
- Finish with `docs/NovaModuleTools/en-US/Get-NovaProjectInfo.md`, `docs/commands.html`, `docs/versioning-and-updates.html`, `README.md`, and `CHANGELOG.md` for the user-facing wording and version-view examples.
- Minor side change: `src/private/cli/SetNovaCliExecutablePermission.ps1` now suppresses `chmod` stderr noise, but it does not change the permission-update failure behavior.

## Validation

- [x] `Invoke-NovaBuild`
- [ ] `Test-NovaBuild`
- [x] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
- [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
- [ ] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`,
  `% nova publish`,
  `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
- [ ] Docs/example only; executable validation not needed

Validation notes:

```text
Focused validation run from the repository root:
- pwsh -NoProfile -Command '$ErrorActionPreference = "Stop"; Set-Location "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools"; Invoke-NovaBuild; Invoke-Pester -Path "./tests/NovaCommandModel.Tests.ps1","./tests/ArchitectureGuardrails.Tests.ps1" -Output Detailed'
- Result: 47 passed, 0 failed

Repository analyzer validation:
- pwsh -NoProfile -Command '$ErrorActionPreference = "Stop"; Set-Location "/Users/stiwi.courage/workspace/couragedk/NovaModuleTools"; ./scripts/build/Invoke-ScriptAnalyzerCI.ps1; Get-Content -LiteralPath "./artifacts/scriptanalyzer.txt" -Raw'
- Result: PSScriptAnalyzer: no findings.

Maintainability safeguard:
- Code Health branch diff against `develop`: passed

I did not run a launcher-oriented `% nova ...` validation because this change adds a PowerShell-only installed-tool view on top of the existing installed-version helper, and the targeted cmdlet/tests cover the changed behavior directly.
```

## Documentation and release follow-up

- [x] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
- [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
- [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
- [x] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
- [x] `docs/*.html` updated if end-user workflows or examples changed
- [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
  changed
- [ ] No documentation, changelog, or example updates were needed

## Maintainability, compatibility, and risk

- [x] Code Health / maintainability impact considered
- [x] No breaking change
- [ ] Breaking change
- [ ] Security-sensitive change
- [ ] CI, workflow, or release-pipeline impact
- [ ] Dependency-review impact

Risk, rollout, or rollback notes:

```text
Low risk: the behavior change is additive and limited to a new `Get-NovaProjectInfo -Installed` parameter set on the PowerShell surface.

Compatibility impact should be minimal because the existing default and `-Version` paths are unchanged, and the installed-version logic reuses the existing internal helper that already formats Nova tool versions.

Rollback is straightforward: remove the `-Installed` parameter set from `src/public/GetNovaProjectInfo.ps1`, revert the new test expectations, and revert the related README/help/docs/changelog wording.
```

> [!IMPORTANT]
> Do not use a public pull request to disclose a vulnerability before coordinated handling.
> Use the private reporting path in `SECURITY.md` for new security issues.

