### PR TITLE
New release 

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -64,6 +64,7 @@ jobs:
         id: semantic_release
         if: github.ref_name == 'main'
         run: |
+          & ./scripts/build/ci/Import-BuiltCiModule.ps1 | Out-Null
           Invoke-NovaRelease -Repository PSGallery -ApiKey $env:PSGALLERY_API -SkipTests -ContinuousIntegration
           $version = Get-NovaProjectInfo -Version
           $result = Move-UnreleasedChangelog -Version $version
@@ -142,6 +143,7 @@ jobs:
       - name: Publish develop prerelease to PSGallery
         if: github.ref_name == 'develop'
         run: |
+          & ./scripts/build/ci/Import-BuiltCiModule.ps1 | Out-Null
           Publish-NovaModule -Repository PSGallery -ApiKey $env:PSGALLERY_API -SkipTests -ContinuousIntegration
         env:
           PSGALLERY_API: ${{ secrets.PSGALLERY_API }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ Keep stable `Update-NovaModuleVersion` / `% nova bump` releases on the SemVer ma
 
 ### Fixed
 
+- Fix the release workflow so repository publish steps run against the freshly built `dist/` module in each CI
+  PowerShell process.
+    - `Publish.yml` now imports the built module before `Invoke-NovaRelease` and `Publish-NovaModule`, which avoids
+      missing private helper failures when the runner also has an older installed `NovaModuleTools` version available
+      for autoload.
 - Fix the command-line test workflow wording in `docs/core-workflows.html` so the CLI preview flag is shown as
   `--what-if`.
     - The GitHub Pages guide now keeps the PowerShell `-WhatIf` wording only in the PowerShell view and shows


### PR DESCRIPTION
- Import built module in CI before invoking release and publish steps to prevent missing private helper failures.
