### PR TITLE
#174 fix: detect parent git repositories for nova bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `nova bump` and `Update-NovaModuleVersion` so nested project folders now reuse parent Git repository history for bump inference instead of silently falling back to `Patch`.
+
 ### Security
 
 ## [2.3.0] - 2026-05-06

--- a/src/private/release/GetGitCommitMessagesForVersionBump.ps1
+++ b/src/private/release/GetGitCommitMessagesForVersionBump.ps1
@@ -4,7 +4,7 @@ function Get-GitCommitMessageForVersionBump {
         [Parameter(Mandatory)][string]$ProjectRoot
     )
 
-    if (-not (Test-Path -LiteralPath (Join-Path $ProjectRoot '.git'))) {
+    if (-not (Test-GitRepositoryIsAvailable -ProjectRoot $ProjectRoot)) {
         return @()
     }
 

--- a/src/private/release/GetNovaVersionLabelForBump.ps1
+++ b/src/private/release/GetNovaVersionLabelForBump.ps1
@@ -35,10 +35,6 @@ function Test-GitRepositoryIsAvailable {
         [Parameter(Mandatory)][string]$ProjectRoot
     )
 
-    if (-not (Test-Path -LiteralPath (Join-Path $ProjectRoot '.git'))) {
-        return $false
-    }
-
     $result = Invoke-NovaGitCommand -ProjectRoot $ProjectRoot -Arguments @('rev-parse', '--git-dir')
     return $result.ExitCode -eq 0
 }

--- a/tests/CoverageGaps.ReleaseInternals.Tests.ps1
+++ b/tests/CoverageGaps.ReleaseInternals.Tests.ps1
@@ -620,6 +620,28 @@ Describe 'Coverage gaps for release and git internals' {
         }
     }
 
