### PR TITLE
#151 feat: default prerelease self-update confirmation to no

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Make prerelease self-update confirmation default to `No`.
+    - `Update-NovaModuleTool`, `Update-NovaModuleTools`, and `% nova update` now require an explicit `Y` before a
+      prerelease self-update continues, so pressing Enter cancels the update instead of accepting it.
+
 ### Deprecated
 
 ### Removed
@@ -358,4 +362,3 @@ Keep stable `Update-NovaModuleVersion` / `% nova bump` releases on the SemVer ma
 [0.0.6]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.5...Version_0.0.6
 [0.0.5]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.4...Version_0.0.5
 [0.0.4]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.3...Version_0.0.4
-

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ Update notification preferences use one shared settings location:
 `Update-NovaModuleTool` (and its `Update-NovaModuleTools` alias), CLI:`% nova update` use that stored prerelease
 preference to decide whether prerelease self-updates are eligible. When prerelease self-updates are disabled,
 self-update stays on stable releases. When they are enabled, self-update may target a prerelease, but it asks for
-explicit confirmation before proceeding.
+explicit confirmation before proceeding and defaults that prerelease prompt to `No`, so pressing Enter cancels the
+update.
 
 
 Successful `Update-NovaModuleTool`, CLI:`% nova update`, and `Install-NovaCli` runs print the release notes link from

--- a/docs/NovaModuleTools/en-US/Get-NovaUpdateNotificationPreference.md
+++ b/docs/NovaModuleTools/en-US/Get-NovaUpdateNotificationPreference.md
@@ -81,7 +81,8 @@ eligible.
 Use `Set-NovaUpdateNotificationPreference -EnablePrereleaseNotifications` to allow prerelease self-updates again.
 
 When prerelease notifications are enabled again, `Update-NovaModuleTool` / `Update-NovaModuleTools` may again select a
-prerelease target. Prerelease self-updates still require explicit confirmation before the update proceeds.
+prerelease target. Prerelease self-updates still require explicit confirmation before the update proceeds, and that
+confirmation defaults to `No` so pressing Enter cancels the update.
 
 ## RELATED LINKS
 

--- a/docs/NovaModuleTools/en-US/NovaModuleTools.md
+++ b/docs/NovaModuleTools/en-US/NovaModuleTools.md
@@ -62,7 +62,8 @@ Runs the project's Pester test workflow using settings from `project.json`.
 ### `PS> Update-NovaModuleTool`
 
 Updates the installed `NovaModuleTools` module by using the stored prerelease preference that also controls whether
-prerelease self-updates are eligible. The compatibility alias `Update-NovaModuleTools` is also available.
+prerelease self-updates are eligible. Prerelease confirmations default to `No`, so pressing Enter cancels the
+update. The compatibility alias `Update-NovaModuleTools` is also available.
 
 ### `PS> Initialize-NovaModule`
 

--- a/docs/NovaModuleTools/en-US/Update-NovaModuleTools.md
+++ b/docs/NovaModuleTools/en-US/Update-NovaModuleTools.md
@@ -37,7 +37,8 @@ When prerelease notifications are disabled, `Update-NovaModuleTool` only conside
 `-AllowPrerelease` to the update flow.
 
 When prerelease notifications are enabled, `Update-NovaModuleTool` may target a prerelease. If the selected target is a
-prerelease, the command always asks for explicit confirmation before it proceeds.
+prerelease, the command always asks for explicit confirmation before it proceeds, and that prerelease confirmation
+defaults to `No` so pressing Enter cancels the update.
 
 Stable updates do not require prerelease confirmation.
 

--- a/docs/versioning-and-updates.html
+++ b/docs/versioning-and-updates.html
@@ -281,7 +281,7 @@ PS&gt; Update-NovaModuleTools</code></pre>
                         <tr>
                             <td>Only prerelease update available and prerelease eligibility is enabled</td>
                             <td>Nova may target the prerelease, but it always asks for explicit confirmation before
-                                updating.
+                                updating, and that prompt defaults to No so pressing Enter cancels the update.
                             </td>
                         </tr>
                         <tr>

