### PR TITLE
#175 fix: require explicit override for no-git bump fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `nova bump` and `Update-NovaModuleVersion` so nested project folders now reuse parent Git repository history for bump inference instead of silently falling back to `Patch`.
+- Fixed `nova bump` and `Update-NovaModuleVersion` so non-git bump flows now stop with a clear override-warning requirement instead of silently presenting `Patch | Commits: 0` as if it were an inferred result.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,9 @@ These switches keep the behavior explicit and opt-in:
 - `Update-NovaModuleVersion -ContinuousIntegration` also falls back to a patch bump when the current `HEAD` already
   matches the latest tag, so release automation can seed the next prerelease line without requiring an extra commit
   first
+- `Update-NovaModuleVersion` and `% nova bump` now stop when Git-based bump inference is unavailable, unless you
+  explicitly opt in to the Patch fallback with `-OverrideWarning` / `--override-warning` / `-o` for a non-git
+  example/template flow
 - `Update-NovaModuleVersion` and `% nova bump` treat stable `0.y.z` versions as the SemVer initial-development phase,
   so breaking-change bumps stay on the `0.y.z` line by planning the next minor version instead of jumping to `1.0.0`
 - `Publish-NovaModule -ContinuousIntegration` restores the built module after publish completes

--- a/docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md
+++ b/docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md
@@ -20,7 +20,7 @@ Updates the project version in `project.json` based on git commit history.
 ### __AllParameterSets
 
 ```text
-PS> Update-NovaModuleVersion [[-Path] <string>] [-Preview] [-ContinuousIntegration] [-WhatIf] [-Confirm] [<CommonParameters>]
+PS> Update-NovaModuleVersion [[-Path] <string>] [-Preview] [-ContinuousIntegration] [-OverrideWarning] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -49,8 +49,10 @@ reports the detected `Major` label so you can see that the commit set contained 
 guidance about manually setting `1.0.0` once the software is stable. With `-Preview`, stable versions still enter the
 next patch preview track instead of applying semantic history inference to the semantic core.
 
-When Git tags exist, only commits since the latest tag are considered. If the folder is not a Git repository, the
-command falls back to a patch bump.
+When Git tags exist, only commits since the latest tag are considered. If Git-based inference is unavailable because the
+project path is not inside a Git repository, the command stops with a clear warning/error instead of silently presenting
+an inferred-looking patch result. Use `-OverrideWarning` only when you intentionally want that Patch fallback, for
+example in example/template flows outside Git.
 
 If the repository exists but has no commits yet, the command stops with: `Cannot bump version because the repository
 has no commits yet. Create an initial commit first.`
@@ -186,6 +188,19 @@ CommitCount: 34
 Shows how stable `0.y.z` bumps still warn that `1.0.0` must be set manually when the API becomes stable, while
 breaking-change commits on that line continue to plan the next minor version instead of jumping straight to `1.0.0`.
 
+### EXAMPLE 10
+
+```text
+PS> Update-NovaModuleVersion -Path ./src/resources/example -OverrideWarning -WhatIf
+
+WARNING: Cannot infer the version bump label from Git history because no Git repository was found for this project path. Use -OverrideWarning to continue intentionally with a Patch fallback.
+
+What if: Performing the operation "Update module version using Patch release label" on target "project.json".
+```
+
+Shows how to opt in explicitly to the Patch fallback when a project lives outside a Git repository and Nova therefore
+cannot infer the semantic label from commit history.
+
 ## PARAMETERS
 
 ### -Path
@@ -259,6 +274,30 @@ AcceptedValues: [ ]
 HelpMessage: ''
 ```
 
