### PR TITLE
fix(#153): update command-line test workflow wording in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Keep stable `Update-NovaModuleVersion` / `% nova bump` releases on the SemVer ma
 
 ### Fixed
 
+- Fix the command-line test workflow wording in `docs/core-workflows.html` so the CLI preview flag is shown as
+  `--what-if`.
+    - The GitHub Pages guide now keeps the PowerShell `-WhatIf` wording only in the PowerShell view and shows
+      `--what-if` in the command-line view.
 - Add a PowerShell installed-tool version view through `Get-NovaProjectInfo -Installed`.
     - PowerShell now exposes the installed `NovaModuleTools` module name and version directly instead of requiring the
       launcher-only `% nova --version` path.

--- a/docs/core-workflows.html
+++ b/docs/core-workflows.html
@@ -199,7 +199,11 @@ PS&gt; Test-NovaBuild -OutputVerbosity Detailed -OutputRenderMode Ansi</code></p
                         <code>-OutputRenderMode</code> are PowerShell cmdlet parameters, so switch to the PowerShell
                         view when you need those controls.</p>
                 </div>
-                <p>Use <code>-WhatIf</code> if you want to preview the test run and output path without creating the
+                <p data-command-visibility="powershell">Use <code>-WhatIf</code> if you want to preview the test run and
+                    output path without creating the
+                    results directory or invoking Pester.</p>
+                <p data-command-visibility="command-line" hidden>Use <code>--what-if</code> if you want to preview the
+                    test run and output path without creating the
                     results directory or invoking Pester.</p>
             </section>
 


### PR DESCRIPTION
- Change CLI preview flag wording to `--what-if` in `docs/core-workflows.html`
- Maintain PowerShell `-WhatIf` wording only in the PowerShell view