--- a/src/private/update/ConfirmNovaPrereleaseModuleUpdate.ps1
+++ b/src/private/update/ConfirmNovaPrereleaseModuleUpdate.ps1
@@ -7,5 +7,5 @@ function Confirm-NovaPrereleaseModuleUpdate {
     )
 
     $prompt = Get-NovaPrereleaseModuleUpdateConfirmationPrompt -CurrentVersion $CurrentVersion -TargetVersion $TargetVersion
-    return $Cmdlet.ShouldContinue($prompt.Message, $prompt.Caption)
+    return (Read-AwesomeChoicePrompt -Ask $prompt -HostUi $Cmdlet.Host.UI) -eq 'Y'
 }

--- a/src/private/update/GetNovaPrereleaseModuleUpdateConfirmationPrompt.ps1
+++ b/src/private/update/GetNovaPrereleaseModuleUpdateConfirmationPrompt.ps1
@@ -13,5 +13,10 @@ NovaModuleTools would update from $CurrentVersion to prerelease $TargetVersion.
 Prerelease updates may be less stable than released versions.
 Continue with the prerelease update?
 "@
+        Choice = [ordered]@{
+            Y = 'Yes'
+            N = 'No'
+        }
+        Default = 'N'
     }
 }

--- a/tests/UpdateNotification.Tests.ps1
+++ b/tests/UpdateNotification.Tests.ps1
@@ -732,33 +732,45 @@ NovaModuleTools would update from 1.2.3 to prerelease 1.3.0-preview1.
 Prerelease updates may be less stable than released versions.
 Continue with the prerelease update?
 "@
+            $prompt.Choice.Keys | Should -Be @('Y', 'N')
+            $prompt.Default | Should -Be 'N'
         }
     }
 