+    It 'Get-GitCommitMessageForVersionBump resolves parent git repositories for nested project paths' {
+        if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+            Set-ItResult -Skipped -Because 'git is not available in this environment'
+            return
+        }
+
+        InModuleScope $script:moduleName {
+            $repositoryRoot = Join-Path $TestDrive 'parent-git-repo'
+            $projectRoot = Join-Path $repositoryRoot 'NestedProject'
+            Initialize-TestGitRepository -Path $repositoryRoot
+            New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+            New-TestGitCommit -RepositoryPath $repositoryRoot -Message 'feat!: nested project change' -File @{
+                Name = 'NestedProject/feature.txt'
+                Content = 'feature'
+            }
+
+            $messages = @(Get-GitCommitMessageForVersionBump -ProjectRoot $projectRoot)
+
+            $messages | Should -Be @('feat!: nested project change')
+        }
+    }
+
     It 'Get-NovaVersionLabelForBump falls back to Patch when the project is not a git repository' {
         InModuleScope $script:moduleName {
             $projectRoot = Join-Path $TestDrive 'no-git-project-for-label'

--- a/tests/NovaCommandModel.StandaloneCli.Tests.ps1
+++ b/tests/NovaCommandModel.StandaloneCli.Tests.ps1
@@ -338,6 +338,46 @@ Describe '$projectName tests' {
         }
     }
 
+    It 'Install-NovaCli infers a major bump from parent Git repository history for nested project roots' {
+        $targetDirectory = Join-Path $TestDrive 'parent-git-bump-bin'
+        $installedPath = Join-Path $targetDirectory 'nova'
+        $repositoryRoot = Join-Path $TestDrive 'CliParentGitRepo'
+        $projectRoot = Join-Path $repositoryRoot 'AzureDevOpsAgentInstaller'
+        $projectJsonPath = Join-Path $projectRoot 'project.json'
+        $originalModulePath = $env:PSModulePath
+        $modulePathSeparator = [string][System.IO.Path]::PathSeparator
+        $distParent = Split-Path -Parent $script:distModuleDir
+
+        $env:PSModulePath = "$distParent$modulePathSeparator$originalModulePath"
+
+        New-Item -ItemType Directory -Path $repositoryRoot -Force | Out-Null
+        Initialize-TestNovaCliProjectLayout -ProjectRoot $projectRoot
+        Write-TestNovaCliProjectJson -ProjectRoot $projectRoot -ProjectName 'AzureDevOpsAgentInstaller' -ProjectGuid '77777777-7777-7777-7777-777777777777'
+        Write-TestNovaCliPublicFunction -ProjectRoot $projectRoot -FunctionName 'Invoke-TestNestedParentGitBump'
+
+        $projectData = Get-Content -LiteralPath $projectJsonPath -Raw | ConvertFrom-Json
+        $projectData.Version = '1.5.4-preview'
+        $projectData | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $projectJsonPath -Encoding utf8
+
+        try {
+            Initialize-TestNovaCliGitRepository -ProjectRoot $repositoryRoot -CommitMessage 'feat!: add nested parent repo bump coverage'
+
+            Install-NovaCli -DestinationDirectory $targetDirectory -Force | Out-Null
+
+            $result = Invoke-TestInstalledNovaCommand -InstalledPath $installedPath -WorkingDirectory $projectRoot -Arguments @('bump', '--what-if')
+            $versionAfterBump = (Get-Content -LiteralPath $projectJsonPath -Raw | ConvertFrom-Json).Version
+
+            $result.ExitCode | Should -Be 0
+            $result.Text | Should -Match 'What if:'
+            $result.Text | Should -Match 'Version plan: 1\.5\.4-preview -> 2\.0\.0 \| Label: Major \| Commits: 1'
+            $result.Text | Should -Not -Match 'Version plan: 1\.5\.4-preview -> 1\.5\.4 \| Label: Patch \| Commits: 0'
+            $versionAfterBump | Should -Be '1.5.4-preview'
+        }
+        finally {
+            $env:PSModulePath = $originalModulePath
+        }
+    }
+
     It 'Install-NovaCli rejects unsupported nova init invocations with clear migration guidance' -ForEach @(
         @{
             Name = 'WhatIf'


### PR DESCRIPTION
## Summary
 
 - `nova bump` and `Update-NovaModuleVersion` now resolve Git history through parent repositories instead of requiring `.git` directly inside the project root.
 - This fixes nested project folders that previously fell back to `Patch | Commits: 0` even when reachable Git history contained commits such as `feat!:` that should drive a different semantic version bump.
 - Added regression coverage for both internal Git-history resolution and real standalone `nova bump --what-if` behavior from a nested project under a parent Git repository.
 - Updated `CHANGELOG.md`.
 - Closes #174
 
 ## Affected area
 
 - [x] `nova` CLI or command routing
 - [x] Public PowerShell cmdlet behavior
 - [ ] Scaffolding or `project.json` handling
 - [x] Build, test, analyzer, coverage, or CI helper flow
 - [ ] Package, raw upload, or package metadata workflow
 - [ ] Publish, release, or GitHub Actions automation
 - [ ] Self-update or notification preference behavior
 - [ ] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
 - [ ] End-user docs (`docs/*.html`)
 - [ ] Command help (`docs/NovaModuleTools/en-US/*.md`)
 - [ ] `src/resources/example/`
 - [ ] Dependency or manifest changes (`project.json`, workflow dependencies, release tooling)
 - [ ] Security-sensitive change
 - [ ] Documentation-only change
 - [ ] Other
 
 ## Review guidance
 
 - Start with `src/private/release/GetGitCommitMessagesForVersionBump.ps1` and `src/private/release/GetNovaVersionLabelForBump.ps1`.
 - The key change is that bump inference now uses the shared Git adapter to test repository availability instead of checking only for `./.git`.
 - Then review the regression coverage in:
   - `tests/CoverageGaps.ReleaseInternals.Tests.ps1`
   - `tests/NovaCommandModel.StandaloneCli.Tests.ps1`
 - Main files changed:
   - `src/private/release/`
   - `tests/`
   - `CHANGELOG.md`
 - Trade-off: this makes Nova align with Git’s own repository resolution model, which is more intuitive for nested project layouts. No public API shape changed.
 
 ## Validation
 
 - [x] `Invoke-NovaBuild`
 - [x] `Test-NovaBuild`
 - [x] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
 - [x] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
 - [ ] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`, `% nova publish`, `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
 - [ ] Docs/example only; executable validation not needed
 
 Validation notes:
 
 ```text
 Ran:
 - ./run.ps1
 - Invoke-NovaBuild
 - Invoke-Pester ./tests/CoverageGaps.ReleaseInternals.Tests.ps1 -Output Detailed
 - Invoke-Pester ./tests/NovaCommandModel.StandaloneCli.Tests.ps1 -Output Detailed
 - git diff --check
 
 Result:
 - PSScriptAnalyzer: no findings
 - Full test suite passed through ./run.ps1
 - Targeted nested-project bump tests passed
 - git diff --check passed
 - CodeScene pre-commit safeguard passed
 
 Scenario exercised:
 - nested project without local .git under a parent Git repository
 - nova bump --what-if now infers the bump from parent-repo commit history instead of falling back to Patch
 ```
 
 ## Documentation and release follow-up

 - [ ]  README.md reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
 - [ ]  CONTRIBUTING.md reviewed and updated if contribution expectations or review guidance changed
 - [X]  CHANGELOG.md reviewed and updated if the change matters to users, maintainers, or contributors
 - [ ]  docs/NovaModuleTools/en-US/ help updated if a public command or CLI behavior changed
 - [ ]  docs/*.html updated if end-user workflows or examples changed
 - [ ]  src/resources/example/ reviewed and updated if the real-world project layout, package model, or upload workflow changed
 - [X]  No documentation, changelog, or example updates were needed

 ## Maintainability, compatibility, and risk

 - [X]  Code Health / maintainability impact considered
 - [X]  No breaking change
 - [ ]  Breaking change
 - [ ]  Security-sensitive change
 - [X]  CI, workflow, or release-pipeline impact
 - [ ]  Dependency-review impact

Risk, rollout, or rollback notes:

```text
 Low risk.
 
 The change narrows incorrect fallback behavior and aligns Nova with Git's normal repository resolution model.
 Nested project folders now behave the way users already expect from git status / git log.
 
 Rollback is straightforward because the change is isolated to bump-time Git detection and test coverage.
 No dependency, packaging, or public parameter changes were introduced.
 ``` 
 
 [!IMPORTANT] Do not use a public pull request to disclose a vulnerability before coordinated handling. Use the private reporting path in SECURITY.md for new security issues.