+### -OverrideWarning
+
+Allow the version bump to continue with the explicit Patch fallback when Git-based inference is unavailable.
+
+Use this only when you intentionally want to bump a project outside a Git repository, for example in example/template
+flows where no commit history exists.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: [ ]
+ParameterSets:
+  - Name: (All)
+    Position: Named
+    IsRequired: false
+    ValueFromPipeline: false
+    ValueFromPipelineByPropertyName: false
+    ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: [ ]
+HelpMessage: ''
+```
+
 ### CommonParameters
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
@@ -290,6 +329,9 @@ reflect the new version.
 
 When `-ContinuousIntegration` is used with a real update, the command re-activates the built `dist/` module first. When
 combined with `-WhatIf`, Nova still previews the bump without changing the loaded module state.
+
+When Git-based inference is unavailable, `Update-NovaModuleVersion` now requires `-OverrideWarning` before it continues
+with the intentional Patch fallback.
 
 ## RELATED LINKS
 

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -476,10 +476,13 @@ PS&gt; Invoke-NovaRelease -Repository PSGallery -ApiKey $env:PSGALLERY_API -Cont
                         <ul class="plain-list">
                             <li><strong>Best for:</strong> Git-driven semantic version updates</li>
                             <li><strong>Key parameters:</strong> <code>-Path</code>, <code>-Preview</code>,
-                                <code>-ContinuousIntegration</code>, or the CLI form <code>--preview</code> /
-                                <code>-p</code> and <code>--continuous-integration</code> / <code>-i</code></li>
-                            <li><strong>Notable behavior:</strong> falls back to a patch bump when the folder is not a
-                                Git repository, but throws when the repository exists and has no commits yet
+                                <code>-ContinuousIntegration</code>, <code>-OverrideWarning</code>, or the CLI form
+                                <code>--preview</code> / <code>-p</code>, <code>--continuous-integration</code> /
+                                <code>-i</code>, and <code>--override-warning</code> / <code>-o</code></li>
+                            <li><strong>Notable behavior:</strong> stops when Git-based inference is unavailable, unless
+                                you explicitly opt in to the Patch fallback with <code>-OverrideWarning</code> /
+                                <code>--override-warning</code> / <code>-o</code>; it still throws when the repository
+                                exists and has no commits yet
                             </li>
                             <li><strong>Major-zero rule:</strong> stable <code>0.y.z</code> projects keep
                                 breaking-change
@@ -504,10 +507,12 @@ PS&gt; Invoke-NovaRelease -Repository PSGallery -ApiKey $env:PSGALLERY_API -Cont
                             </div>
                             <div class="surface-example__surface" data-command-surface="powershell">
                                 <pre><code>PS&gt; Update-NovaModuleVersion -Preview -WhatIf
+PS&gt; Update-NovaModuleVersion -Path ./src/resources/example -OverrideWarning -WhatIf
 PS&gt; Update-NovaModuleVersion -ContinuousIntegration</code></pre>
                             </div>
                             <div class="surface-example__surface" data-command-surface="command-line" hidden>
                                 <pre><code>% nova bump --preview --what-if
+% nova bump --override-warning --what-if
 % nova bump --continuous-integration
 % nova bump --preview --confirm</code></pre>
                             </div>

--- a/docs/versioning-and-updates.html
+++ b/docs/versioning-and-updates.html
@@ -177,9 +177,12 @@ PS&gt; Get-NovaProjectInfo -Installed</code></pre>
                 <pre><code>0.0.1 + Patch -> 0.0.2
 0.1.0 + Minor -> 0.2.0
 0.1.0 + Major -> 0.2.0</code></pre>
-                <p>When Git tags exist, Nova uses commits since the latest tag. When the folder is not a Git repository,
-                    Nova falls back to a patch bump. When the repository exists but has no commits yet, Nova stops with
-                    a clear error.</p>
+                <p>When Git tags exist, Nova uses commits since the latest tag. When Git-based inference is unavailable
+                    because the project path is not inside a Git repository, Nova stops instead of silently presenting a
+                    normal-looking patch result. Use <code>-OverrideWarning</code> or the CLI form <code>% nova bump
+                        --override-warning</code> / <code>% nova bump -o</code> only when you intentionally want that
+                    Patch fallback for an example/template flow outside Git. When the repository exists but has no
+                    commits yet, Nova still stops with a clear error.</p>
                 <p>Nova treats prerelease versions as previews of a specific semantic version target. That means a bump
                     does not blindly carry prerelease labels such as <code>preview7</code> into the next major, minor,
                     or
@@ -215,11 +218,13 @@ PS&gt; Get-NovaProjectInfo -Installed</code></pre>
                     <div class="surface-example__surface" data-command-surface="powershell">
                         <pre><code>PS&gt; Update-NovaModuleVersion -WhatIf
 PS&gt; Update-NovaModuleVersion -Preview -WhatIf
+PS&gt; Update-NovaModuleVersion -Path ./src/resources/example -OverrideWarning -WhatIf
 PS&gt; Update-NovaModuleVersion -ContinuousIntegration</code></pre>
                     </div>
                     <div class="surface-example__surface" data-command-surface="command-line" hidden>
                         <pre><code>% nova bump --what-if
 % nova bump --preview --what-if
+% nova bump --override-warning --what-if
 % nova bump --continuous-integration
 % nova bump --confirm</code></pre>
                     </div>

--- a/src/private/cli/ConvertFromNovaBumpCliArgument.ps1
+++ b/src/private/cli/ConvertFromNovaBumpCliArgument.ps1
@@ -9,5 +9,7 @@ function ConvertFrom-NovaBumpCliArgument {
         '-p' = 'Preview'
         '--continuous-integration' = 'ContinuousIntegration'
         '-i' = 'ContinuousIntegration'
+        '--override-warning' = 'OverrideWarning'
+        '-o' = 'OverrideWarning'
     }
 }

--- a/src/private/cli/GetNovaCliArgumentRoutingState.ps1
+++ b/src/private/cli/GetNovaCliArgumentRoutingState.ps1
@@ -68,6 +68,7 @@ function Get-NovaCliLegacyOptionReplacement {
         '-installed' = "'--installed' or '-i'"
         '-local' = "'--local' or '-l'"
         '-moduledirectorypath' = "'--path' or '-p'"
+        '-overridewarning' = "'--override-warning' or '-o'"
         '-packagepath' = "'--path' or '-p'"
         '-packagetype' = "'--type' or '-t'"
         '-path' = "'--path' or '-p'"

--- a/src/private/release/GetNovaVersionUpdateWorkflowContext.ps1
+++ b/src/private/release/GetNovaVersionUpdateWorkflowContext.ps1
@@ -3,16 +3,52 @@ function Get-NovaVersionUpdateWorkflowContext {
     param(
         [Parameter(Mandatory)][string]$ProjectRoot,
         [switch]$PreviewRelease,
-        [switch]$ContinuousIntegrationRequested
+        [switch]$ContinuousIntegrationRequested,
+        [switch]$OverrideWarningRequested
     )
 
     $projectInfo = Get-NovaProjectInfo -Path $ProjectRoot
     $commitMessages = @(Get-GitCommitMessageForVersionBump -ProjectRoot $ProjectRoot)
+    Assert-NovaVersionBumpInferenceAvailability -ProjectRoot $ProjectRoot -CommitMessages $commitMessages -OverrideWarningRequested:$OverrideWarningRequested
     $label = Get-NovaVersionLabelForBump -ProjectRoot $ProjectRoot -CommitMessages $commitMessages -ContinuousIntegrationRequested:$ContinuousIntegrationRequested
     $labelResolution = Get-NovaVersionUpdateLabelResolution -ProjectInfo $projectInfo -Label $label -PreviewRelease:$PreviewRelease
     $versionUpdatePlan = Get-NovaVersionUpdatePlan -ProjectInfo $projectInfo -Label $labelResolution.EffectiveLabel -PreviewRelease:$PreviewRelease
 
     return Get-NovaVersionUpdateWorkflowContextObject -ProjectRoot $ProjectRoot -ProjectInfo $projectInfo -CommitMessages $commitMessages -Label $label -EffectiveLabel $labelResolution.EffectiveLabel -AdvisoryMessage $labelResolution.AdvisoryMessage -VersionUpdatePlan $versionUpdatePlan -PreviewRelease:$PreviewRelease -ContinuousIntegrationRequested:$ContinuousIntegrationRequested
+}
+
+function Assert-NovaVersionBumpInferenceAvailability {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ProjectRoot,
+        [AllowEmptyCollection()][string[]]$CommitMessages = @(),
+        [switch]$OverrideWarningRequested
+    )
+
+    if ($CommitMessages.Count -gt 0) {
+        return
+    }
+
+    if (Test-GitRepositoryIsAvailable -ProjectRoot $ProjectRoot) {
+        return
+    }
+
+    $message = Get-NovaVersionBumpInferenceUnavailableMessage
+    Write-Warning $message
+
+    if ($OverrideWarningRequested) {
+        Write-Verbose 'Continuing version bump because OverrideWarning was specified and Git-based bump inference is unavailable.'
+        return
+    }
+
+    Stop-NovaOperation -Message $message -ErrorId 'Nova.Workflow.VersionBumpInferenceUnavailable' -Category InvalidOperation -TargetObject $ProjectRoot
+}
+
+function Get-NovaVersionBumpInferenceUnavailableMessage {
+    [CmdletBinding()]
+    param()
+
+    return 'Cannot infer the version bump label from Git history because no Git repository was found for this project path. Use -OverrideWarning / --override-warning / -o to continue intentionally with a Patch fallback, for example in example or template flows.'
 }
 
 function Get-NovaVersionUpdateLabelResolution {

--- a/src/public/UpdateNovaModuleVersion.ps1
+++ b/src/public/UpdateNovaModuleVersion.ps1
@@ -3,7 +3,8 @@ function Update-NovaModuleVersion {
     param(
         [string]$Path = (Get-Location).Path,
         [switch]$Preview,
-        [switch]$ContinuousIntegration
+        [switch]$ContinuousIntegration,
+        [switch]$OverrideWarning
     )
 
     $projectRoot = (Resolve-Path -LiteralPath $Path).Path
@@ -12,7 +13,7 @@ function Update-NovaModuleVersion {
         return $ciActivation.Result
     }
 
-    $workflowContext = Get-NovaVersionUpdateWorkflowContext -ProjectRoot $projectRoot -PreviewRelease:$Preview -ContinuousIntegrationRequested:$ContinuousIntegration
+    $workflowContext = Get-NovaVersionUpdateWorkflowContext -ProjectRoot $projectRoot -PreviewRelease:$Preview -ContinuousIntegrationRequested:$ContinuousIntegration -OverrideWarningRequested:$OverrideWarning
     $shouldRun = $PSCmdlet.ShouldProcess($workflowContext.Target, $workflowContext.Action)
     $result = Invoke-NovaVersionUpdateWorkflow -WorkflowContext $workflowContext -ShouldRun:$shouldRun -WhatIfEnabled:$WhatIfPreference
     if ($null -eq $result) {
@@ -23,4 +24,3 @@ function Update-NovaModuleVersion {
 
     return $result
 }
-

--- a/src/resources/cli/help/bump.psd1
+++ b/src/resources/cli/help/bump.psd1
@@ -7,6 +7,7 @@
         'When the current stable version is 0.y.z, Nova keeps breaking-change bumps on the initial-development line and plans the next minor version instead of jumping to 1.0.0.',
         'Set 1.0.0 manually once the software is stable. After that, nova bump can increment major versions normally.',
         'Use --preview when you want an explicit prerelease iteration instead of the next stable semantic version.',
+        'When Git-based bump inference is unavailable, nova bump stops unless you opt in to the Patch fallback with --override-warning.',
         'For more information, documentation, and examples, visit:',
         'https://www.novamoduletools.com/versioning-and-updates.html#bump'
     )
@@ -40,6 +41,12 @@
             Long = '--continuous-integration'
             Placeholder = ''
             Description = 'Re-import the built dist module before the version bump workflow starts so later CI steps keep using the correct built module state.'
+        },
+        @{
+            Short = '-o'
+            Long = '--override-warning'
+            Placeholder = ''
+            Description = 'Allow an intentional Patch fallback when Git-based bump inference is unavailable, for example in example or template flows outside a Git repository.'
         }
     )
     Examples = @(
@@ -58,6 +65,10 @@
         @{
             Command = 'nova bump --continuous-integration --what-if'
             Description = 'Preview the next version by using the CI-safe routed bump entrypoint without changing project.json.'
+        },
+        @{
+            Command = 'nova bump --override-warning --what-if'
+            Description = 'Preview the explicit Patch fallback when Git-based bump inference is unavailable outside a Git repository.'
         }
     )
 }

--- a/tests/CoverageGaps.Cli.TestSupport.ps1
+++ b/tests/CoverageGaps.Cli.TestSupport.ps1
@@ -81,6 +81,8 @@ function Get-TestNovaCliRoutedParserCaseList {
                 @{Arguments = @('-p'); Property = 'Preview'}
                 @{Arguments = @('--continuous-integration'); Property = 'ContinuousIntegration'}
                 @{Arguments = @('-i'); Property = 'ContinuousIntegration'}
+                @{Arguments = @('--override-warning'); Property = 'OverrideWarning'}
+                @{Arguments = @('-o'); Property = 'OverrideWarning'}
             )
         }
         @{

--- a/tests/CoverageGaps.ReleaseInternals.Tests.ps1
+++ b/tests/CoverageGaps.ReleaseInternals.Tests.ps1
@@ -651,6 +651,42 @@ Describe 'Coverage gaps for release and git internals' {
         }
     }
 
+    It 'Assert-NovaVersionBumpInferenceAvailability throws a clear error when Git-based bump inference is unavailable' {
+        InModuleScope $script:moduleName {
+            $projectRoot = Join-Path $TestDrive 'no-git-project-for-override-guard'
+            New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+
+            $warningMessages = @()
+            $thrown = $null
+            try {
+                Assert-NovaVersionBumpInferenceAvailability -ProjectRoot $projectRoot -CommitMessages @() -WarningVariable warningMessages
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be 'Cannot infer the version bump label from Git history because no Git repository was found for this project path. Use -OverrideWarning / --override-warning / -o to continue intentionally with a Patch fallback, for example in example or template flows.'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Workflow.VersionBumpInferenceUnavailable'
+            $thrown.CategoryInfo.Category | Should -Be ([System.Management.Automation.ErrorCategory]::InvalidOperation)
+            $thrown.TargetObject | Should -Be $projectRoot
+            ($warningMessages -join [Environment]::NewLine) | Should -Match '-OverrideWarning / --override-warning / -o'
+        }
+    }
+
+    It 'Assert-NovaVersionBumpInferenceAvailability warns but continues when OverrideWarningRequested is set' {
+        InModuleScope $script:moduleName {
+            $projectRoot = Join-Path $TestDrive 'no-git-project-for-override-continue'
+            New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+
+            $records = @(& {Assert-NovaVersionBumpInferenceAvailability -ProjectRoot $projectRoot -CommitMessages @() -OverrideWarningRequested} 3>&1)
+
+            { $null = $records } | Should -Not -Throw
+            @($records | Where-Object {$_ -is [System.Management.Automation.WarningRecord]}).Count | Should -Be 1
+            (@($records | Where-Object {$_ -is [System.Management.Automation.WarningRecord]} | ForEach-Object Message) -join [Environment]::NewLine) | Should -Match 'Cannot infer the version bump label from Git history'
+        }
+    }
+
     It 'Get-GitCommitMessageForVersionBump uses the shared git adapter to resolve tagged commit history' {
         InModuleScope $script:moduleName {
             $projectRoot = Join-Path $TestDrive 'mocked-git-history'

--- a/tests/NovaCommandModel.BumpAndCli.Tests.ps1
+++ b/tests/NovaCommandModel.BumpAndCli.Tests.ps1
@@ -352,6 +352,24 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
         }
     }
 
+    It 'Update-NovaModuleVersion forwards OverrideWarning into the version-update workflow context' {
+        InModuleScope $script:moduleName {
+            Mock Get-NovaVersionUpdateWorkflowContext {
+                [pscustomobject]@{
+                    Target = 'project.json'
+                    Action = 'Update module version using Minor release label'
+                }
+            }
+            Mock Invoke-NovaVersionUpdateWorkflow {
+                [pscustomobject]@{NewVersion = '1.1.0'; Applied = $false}
+            }
+
+            $null = Update-NovaModuleVersion -Path (Get-Location).Path -OverrideWarning -WhatIf
+
+            Assert-MockCalled Get-NovaVersionUpdateWorkflowContext -Times 1 -ParameterFilter {$OverrideWarningRequested}
+        }
+    }
+
     It 'Update-NovaModuleVersion writes the initial-development warning for stable 0.y.z breaking-change bumps' {
         Assert-TestUpdateNovaModuleVersionMajorZeroWarning -ModuleName $script:moduleName -TestCase @{
             PreviousVersion = '0.1.0'
@@ -572,7 +590,7 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
         }
     }
 
-    It 'Update-NovaModuleVersion -WhatIf falls back to a Patch preview when the project is not a git repository' {
+    It 'Update-NovaModuleVersion -WhatIf requires OverrideWarning when the project is not a git repository' {
         InModuleScope $script:moduleName {
             $projectRoot = Join-Path $TestDrive 'no-git-bump-project'
             New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
@@ -592,12 +610,52 @@ Describe 'Nova command model - bump and CLI confirmation behavior' {
             }
             Mock Set-NovaModuleVersion {}
 
-            $result = Update-NovaModuleVersion -Path $projectRoot -WhatIf
+            $warningMessages = @()
+            $thrown = $null
+            try {
+                Update-NovaModuleVersion -Path $projectRoot -WhatIf -WarningVariable warningMessages
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.Exception.Message | Should -Be 'Cannot infer the version bump label from Git history because no Git repository was found for this project path. Use -OverrideWarning / --override-warning / -o to continue intentionally with a Patch fallback, for example in example or template flows.'
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Workflow.VersionBumpInferenceUnavailable'
+            ($warningMessages -join [Environment]::NewLine) | Should -Match '-OverrideWarning / --override-warning / -o'
+            Assert-MockCalled Get-NovaVersionUpdatePlan -Times 0
+            Assert-MockCalled Set-NovaModuleVersion -Times 0
+        }
+    }
+
+    It 'Update-NovaModuleVersion -WhatIf continues with a Patch fallback when OverrideWarning is specified outside a git repository' {
+        InModuleScope $script:moduleName {
+            $projectRoot = Join-Path $TestDrive 'no-git-bump-project-with-override'
+            New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+
+            Mock Get-NovaProjectInfo {
+                [pscustomobject]@{
+                    Version = '1.0.0'
+                    ProjectJSON = (Join-Path $projectRoot 'project.json')
+                }
+            }
+            Mock Get-NovaVersionUpdatePlan {
+                [pscustomobject]@{
+                    ProjectFile = (Join-Path $projectRoot 'project.json')
+                    CurrentVersion = [semver]'1.0.0'
+                    NewVersion = [semver]'1.0.1'
+                }
+            }
+            Mock Set-NovaModuleVersion {}
+
+            $warningMessages = @()
+            $result = Update-NovaModuleVersion -Path $projectRoot -OverrideWarning -WhatIf -WarningVariable warningMessages
 
             $result.PreviousVersion | Should -Be '1.0.0'
             $result.NewVersion | Should -Be '1.0.1'
             $result.Label | Should -Be 'Patch'
             $result.CommitCount | Should -Be 0
+            ($warningMessages -join [Environment]::NewLine) | Should -Match 'Cannot infer the version bump label from Git history'
             Assert-MockCalled Set-NovaModuleVersion -Times 0
         }
     }

--- a/tests/NovaCommandModel.StandaloneCli.OverrideWarning.Tests.ps1
+++ b/tests/NovaCommandModel.StandaloneCli.OverrideWarning.Tests.ps1
@@ -62,6 +62,7 @@ BeforeAll {
 Describe 'Nova command model - standalone CLI override-warning behavior' {
     It 'Invoke-NovaCli forwards override-warning for routed build-aware commands' -ForEach @(
         @{CommandName = 'build'; ActionCommand = 'Invoke-NovaBuild'; Arguments = @('--override-warning')}
+        @{CommandName = 'bump'; ActionCommand = 'Update-NovaModuleVersion'; Arguments = @('--override-warning')}
         @{CommandName = 'test'; ActionCommand = 'Test-NovaBuild'; Arguments = @('--build', '--override-warning')}
         @{CommandName = 'package'; ActionCommand = 'New-NovaModulePackage'; Arguments = @('--override-warning')}
         @{CommandName = 'publish'; ActionCommand = 'Publish-NovaModule'; Arguments = @('--repository', 'PSGallery', '--api-key', 'key123', '--override-warning')}

--- a/tests/NovaCommandModel.StandaloneCli.Tests.ps1
+++ b/tests/NovaCommandModel.StandaloneCli.Tests.ps1
@@ -605,6 +605,20 @@ Describe '$projectName tests' {
         }
     }
 
+    It 'Invoke-NovaCli help for bump documents the override-warning options' -ForEach @(
+        @{CommandName = 'bump'}
+    ) {
+        InModuleScope $script:moduleName -Parameters @{CommandName = $_.CommandName} {
+            param($CommandName)
+
+            $shortHelp = Invoke-NovaCli -Command $CommandName -Arguments @('--help')
+            $longHelp = Invoke-NovaCli -Command '--help' -Arguments @($CommandName)
+
+            $shortHelp | Should -Match '-o, --override-warning'
+            $longHelp | Should -Match '--override-warning'
+        }
+    }
+
     It 'Invoke-NovaCli CLI help never delegates to PowerShell Get-Help' {
         InModuleScope $script:moduleName {
             Mock Get-Help {throw 'CLI help should not call Get-Help'}


### PR DESCRIPTION
 Stop `nova bump` and `Update-NovaModuleVersion` from silently presenting
 `Patch | Commits: 0` when Git-based bump inference is unavailable.

 Add `-OverrideWarning` / `--override-warning` / `-o` as the explicit opt-in
 for intentional non-git Patch fallback flows, add regression coverage, and
 update bump docs and changelog.

 Closes #175

Summary

   - nova bump / Update-NovaModuleVersion now stop with a clear warning/error when Git-based bump inference is unavailable, instead of silently showing a normal-looking Patch | Commits: 0 result.
   - Added an explicit opt-in fallback for real non-git scenarios: -OverrideWarning in PowerShell and --override-warning / -o in the CLI.
   - Added regression coverage for the no-git and override flows, updated bump help/output docs, and recorded the change in CHANGELOG.md.
   - This was needed because the old fallback hid inference failures and could produce the wrong version plan while looking legitimate.
   - Closes #175

  Affected area

   - [X]  nova CLI or command routing
   - [X]  Public PowerShell cmdlet behavior
   - [ ]  Scaffolding or project.json handling
   - [X]  Build, test, analyzer, coverage, or CI helper flow
   - [ ]  Package, raw upload, or package metadata workflow
   - [ ]  Publish, release, or GitHub Actions automation
   - [ ]  Self-update or notification preference behavior
   - [X]  Contributor documentation (README.md, CONTRIBUTING.md, repository workflow docs)
   - [X]  End-user docs (docs/*.html)
   - [X]  Command help (docs/NovaModuleTools/en-US/*.md)
   - [ ]  src/resources/example/
   - [ ]  Dependency or manifest changes (project.json, workflow dependencies, release tooling)
   - [ ]  Security-sensitive change
   - [ ]  Documentation-only change
   - [ ]  Other

  Review guidance

   - Start with the bump workflow guard in src/private/release/GetNovaVersionUpdateWorkflowContext.ps1 and the public entrypoint in src/public/UpdateNovaModuleVersion.ps1.
   - Then review CLI routing in src/private/cli/ConvertFromNovaBumpCliArgument.ps1, src/private/cli/GetNovaCliArgumentRoutingState.ps1, and src/resources/cli/help/bump.psd1.
   - Regression coverage is mainly in tests/NovaCommandModel.BumpAndCli.Tests.ps1, tests/CoverageGaps.ReleaseInternals.Tests.ps1, tests/NovaCommandModel.StandaloneCli.OverrideWarning.Tests.ps1, and tests/NovaCommandModel.StandaloneCli.Tests.ps1.
   - Trade-off: intentional non-git bump flows now require explicit opt-in. That is the point of the fix, but existing automation that relied on the silent fallback must add -OverrideWarning / --override-warning / -o.

  Validation

   - [ ]  Invoke-NovaBuild
   - [ ]  Test-NovaBuild
   - [ ]  ./scripts/build/Invoke-ScriptAnalyzerCI.ps1
   - [ ]  ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1
   - [X]  Targeted Nova workflow validated (% nova build, % nova test, % nova merge, % nova deploy,
   % nova publish,
   % nova release, % nova update, % nova notification, or % nova init as relevant)
   - [ ]  Docs/example only; executable validation not needed

  Validation notes:

   Ran the repo quality gate with:
     pwsh -NoLogo -NoProfile -File ./run.ps1
   
   Result:
     PSScriptAnalyzer: no findings
     Tests Passed: 674
     Failed: 0
   
   Also ran:
     git --no-pager diff --check
   
   Targeted bump behavior was covered through the automated cmdlet + standalone CLI regression tests for
   Update-NovaModuleVersion / nova bump, including the new override-warning path.

  Documentation and release follow-up

   - [X]  README.md reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
   - [ ]  CONTRIBUTING.md reviewed and updated if contribution expectations or review guidance changed
   - [X]  CHANGELOG.md reviewed and updated if the change matters to users, maintainers, or contributors
   - [X]  docs/NovaModuleTools/en-US/ help updated if a public command or CLI behavior changed
   - [X]  docs/*.html updated if end-user workflows or examples changed
   - [ ]  src/resources/example/ reviewed and updated if the real-world project layout, package model, or upload workflow
   changed
   - [ ]  No documentation, changelog, or example updates were needed

  Maintainability, compatibility, and risk

   - [X]  Code Health / maintainability impact considered
   - [X]  No breaking change
   - [ ]  Breaking change
   - [ ]  Security-sensitive change
   - [X]  CI, workflow, or release-pipeline impact
   - [ ]  Dependency-review impact

  Risk, rollout, or rollback notes:

   Risk is low and localized to bump inference when Git history is unavailable.
   
   Compatibility note:
   - Intentional non-git bump workflows now need explicit opt-in with
     -OverrideWarning / --override-warning / -o.
   - That is an intentional UX/safety tightening so Nova no longer hides inference failure behind a
     plausible Patch plan.
   
   Rollback is straightforward:
   - revert the bump guard + CLI option wiring if maintainers decide the fallback should remain implicit,
     though that would reintroduce the misleading Patch | Commits: 0 behavior.

   [!IMPORTANT] Do not use a public pull request to disclose a vulnerability before coordinated handling. Use the private reporting path in SECURITY.md for new security issues.