-    It 'Confirm-NovaPrereleaseModuleUpdate delegates the generated prompt to ShouldContinue and returns the decision' {
-        InModuleScope $script:moduleName {
-            $calls = [System.Collections.Generic.List[object]]::new()
-            $cmdlet = [pscustomobject]@{
-                Calls = $calls
-                ShouldContinueResult = $false
-            }
-            $cmdlet | Add-Member -MemberType ScriptMethod -Name ShouldContinue -Value {
-                param($Message, $Caption)
+    It 'Confirm-NovaPrereleaseModuleUpdate uses a choice prompt that defaults prerelease updates to No' -ForEach @(
+        @{ChoiceIndex = 1; Expected = $false}
+        @{ChoiceIndex = 0; Expected = $true}
+    ) {
+        InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+            param($TestCase)
 
-                $this.Calls.Add([pscustomobject]@{
-                    Message = $Message
-                    Caption = $Caption
-                }) | Out-Null
-                return $this.ShouldContinueResult
+            $hostUi = [pscustomobject]@{
+                State = [ordered]@{
+                    ChoiceCalls = 0
+                    ChoiceLabels = @()
+                    DefaultChoiceIndex = $null
+                }
+            }
+            $hostUi | Add-Member -MemberType ScriptMethod -Name PromptForChoice -Value {
+                param($Caption, $Message, $Choices, $DefaultChoiceIndex)
+
+                $this.State.ChoiceCalls += 1
+                $this.State.ChoiceLabels = @($Choices | ForEach-Object Label)
+                $this.State.DefaultChoiceIndex = $DefaultChoiceIndex
+                return $TestCase.ChoiceIndex
+            }
+            $cmdlet = [pscustomobject]@{
+                Host = [pscustomobject]@{
+                    UI = $hostUi
+                }
             }
 
             $result = Confirm-NovaPrereleaseModuleUpdate -Cmdlet $cmdlet -CurrentVersion '1.2.3' -TargetVersion '2.0.0-preview2'
 
-            $result | Should -BeFalse
-            $calls.Count | Should -Be 1
-            $calls[0].Caption | Should -Be 'Confirm prerelease NovaModuleTools update'
-            $calls[0].Message | Should -Match '1.2.3'
-            $calls[0].Message | Should -Match '2.0.0-preview2'
+            $result | Should -Be $TestCase.Expected
+            $hostUi.State.ChoiceCalls | Should -Be 1
+            $hostUi.State.ChoiceLabels | Should -Be @('&Y', '&N')
+            $hostUi.State.DefaultChoiceIndex | Should -Be 1
         }
     }
 


### PR DESCRIPTION
Summary

 - Changed prerelease self-update confirmation for Update-NovaModuleTool, Update-NovaModuleTools, and % nova update so the prerelease prompt now defaults to No instead of Yes.
 - This was needed to make prerelease self-updates safer by preventing accidental updates when a user presses Enter before reading the prompt fully.
 - Follow-up work: consider adding a CLI-facing integration test that exercises the full interactive % nova update prompt path end to end.

Affected area

 - [X]  nova CLI or command routing
 - [X]  Public PowerShell cmdlet behavior
 - [ ]  Scaffolding or project.json handling
 - [ ]  Build, test, analyzer, coverage, or CI helper flow
 - [ ]  Package, raw upload, or package metadata workflow
 - [ ]  Publish, release, or GitHub Actions automation
 - [X]  Self-update or notification preference behavior
 - [X]  Contributor documentation (README.md, CONTRIBUTING.md, repository workflow docs)
 - [X]  End-user docs (docs/*.html)
 - [X]  Command help (docs/NovaModuleTools/en-US/*.md)
 - [ ]  src/resources/example/
 - [ ]  Dependency or manifest changes (project.json, workflow dependencies, release tooling)
 - [ ]  Security-sensitive change
 - [ ]  Documentation-only change
 - [ ]  Other

Review guidance

 - Start with src/private/update/ConfirmNovaPrereleaseModuleUpdate.ps1 and src/private/update/GetNovaPrereleaseModuleUpdateConfirmationPrompt.ps1.
 - Main files changed:
  - src/private/update/
  - tests/UpdateNotification.Tests.ps1
  - README.md
  - docs/NovaModuleTools/en-US/
  - docs/versioning-and-updates.html
  - CHANGELOG.md
 - Trade-off: this replaces the generic ShouldContinue prerelease confirmation with an explicit choice prompt so the default can be controlled. The behavior is safer, but it is now 
intentionally more conservative for prerelease self-update flows.

Validation

 - [X]  Invoke-NovaBuild
 - [X]  Test-NovaBuild
 - [ ]  ./scripts/build/Invoke-ScriptAnalyzerCI.ps1
 - [X]  ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1
 - [X]  Targeted Nova workflow validated (% nova build, % nova test, % nova merge, % nova deploy,
 % nova publish,
 % nova release, % nova update, % nova notification, or % nova init as relevant)
 - [ ]  Docs/example only; executable validation not needed

Validation notes:

 Invoke-NovaBuild
 Invoke-Pester ./tests/UpdateNotification.Tests.ps1 -Output Detailed
 ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1 -OutputDirectory ./artifacts
 
 Focused validation covered the prerelease self-update prompt helper and the UpdateNotification test suite, including the nova update path through the shared self-update flow.
 CodeScene pre-commit safeguard passed for the branch diff.

Documentation and release follow-up

 - [X]  README.md reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
 - [ ]  CONTRIBUTING.md reviewed and updated if contribution expectations or review guidance changed
 - [X]  CHANGELOG.md reviewed and updated if the change matters to users, maintainers, or contributors
 - [X]  docs/NovaModuleTools/en-US/ help updated if a public command or CLI behavior changed
 - [X]  docs/*.html updated if end-user workflows or examples changed
 - [ ]  src/resources/example/ reviewed and updated if the real-world project layout, package model, or upload workflow
 changed
 - [ ]  No documentation, changelog, or example updates were needed

Maintainability, compatibility, and risk

 - [X]  Code Health / maintainability impact considered
 - [X]  No breaking change
 - [ ]  Breaking change
 - [ ]  Security-sensitive change
 - [ ]  CI, workflow, or release-pipeline impact
 - [ ]  Dependency-review impact

Risk, rollout, or rollback notes:

 Compatibility impact is low: prerelease self-updates are still available, but they now require an explicit Y confirmation instead of accepting Enter as Yes.
 
 Rollback is straightforward:
 - restore Confirm-NovaPrereleaseModuleUpdate to use ShouldContinue
 - remove the explicit choice/default metadata from the prerelease prompt helper
 - revert the docs/changelog text that describes Enter as cancel
 
 This does not change stable self-update behavior, package/release automation, or dependency handling.