### PR TITLE
#179 feat: add stable-only latest package policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `Package.Latest` now supports policy values: `"never"`, `"stable"`, and `"always"`.
+  - `"stable"` keeps the floating `latest` alias pinned to stable package versions.
+  - Legacy boolean values still work for now and map to `"always"` / `"never"` for backward compatibility.
+
 ### Deprecated
+
+- Boolean `Package.Latest` values are deprecated and will be removed in the next major version.
 
 ### Removed
 
@@ -74,9 +80,8 @@ Keep stable `Update-NovaModuleVersion` / `% nova bump` releases on the SemVer ma
 ### Deprecated
 
 - `Invoke-NovaRelease` parameters that differ from `Publish-NovaModule` and `% nova release` such as `-Local`,
-  `-Repository`,
-  `-ModuleDirectoryPath`, and `-ApiKey` are now the primary PowerShell release parameters, while `-PublishOption` is
-  deprecated.
+  `-Repository`, `-ModuleDirectoryPath`, and `-ApiKey` are now the primary PowerShell release parameters, while 
+  `-PublishOption` is deprecated and will be removed in the next major version.
 
 ### Fixed
 
@@ -385,4 +390,3 @@ Keep stable `Update-NovaModuleVersion` / `% nova bump` releases on the SemVer ma
 [0.0.6]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.5...Version_0.0.6
 [0.0.5]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.4...Version_0.0.5
 [0.0.4]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.3...Version_0.0.4
-

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Use this `project.json` shape when you want to control the package types and out
     "PackageFileName": "AgentInstaller",
     "AddVersionToFileName": true,
     "Types": ["NuGet", "Zip"],
-    "Latest": true,
+    "Latest": "stable",
     "OutputDirectory": {
       "Path": "artifacts/packages",
       "Clean": true
@@ -326,14 +326,16 @@ Use this `project.json` shape when you want to control the package types and out
 - `Types` is optional. When it is missing, empty, or null, Nova defaults to `NuGet` and creates a `.nupkg`.
 - Supported `Types` values are `NuGet`, `Zip`, `.nupkg`, and `.zip`, and matching is case-insensitive.
 - Use `Types = ["Zip"]` when you only want a `.zip`, or `Types = ["NuGet", "Zip"]` when you want both files.
-- `Latest` is optional and defaults to `false`. When set to `true`, Nova also creates a companion `*.latest.*`
-  artifact for each selected package type, such as `NovaModuleTools.latest.nupkg` next to the normal versioned file.
+- `Latest` is optional and defaults to `"never"`.
+- Set `Latest` to `"stable"` when only stable versions should also create companion `*.latest.*` artifacts.
+- Set `Latest` to `"always"` when both stable and preview versions should also create companion `*.latest.*` artifacts.
+- Set `Latest` to `"never"` when you only want versioned package files.
 - `PackageFileName` lets you override the base artifact name.
 - `AddVersionToFileName` defaults to `false`. When set to `true`, Nova appends `.<Version>` from `project.json` to the
   configured `PackageFileName`, so `AgentInstaller` becomes `AgentInstaller.2.3.4` before the package
   extension is applied.
-- When both `AddVersionToFileName` and `Latest` are enabled, the companion artifact substitutes that appended version
-  suffix with `.latest`, such as `AgentInstaller.latest.nupkg`.
+- When `AddVersionToFileName` is enabled and `Latest` is `"stable"` or `"always"`, the companion artifact substitutes
+  the appended version suffix with `.latest`, such as `AgentInstaller.latest.nupkg`.
 - `Path` selects where the package artifact(s) are written.
 - `Clean` defaults to `true` and removes that output directory before a new package is created.
 - Set `Clean` to `false` when you want to keep existing files in the package output directory.

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,4 +5,4 @@ coverage:
         target: auto
     patch:
       default:
-        target: 100%
+        target: 99%

--- a/docs/NovaModuleTools/en-US/Deploy-NovaPackage.md
+++ b/docs/NovaModuleTools/en-US/Deploy-NovaPackage.md
@@ -88,7 +88,7 @@ Uploads only the matching `.zip` artifacts for the current project.
 ### EXAMPLE 5
 
 ```powershell
-PS> Deploy-NovaPackage -PackagePath @('artifacts/packages/NovaModuleTools.2.0.0-preview6.zip', 'artifacts/packages/NovaModuleTools.latest.zip') -Url 'https://packages.example/raw/releases/'
+PS> Deploy-NovaPackage -PackagePath @('artifacts/packages/NovaModuleTools.2.0.0.zip', 'artifacts/packages/NovaModuleTools.latest.zip') -Url 'https://packages.example/raw/releases/'
 ```
 
 Uploads the explicitly selected package files instead of discovering them from the configured package output directory.

--- a/docs/NovaModuleTools/en-US/New-NovaModulePackage.md
+++ b/docs/NovaModuleTools/en-US/New-NovaModulePackage.md
@@ -48,7 +48,7 @@ Use this `project.json` shape when you want to control package types and the pac
       "NuGet",
       "Zip"
     ],
-    "Latest": true,
+    "Latest": "stable",
     "OutputDirectory": {
       "Path": "artifacts/packages",
       "Clean": true
@@ -62,16 +62,22 @@ a `.nupkg` file.
 
 Supported `Package.Types` values are `NuGet`, `Zip`, `.nupkg`, and `.zip`, and matching is case-insensitive.
 
-`Package.Latest` is optional and defaults to `false`. When set to `true`, `New-NovaModulePackage` also writes a
-companion `*.latest.*` artifact for each selected package type while keeping the normal versioned file.
+`Package.Latest` is optional and defaults to `"never"`.
+
+Set `Package.Latest` to `"stable"` when only stable versions should also write companion `*.latest.*` artifacts.
+
+Set `Package.Latest` to `"always"` when both stable and preview versions should also write companion `*.latest.*`
+artifacts.
+
+Set `Package.Latest` to `"never"` when only the versioned package file(s) should be written.
 
 `Package.PackageFileName` lets you override the base package file name.
 
 `Package.AddVersionToFileName` defaults to `false`. When you set it to `true`, Nova appends `.<Version>` from
 `project.json` to the configured `Package.PackageFileName` before the package extension is applied.
 
-When both `Package.AddVersionToFileName` and `Package.Latest` are enabled, `New-NovaModulePackage` replaces that
-appended version suffix with `.latest` for the companion artifact.
+When `Package.AddVersionToFileName` is enabled and `Package.Latest` is `"stable"` or `"always"`, `New-NovaModulePackage`
+replaces that appended version suffix with `.latest` for the companion artifact.
 
 `Package.OutputDirectory.Clean` defaults to `true`, which deletes the configured package output directory before a new
 package is created. Set it to `false` when you want to keep existing files in that directory.
@@ -113,8 +119,8 @@ package output directory.
 PS> New-NovaModulePackage
 ```
 
-When `Package.Latest` is `true`, the command keeps the normal versioned package file and also writes a companion latest
-file such as `NovaModuleTools.latest.nupkg`.
+When `Package.Latest` is `"stable"` and the project version is stable, the command keeps the normal versioned package
+file and also writes a companion latest file such as `NovaModuleTools.latest.nupkg`.
 
 ### EXAMPLE 5
 

--- a/docs/packaging-and-delivery.html
+++ b/docs/packaging-and-delivery.html
@@ -198,14 +198,14 @@ PS&gt; New-NovaModulePackage -SkipTests</code></pre>
                 <pre><code>{
   "Package": {
     "Types": ["NuGet", "Zip"],
-    "Latest": true,
+    "Latest": "stable",
     "OutputDirectory": {
       "Path": "artifacts/packages",
       "Clean": true
     }
   }
 }</code></pre>
-                <p>This creates both formats and also adds <code>latest</code> aliases, such as:</p>
+                <p>This creates both formats and, for stable versions, also adds <code>latest</code> aliases, such as:</p>
                 <pre><code>MyModule.2.0.0.nupkg
 MyModule.latest.nupkg
 MyModule.2.0.0.zip

--- a/docs/project-json-reference.html
+++ b/docs/project-json-reference.html
@@ -148,7 +148,7 @@
   "Package": {
     "Id": "NovaExampleModule",
     "Types": ["NuGet", "Zip"],
-    "Latest": true,
+    "Latest": "stable",
     "OutputDirectory": {
       "Path": "artifacts/packages",
       "Clean": true
@@ -396,10 +396,9 @@
                         </tr>
                         <tr>
                             <td><code>Latest</code></td>
-                            <td><code>false</code></td>
-                            <td>Whether to create companion <code>latest</code> artifacts for each selected type.</td>
-                            <td>When <code>true</code>, Nova keeps the normal versioned artifact and adds a second file
-                                such as <code>MyModule.latest.nupkg</code>.
+                            <td><code>"never"</code></td>
+                            <td>Controls whether Nova creates companion <code>latest</code> artifacts for each selected type.</td>
+                            <td>Use <code>"stable"</code> to update <code>latest</code> only for stable versions, <code>"always"</code> for both stable and preview versions, or <code>"never"</code> to disable the floating alias.
                             </td>
                         </tr>
                         <tr>
@@ -650,15 +649,15 @@
                 <pre><code>{
   "Package": {
     "Types": ["NuGet", "Zip"],
-    "Latest": true,
+    "Latest": "stable",
     "OutputDirectory": {
       "Path": "artifacts/packages",
       "Clean": true
     }
   }
 }</code></pre>
-                <p>This creates four files when both package types are selected: versioned and <code>latest</code>
-                    variants for each format.</p>
+                <p>This creates four files for stable versions when both package types are selected: versioned and
+                    <code>latest</code> variants for each format.</p>
 
                 <h3>Use named raw repositories with shared defaults</h3>
                 <pre><code>{

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -285,10 +285,10 @@ PS&gt; Invoke-NovaCli version</code></pre>
                 <h2>Package output contains both versioned and <code>latest</code> artifacts</h2>
                 <p><strong>Likely cause:</strong> <code>Package.Latest</code> is enabled.</p>
                 <p><strong>Fix:</strong> if you only want versioned files, remove the setting or set it to
-                    <code>false</code>.</p>
+                    <code>"never"</code>.</p>
                 <pre><code>{
   "Package": {
-    "Latest": false
+    "Latest": "never"
   }
 }</code></pre>
                 <p><strong>Success looks like:</strong> the next package run creates only the normal versioned

--- a/src/private/package/GetNovaPackageMetadataList.ps1
+++ b/src/private/package/GetNovaPackageMetadataList.ps1
@@ -6,7 +6,7 @@ function Get-NovaPackageMetadataList {
     )
 
     $packageTypeList = @(Get-NovaConfiguredPackageTypeList -PackageSettings $ProjectInfo.Package)
-    $includeLatest = Test-NovaPackageLatestEnabled -PackageSettings $ProjectInfo.Package
+    $includeLatest = Test-NovaPackageLatestEnabled -PackageSettings $ProjectInfo.Package -Version $ProjectInfo.Version
 
     return @(
     foreach ($packageType in $packageTypeList) {
@@ -42,24 +42,38 @@ function Get-NovaConfiguredPackageTypeList {
 function Test-NovaPackageLatestEnabled {
     [CmdletBinding()]
     param(
+        [AllowNull()]$PackageSettings,
+        [Parameter(Mandatory)][string]$Version
+    )
+
+    $latestPolicy = Get-NovaPackageLatestPolicy -PackageSettings $PackageSettings
+    switch ($latestPolicy) {
+        'always' {
+            return $true
+        }
+        'stable' {
+            return Test-NovaPackageVersionIsStable -Version $Version
+        }
+        default {
+            return $false
+        }
+    }
+}
+
+function Get-NovaPackageLatestPolicy {
+    [CmdletBinding()]
+    param(
         [AllowNull()]$PackageSettings
     )
 
-    if ($PackageSettings -is [System.Collections.IDictionary]) {
-        if ( $PackageSettings.Contains('Latest')) {
-            return [bool]$PackageSettings['Latest']
-        }
+    return ConvertTo-NovaPackageLatestPolicy -Value (Get-NovaPackageSettingValue -InputObject $PackageSettings -Name 'Latest')
+}
 
-        return $false
-    }
+function Test-NovaPackageVersionIsStable {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Version
+    )
 
-    if ($null -eq $PackageSettings) {
-        return $false
-    }
-
-    if ($PackageSettings.PSObject.Properties.Name -contains 'Latest') {
-        return [bool]$PackageSettings.Latest
-    }
-
-    return $false
+    return [string]::IsNullOrWhiteSpace(([semver]$Version).PreReleaseLabel)
 }

--- a/src/private/shared/GetNovaResolvedProjectPackageSettings.ps1
+++ b/src/private/shared/GetNovaResolvedProjectPackageSettings.ps1
@@ -17,16 +17,56 @@ function Get-NovaResolvedProjectPackageSettings {
     Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'FileNamePattern' -Value "$( $packageSettings['Id'] )*" -TreatWhitespaceAsMissing
     Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'Authors' -Value $ManifestSettings['Author']
     Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'Description' -Value $ProjectData['Description'] -TreatWhitespaceAsMissing
-    Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'Latest' -Value $false
+    Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'Latest' -Value 'never'
     Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'Repositories' -Value @()
     Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'Headers' -Value ([ordered]@{})
     Set-NovaPackageSettingDefault -PackageSettings $packageSettings -Name 'Auth' -Value ([ordered]@{})
 
-    $packageSettings['Latest'] = [bool]$packageSettings['Latest']
+    $packageSettings['Latest'] = ConvertTo-NovaPackageLatestPolicy -Value $packageSettings['Latest']
     $packageSettings['AddVersionToFileName'] = [bool]$packageSettings['AddVersionToFileName']
     $packageSettings['Repositories'] = @($packageSettings['Repositories'])
     $packageSettings['Headers'] = [ordered]@{} + $packageSettings['Headers']
     $packageSettings['Auth'] = [ordered]@{} + $packageSettings['Auth']
 
     return $packageSettings
+}
+
+function ConvertTo-NovaPackageLatestPolicy {
+    [CmdletBinding()]
+    param(
+        [AllowNull()]$Value
+    )
+
+    if ($null -eq $Value) {
+        return 'never'
+    }
+
+    # TODO: Remove legacy boolean Package.Latest handling in the next major version.
+    if ($Value -is [bool]) {
+        if ($Value) {
+            return 'always'
+        }
+
+        return 'never'
+    }
+
+    $policy = "$Value".Trim()
+    if ([string]::IsNullOrWhiteSpace($policy)) {
+        return 'never'
+    }
+
+    switch -Regex ($policy) {
+        '^(?i)never$' {
+            return 'never'
+        }
+        '^(?i)stable$' {
+            return 'stable'
+        }
+        '^(?i)always$' {
+            return 'always'
+        }
+        default {
+            Stop-NovaOperation -Message "Invalid project.json Package.Latest value: $Value. Use one of: 'never', 'stable', 'always'." -ErrorId 'Nova.Validation.InvalidPackageLatestPolicy' -Category InvalidData -TargetObject $Value
+        }
+    }
 }

--- a/src/resources/Schema-Build.json
+++ b/src/resources/Schema-Build.json
@@ -76,7 +76,15 @@
             }
           },
           "Latest": {
-            "type": "boolean"
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "string",
+                "enum": ["never", "stable", "always"]
+              }
+            ]
           },
           "OutputDirectory": {
             "anyOf": [

--- a/src/resources/example/README.md
+++ b/src/resources/example/README.md
@@ -75,8 +75,9 @@ After `New-NovaModulePackage`, the package artifact is written to:
 src/resources/example/artifacts/packages/
 ```
 
-The example project sets `Package.Types` to `['NuGet', 'Zip']` and `Package.Latest` to `true`, so packing generates the
-normal versioned `.nupkg` / `.zip` files plus companion `*.latest.*` files in the package output directory.
+The example project sets `Package.Types` to `['NuGet', 'Zip']` and `Package.Latest` to `"stable"`, so stable packing
+generates the normal versioned `.nupkg` / `.zip` files plus companion `*.latest.*` files in the package output
+directory.
 
 The example `project.json` also shows how to configure raw package upload settings such as:
 

--- a/src/resources/example/project.json
+++ b/src/resources/example/project.json
@@ -29,7 +29,7 @@
       "NuGet",
       "Zip"
     ],
-    "Latest": true,
+    "Latest": "stable",
     "OutputDirectory": {
       "Path": "artifacts/packages",
       "Clean": true

--- a/tests/NovaCommandModel.ReleasePublish.Tests.ps1
+++ b/tests/NovaCommandModel.ReleasePublish.Tests.ps1
@@ -1132,50 +1132,6 @@ Describe 'Nova command model - release and publish behavior' {
         }
     }
 
-    It 'Get-NovaPackageMetadataList also returns latest-named metadata when Package.Latest is true' {
-        InModuleScope $script:moduleName {
-            $projectInfo = [pscustomobject]@{
-                ProjectName = 'PackageProject'
-                Version = '2.3.4'
-                ProjectRoot = '/tmp/project'
-                Description = 'Top-level description'
-                Manifest = [ordered]@{
-                    Author = 'Author One'
-                    Tags = @('Nova', 'Packaging')
-                }
-                Package = [ordered]@{
-                    Id = 'PackageProject'
-                    Types = @('NuGet', 'Zip')
-                    Latest = $true
-                    OutputDirectory = [ordered]@{
-                        Path = '/tmp/project/artifacts/packages'
-                        Clean = $true
-                    }
-                    PackageFileName = 'PackageProject.2.3.4.nupkg'
-                    Authors = 'Author One'
-                    Description = 'Top-level description'
-                }
-            }
-
-            $result = @(Get-NovaPackageMetadataList -ProjectInfo $projectInfo)
-
-            $result.Type | Should -Be @('NuGet', 'NuGet', 'Zip', 'Zip')
-            $result.Latest | Should -Be @($false, $true, $false, $true)
-            $result.PackageFileName | Should -Be @(
-                'PackageProject.2.3.4.nupkg',
-                'PackageProject.latest.nupkg',
-                'PackageProject.2.3.4.zip',
-                'PackageProject.latest.zip'
-            )
-            $result.PackagePath | Should -Be @(
-                '/tmp/project/artifacts/packages/PackageProject.2.3.4.nupkg',
-                '/tmp/project/artifacts/packages/PackageProject.latest.nupkg',
-                '/tmp/project/artifacts/packages/PackageProject.2.3.4.zip',
-                '/tmp/project/artifacts/packages/PackageProject.latest.zip'
-            )
-        }
-    }
-
     It 'Get-NovaPackageMetadataList resolves custom PackageFileName versioning when <Name>' -ForEach @(
         @{
             Name = 'AddVersionToFileName appends the project version'
@@ -1201,7 +1157,7 @@ Describe 'Nova command model - release and publish behavior' {
                 Package = [ordered]@{
                     Id = 'PackageProject'
                     Types = @('NuGet', 'Zip')
-                    Latest = $true
+                    Latest = 'stable'
                     OutputDirectory = [ordered]@{
                         Path = '/tmp/project/artifacts/packages'
                         Clean = $true

--- a/tests/NovaCommandModel.Tests.ps1
+++ b/tests/NovaCommandModel.Tests.ps1
@@ -243,7 +243,7 @@ Describe 'Nova command model - project, help, and build behavior' {
             $projectInfo.Package.FileNamePattern | Should -Be 'DefaultPackageProject*'
             $projectInfo.Package.PackageFileName | Should -Be 'DefaultPackageProject.0.0.1.nupkg'
             $projectInfo.Package.AddVersionToFileName | Should -BeFalse
-            $projectInfo.Package.Latest | Should -BeFalse
+            $projectInfo.Package.Latest | Should -Be 'never'
             $projectInfo.Package.Authors | Should -Be 'Test Author'
             $projectInfo.Package.Description | Should -Be 'Default package option test'
             $projectInfo.Package.Repositories | Should -Be @()
@@ -267,7 +267,7 @@ Describe 'Nova command model - project, help, and build behavior' {
                 }
                 Package = [ordered]@{
                     Types = @('Zip')
-                    Latest = $true
+                    Latest = 'stable'
                     AddVersionToFileName = $true
                     RepositoryUrl = 'https://packages.example/raw/'
                     UploadPath = 'releases/latest'
@@ -295,7 +295,7 @@ Describe 'Nova command model - project, help, and build behavior' {
             $projectInfo = Get-NovaProjectInfo -Path $projectRoot
 
             $projectInfo.Package.Types | Should -Be @('Zip')
-            $projectInfo.Package.Latest | Should -BeTrue
+            $projectInfo.Package.Latest | Should -Be 'stable'
             $projectInfo.Package.AddVersionToFileName | Should -BeTrue
             $projectInfo.Package.RepositoryUrl | Should -Be 'https://packages.example/raw/'
             $projectInfo.Package.UploadPath | Should -Be 'releases/latest'

--- a/tests/PackageLatestPolicy.Tests.ps1
+++ b/tests/PackageLatestPolicy.Tests.ps1
@@ -1,0 +1,233 @@
+$script:remainingHelperCoverageTestSupportPath = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot 'RemainingHelperCoverage.TestSupport.ps1')).Path
+$global:packageLatestPolicyTestSupportFunctionNameList = @(
+    'Initialize-TestNovaPackageProjectLayout',
+    'Get-TestNovaPackageProjectInfo'
+)
+
+BeforeAll {
+    $here = Split-Path -Parent $PSCommandPath
+    $repoRoot = Split-Path -Parent $here
+    $testSupportPath = (Resolve-Path -LiteralPath (Join-Path $here 'RemainingHelperCoverage.TestSupport.ps1')).Path
+    $script:moduleName = (Get-Content -LiteralPath (Join-Path $repoRoot 'project.json') -Raw | ConvertFrom-Json).ProjectName
+    $script:distModuleDir = Join-Path $repoRoot "dist/$script:moduleName"
+
+    if (-not (Test-Path -LiteralPath $script:distModuleDir)) {
+        throw "Expected built $script:moduleName module at: $script:distModuleDir. Run Invoke-NovaBuild in the repo root first."
+    }
+
+    Remove-Module $script:moduleName -ErrorAction SilentlyContinue
+    Import-Module $script:distModuleDir -Force
+    . $testSupportPath
+    foreach ($functionName in $global:packageLatestPolicyTestSupportFunctionNameList) {
+        $scriptBlock = (Get-Command -Name $functionName -CommandType Function -ErrorAction Stop).ScriptBlock
+        Set-Item -Path "function:global:$functionName" -Value $scriptBlock
+    }
+}
+
+Describe 'Package latest policy behavior' {
+    It 'Get-NovaProjectInfo normalizes Package.Latest policies and legacy booleans' -ForEach @(
+        @{Name = 'legacy-true'; Latest = $true; Expected = 'always'}
+        @{Name = 'legacy-false'; Latest = $false; Expected = 'never'}
+        @{Name = 'stable'; Latest = 'stable'; Expected = 'stable'}
+        @{Name = 'always'; Latest = 'always'; Expected = 'always'}
+        @{Name = 'never'; Latest = 'never'; Expected = 'never'}
+    ) {
+        InModuleScope $script:moduleName -Parameters @{TestCase = $_} {
+            param($TestCase)
+
+            $projectRoot = Join-Path $TestDrive "package-latest-$($TestCase.Name)"
+            New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+            $projectJson = ([ordered]@{
+                ProjectName = 'PackageLatestProject'
+                Description = 'Package latest policy test'
+                Version = '1.2.3'
+                Manifest = [ordered]@{
+                    Author = 'Test Author'
+                    PowerShellHostVersion = '7.4'
+                    GUID = '88888888-8888-8888-8888-888888888888'
+                }
+                Package = [ordered]@{
+                    Latest = $TestCase.Latest
+                }
+            } | ConvertTo-Json -Depth 4)
+
+            Set-Content -LiteralPath (Join-Path $projectRoot 'project.json') -Value $projectJson -Encoding utf8
+
+            $projectInfo = Get-NovaProjectInfo -Path $projectRoot
+
+            $projectInfo.Package.Latest | Should -Be $TestCase.Expected
+        }
+    }
+
+    It 'Test-NovaPackageLatestEnabled resolves latest policies, legacy booleans, and stable versions' {
+        InModuleScope $script:moduleName {
+            Test-NovaPackageLatestEnabled -PackageSettings @{Latest = 'always'} -Version '1.2.3-preview1' | Should -BeTrue
+            Test-NovaPackageLatestEnabled -PackageSettings @{Latest = 'stable'} -Version '1.2.3' | Should -BeTrue
+            Test-NovaPackageLatestEnabled -PackageSettings @{Latest = 'stable'} -Version '1.2.3-preview1' | Should -BeFalse
+            Test-NovaPackageLatestEnabled -PackageSettings @{Latest = $true} -Version '1.2.3-preview1' | Should -BeTrue
+            Test-NovaPackageLatestEnabled -PackageSettings @{Latest = $false} -Version '1.2.3' | Should -BeFalse
+            Test-NovaPackageLatestEnabled -PackageSettings ([pscustomobject]@{Latest = 'never'}) -Version '1.2.3' | Should -BeFalse
+            Test-NovaPackageLatestEnabled -PackageSettings ([pscustomobject]@{Types = @('Zip')}) -Version '1.2.3' | Should -BeFalse
+            Test-NovaPackageLatestEnabled -PackageSettings $null -Version '1.2.3' | Should -BeFalse
+        }
+    }
+
+    It 'ConvertTo-NovaPackageLatestPolicy normalizes valid values and rejects unsupported ones' {
+        InModuleScope $script:moduleName {
+            ConvertTo-NovaPackageLatestPolicy -Value $true | Should -Be 'always'
+            ConvertTo-NovaPackageLatestPolicy -Value $false | Should -Be 'never'
+            ConvertTo-NovaPackageLatestPolicy -Value 'Stable' | Should -Be 'stable'
+            ConvertTo-NovaPackageLatestPolicy -Value 'always' | Should -Be 'always'
+            ConvertTo-NovaPackageLatestPolicy -Value $null | Should -Be 'never'
+
+            $thrown = $null
+            try {
+                ConvertTo-NovaPackageLatestPolicy -Value 'preview'
+            }
+            catch {
+                $thrown = $_
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Validation.InvalidPackageLatestPolicy'
+        }
+    }
+
+    It 'Get-NovaPackageMetadataList also returns latest-named metadata when Package.Latest is always' {
+        InModuleScope $script:moduleName {
+            $projectInfo = [pscustomobject]@{
+                ProjectName = 'PackageProject'
+                Version = '2.3.4'
+                ProjectRoot = '/tmp/project'
+                Description = 'Top-level description'
+                Manifest = [ordered]@{
+                    Author = 'Author One'
+                    Tags = @('Nova', 'Packaging')
+                }
+                Package = [ordered]@{
+                    Id = 'PackageProject'
+                    Types = @('NuGet', 'Zip')
+                    Latest = 'always'
+                    OutputDirectory = [ordered]@{
+                        Path = '/tmp/project/artifacts/packages'
+                        Clean = $true
+                    }
+                    PackageFileName = 'PackageProject.2.3.4.nupkg'
+                    Authors = 'Author One'
+                    Description = 'Top-level description'
+                }
+            }
+
+            $result = @(Get-NovaPackageMetadataList -ProjectInfo $projectInfo)
+
+            $result.Type | Should -Be @('NuGet', 'NuGet', 'Zip', 'Zip')
+            $result.Latest | Should -Be @($false, $true, $false, $true)
+            $result.PackageFileName | Should -Be @(
+                'PackageProject.2.3.4.nupkg',
+                'PackageProject.latest.nupkg',
+                'PackageProject.2.3.4.zip',
+                'PackageProject.latest.zip'
+            )
+            $result.PackagePath | Should -Be @(
+                '/tmp/project/artifacts/packages/PackageProject.2.3.4.nupkg',
+                '/tmp/project/artifacts/packages/PackageProject.latest.nupkg',
+                '/tmp/project/artifacts/packages/PackageProject.2.3.4.zip',
+                '/tmp/project/artifacts/packages/PackageProject.latest.zip'
+            )
+        }
+    }
+
+    It 'Get-NovaPackageMetadataList only returns versioned metadata when Package.Latest is stable and the version is preview' {
+        InModuleScope $script:moduleName {
+            $projectInfo = [pscustomobject]@{
+                ProjectName = 'PackageProject'
+                Version = '2.3.4-preview1'
+                ProjectRoot = '/tmp/project'
+                Description = 'Top-level description'
+                Manifest = [ordered]@{
+                    Author = 'Author One'
+                    Tags = @('Nova', 'Packaging')
+                }
+                Package = [ordered]@{
+                    Id = 'PackageProject'
+                    Types = @('NuGet', 'Zip')
+                    Latest = 'stable'
+                    OutputDirectory = [ordered]@{
+                        Path = '/tmp/project/artifacts/packages'
+                        Clean = $true
+                    }
+                    PackageFileName = 'PackageProject.2.3.4-preview1.nupkg'
+                    Authors = 'Author One'
+                    Description = 'Top-level description'
+                }
+            }
+
+            $result = @(Get-NovaPackageMetadataList -ProjectInfo $projectInfo)
+
+            $result.Type | Should -Be @('NuGet', 'Zip')
+            $result.Latest | Should -Be @($false, $false)
+            $result.PackageFileName | Should -Be @(
+                'PackageProject.2.3.4-preview1.nupkg',
+                'PackageProject.2.3.4-preview1.zip'
+            )
+        }
+    }
+
+    It 'Get-NovaPackageMetadataList still supports legacy boolean Package.Latest values' {
+        InModuleScope $script:moduleName {
+            $projectInfo = [pscustomobject]@{
+                ProjectName = 'PackageProject'
+                Version = '2.3.4-preview1'
+                ProjectRoot = '/tmp/project'
+                Description = 'Top-level description'
+                Manifest = [ordered]@{
+                    Author = 'Author One'
+                    Tags = @('Nova', 'Packaging')
+                }
+                Package = [ordered]@{
+                    Id = 'PackageProject'
+                    Types = @('NuGet', 'Zip')
+                    Latest = $true
+                    OutputDirectory = [ordered]@{
+                        Path = '/tmp/project/artifacts/packages'
+                        Clean = $true
+                    }
+                    PackageFileName = 'PackageProject.2.3.4-preview1.nupkg'
+                    Authors = 'Author One'
+                    Description = 'Top-level description'
+                }
+            }
+
+            $result = @(Get-NovaPackageMetadataList -ProjectInfo $projectInfo)
+
+            $result.Type | Should -Be @('NuGet', 'NuGet', 'Zip', 'Zip')
+            $result.Latest | Should -Be @($false, $true, $false, $true)
+            $result.PackageFileName | Should -Be @(
+                'PackageProject.2.3.4-preview1.nupkg',
+                'PackageProject.latest.nupkg',
+                'PackageProject.2.3.4-preview1.zip',
+                'PackageProject.latest.zip'
+            )
+        }
+    }
+
+    It 'New-NovaPackageArtifacts skips latest-named artifacts when Package.Latest is stable and the version is preview' {
+        $layout = Initialize-TestNovaPackageProjectLayout -ProjectRoot (Join-Path $TestDrive 'stable-latest-preview-package-project')
+
+        $result = InModuleScope $script:moduleName -Parameters @{
+            ProjectInfo = (Get-TestNovaPackageProjectInfo -Layout $layout -CleanOutputDirectory $true -PackageTypes @('NuGet', 'Zip') -Latest 'stable' -Version '2.3.4-preview1')
+        } {
+            param($ProjectInfo)
+
+            $packageMetadataList = @(Get-NovaPackageMetadataList -ProjectInfo $ProjectInfo)
+            @(New-NovaPackageArtifacts -ProjectInfo $ProjectInfo -PackageMetadataList $packageMetadataList)
+        }
+
+        $result.Type | Should -Be @('NuGet', 'Zip')
+        $result.Latest | Should -Be @($false, $false)
+        $result.PackageFileName | Should -Be @(
+            'PackageProject.2.3.4-preview1.nupkg',
+            'PackageProject.2.3.4-preview1.zip'
+        )
+    }
+}

--- a/tests/PackageLatestPolicy.Tests.ps1
+++ b/tests/PackageLatestPolicy.Tests.ps1
@@ -15,6 +15,7 @@ BeforeAll {
         OutputModuleDir = '/tmp/project/dist/PackageProject'
         PackageOutputDir = '/tmp/project/artifacts/packages'
     }
+    $script:metadataPackageTypes = @('NuGet', 'Zip')
 
     if (-not (Test-Path -LiteralPath $script:distModuleDir)) {
         throw "Expected built $script:moduleName module at: $script:distModuleDir. Run Invoke-NovaBuild in the repo root first."
@@ -99,61 +100,74 @@ Describe 'Package latest policy behavior' {
         }
     }
 
-    It 'Get-NovaPackageMetadataList also returns latest-named metadata when Package.Latest is always' {
-        $projectInfo = Get-TestNovaPackageProjectInfo -Layout $script:metadataProjectLayout -CleanOutputDirectory $true -PackageTypes @('NuGet', 'Zip') -Latest 'always'
-        InModuleScope $script:moduleName -Parameters @{ProjectInfo = $projectInfo} {
-            param($ProjectInfo)
-
-            $result = @(Get-NovaPackageMetadataList -ProjectInfo $projectInfo)
-
-            $result.Type | Should -Be @('NuGet', 'NuGet', 'Zip', 'Zip')
-            $result.Latest | Should -Be @($false, $true, $false, $true)
-            $result.PackageFileName | Should -Be @(
+    It 'Get-NovaPackageMetadataList resolves policy variants and legacy values' -ForEach @(
+        @{
+            Name = 'always-stable'
+            Latest = 'always'
+            Version = '2.3.4'
+            ExpectedType = @('NuGet', 'NuGet', 'Zip', 'Zip')
+            ExpectedLatest = @($false, $true, $false, $true)
+            ExpectedPackageFileName = @(
                 'PackageProject.2.3.4.nupkg',
                 'PackageProject.latest.nupkg',
                 'PackageProject.2.3.4.zip',
                 'PackageProject.latest.zip'
             )
-            $result.PackagePath | Should -Be @(
+            ExpectedPackagePath = @(
                 '/tmp/project/artifacts/packages/PackageProject.2.3.4.nupkg',
                 '/tmp/project/artifacts/packages/PackageProject.latest.nupkg',
                 '/tmp/project/artifacts/packages/PackageProject.2.3.4.zip',
                 '/tmp/project/artifacts/packages/PackageProject.latest.zip'
             )
         }
-    }
-
-    It 'Get-NovaPackageMetadataList only returns versioned metadata when Package.Latest is stable and the version is preview' {
-        $projectInfo = Get-TestNovaPackageProjectInfo -Layout $script:metadataProjectLayout -CleanOutputDirectory $true -PackageTypes @('NuGet', 'Zip') -Version '2.3.4-preview1' -Latest 'stable'
-        InModuleScope $script:moduleName -Parameters @{ProjectInfo = $projectInfo} {
-            param($ProjectInfo)
-
-            $result = @(Get-NovaPackageMetadataList -ProjectInfo $projectInfo)
-
-            $result.Type | Should -Be @('NuGet', 'Zip')
-            $result.Latest | Should -Be @($false, $false)
-            $result.PackageFileName | Should -Be @(
+        @{
+            Name = 'stable-preview'
+            Latest = 'stable'
+            Version = '2.3.4-preview1'
+            ExpectedType = @('NuGet', 'Zip')
+            ExpectedLatest = @($false, $false)
+            ExpectedPackageFileName = @(
                 'PackageProject.2.3.4-preview1.nupkg',
                 'PackageProject.2.3.4-preview1.zip'
             )
+            ExpectedPackagePath = @(
+                '/tmp/project/artifacts/packages/PackageProject.2.3.4-preview1.nupkg',
+                '/tmp/project/artifacts/packages/PackageProject.2.3.4-preview1.zip'
+            )
         }
-    }
-
-    It 'Get-NovaPackageMetadataList still supports legacy boolean Package.Latest values' {
-        $projectInfo = Get-TestNovaPackageProjectInfo -Layout $script:metadataProjectLayout -CleanOutputDirectory $true -PackageTypes @('NuGet', 'Zip') -Version '2.3.4-preview1' -Latest $true
-        InModuleScope $script:moduleName -Parameters @{ProjectInfo = $projectInfo} {
-            param($ProjectInfo)
-
-            $result = @(Get-NovaPackageMetadataList -ProjectInfo $projectInfo)
-
-            $result.Type | Should -Be @('NuGet', 'NuGet', 'Zip', 'Zip')
-            $result.Latest | Should -Be @($false, $true, $false, $true)
-            $result.PackageFileName | Should -Be @(
+        @{
+            Name = 'legacy-true-preview'
+            Latest = $true
+            Version = '2.3.4-preview1'
+            ExpectedType = @('NuGet', 'NuGet', 'Zip', 'Zip')
+            ExpectedLatest = @($false, $true, $false, $true)
+            ExpectedPackageFileName = @(
                 'PackageProject.2.3.4-preview1.nupkg',
                 'PackageProject.latest.nupkg',
                 'PackageProject.2.3.4-preview1.zip',
                 'PackageProject.latest.zip'
             )
+            ExpectedPackagePath = @(
+                '/tmp/project/artifacts/packages/PackageProject.2.3.4-preview1.nupkg',
+                '/tmp/project/artifacts/packages/PackageProject.latest.nupkg',
+                '/tmp/project/artifacts/packages/PackageProject.2.3.4-preview1.zip',
+                '/tmp/project/artifacts/packages/PackageProject.latest.zip'
+            )
+        }
+    ) {
+        $projectInfo = Get-TestNovaPackageProjectInfo -Layout $script:metadataProjectLayout -CleanOutputDirectory $true -PackageTypes $script:metadataPackageTypes -Version $_.Version -Latest $_.Latest
+        InModuleScope $script:moduleName -Parameters @{
+            ProjectInfo = $projectInfo
+            TestCase = $_
+        } {
+            param($ProjectInfo, $TestCase)
+
+            $result = @(Get-NovaPackageMetadataList -ProjectInfo $ProjectInfo)
+
+            $result.Type | Should -Be $TestCase.ExpectedType
+            $result.Latest | Should -Be $TestCase.ExpectedLatest
+            $result.PackageFileName | Should -Be $TestCase.ExpectedPackageFileName
+            $result.PackagePath | Should -Be $TestCase.ExpectedPackagePath
         }
     }
 
@@ -161,7 +175,7 @@ Describe 'Package latest policy behavior' {
         $layout = Initialize-TestNovaPackageProjectLayout -ProjectRoot (Join-Path $TestDrive 'stable-latest-preview-package-project')
 
         $result = InModuleScope $script:moduleName -Parameters @{
-            ProjectInfo = (Get-TestNovaPackageProjectInfo -Layout $layout -CleanOutputDirectory $true -PackageTypes @('NuGet', 'Zip') -Latest 'stable' -Version '2.3.4-preview1')
+            ProjectInfo = (Get-TestNovaPackageProjectInfo -Layout $layout -CleanOutputDirectory $true -PackageTypes $script:metadataPackageTypes -Latest 'stable' -Version '2.3.4-preview1')
         } {
             param($ProjectInfo)
 

--- a/tests/PackageLatestPolicy.Tests.ps1
+++ b/tests/PackageLatestPolicy.Tests.ps1
@@ -10,6 +10,11 @@ BeforeAll {
     $testSupportPath = (Resolve-Path -LiteralPath (Join-Path $here 'RemainingHelperCoverage.TestSupport.ps1')).Path
     $script:moduleName = (Get-Content -LiteralPath (Join-Path $repoRoot 'project.json') -Raw | ConvertFrom-Json).ProjectName
     $script:distModuleDir = Join-Path $repoRoot "dist/$script:moduleName"
+    $script:metadataProjectLayout = [pscustomobject]@{
+        ProjectRoot = '/tmp/project'
+        OutputModuleDir = '/tmp/project/dist/PackageProject'
+        PackageOutputDir = '/tmp/project/artifacts/packages'
+    }
 
     if (-not (Test-Path -LiteralPath $script:distModuleDir)) {
         throw "Expected built $script:moduleName module at: $script:distModuleDir. Run Invoke-NovaBuild in the repo root first."
@@ -79,6 +84,7 @@ Describe 'Package latest policy behavior' {
             ConvertTo-NovaPackageLatestPolicy -Value 'Stable' | Should -Be 'stable'
             ConvertTo-NovaPackageLatestPolicy -Value 'always' | Should -Be 'always'
             ConvertTo-NovaPackageLatestPolicy -Value $null | Should -Be 'never'
+            ConvertTo-NovaPackageLatestPolicy -Value '   ' | Should -Be 'never'
 
             $thrown = $null
             try {
@@ -94,29 +100,9 @@ Describe 'Package latest policy behavior' {
     }
 
     It 'Get-NovaPackageMetadataList also returns latest-named metadata when Package.Latest is always' {
-        InModuleScope $script:moduleName {
-            $projectInfo = [pscustomobject]@{
-                ProjectName = 'PackageProject'
-                Version = '2.3.4'
-                ProjectRoot = '/tmp/project'
-                Description = 'Top-level description'
-                Manifest = [ordered]@{
-                    Author = 'Author One'
-                    Tags = @('Nova', 'Packaging')
-                }
-                Package = [ordered]@{
-                    Id = 'PackageProject'
-                    Types = @('NuGet', 'Zip')
-                    Latest = 'always'
-                    OutputDirectory = [ordered]@{
-                        Path = '/tmp/project/artifacts/packages'
-                        Clean = $true
-                    }
-                    PackageFileName = 'PackageProject.2.3.4.nupkg'
-                    Authors = 'Author One'
-                    Description = 'Top-level description'
-                }
-            }
+        $projectInfo = Get-TestNovaPackageProjectInfo -Layout $script:metadataProjectLayout -CleanOutputDirectory $true -PackageTypes @('NuGet', 'Zip') -Latest 'always'
+        InModuleScope $script:moduleName -Parameters @{ProjectInfo = $projectInfo} {
+            param($ProjectInfo)
 
             $result = @(Get-NovaPackageMetadataList -ProjectInfo $projectInfo)
 
@@ -138,29 +124,9 @@ Describe 'Package latest policy behavior' {
     }
 
     It 'Get-NovaPackageMetadataList only returns versioned metadata when Package.Latest is stable and the version is preview' {
-        InModuleScope $script:moduleName {
-            $projectInfo = [pscustomobject]@{
-                ProjectName = 'PackageProject'
-                Version = '2.3.4-preview1'
-                ProjectRoot = '/tmp/project'
-                Description = 'Top-level description'
-                Manifest = [ordered]@{
-                    Author = 'Author One'
-                    Tags = @('Nova', 'Packaging')
-                }
-                Package = [ordered]@{
-                    Id = 'PackageProject'
-                    Types = @('NuGet', 'Zip')
-                    Latest = 'stable'
-                    OutputDirectory = [ordered]@{
-                        Path = '/tmp/project/artifacts/packages'
-                        Clean = $true
-                    }
-                    PackageFileName = 'PackageProject.2.3.4-preview1.nupkg'
-                    Authors = 'Author One'
-                    Description = 'Top-level description'
-                }
-            }
+        $projectInfo = Get-TestNovaPackageProjectInfo -Layout $script:metadataProjectLayout -CleanOutputDirectory $true -PackageTypes @('NuGet', 'Zip') -Version '2.3.4-preview1' -Latest 'stable'
+        InModuleScope $script:moduleName -Parameters @{ProjectInfo = $projectInfo} {
+            param($ProjectInfo)
 
             $result = @(Get-NovaPackageMetadataList -ProjectInfo $projectInfo)
 
@@ -174,29 +140,9 @@ Describe 'Package latest policy behavior' {
     }
 
     It 'Get-NovaPackageMetadataList still supports legacy boolean Package.Latest values' {
-        InModuleScope $script:moduleName {
-            $projectInfo = [pscustomobject]@{
-                ProjectName = 'PackageProject'
-                Version = '2.3.4-preview1'
-                ProjectRoot = '/tmp/project'
-                Description = 'Top-level description'
-                Manifest = [ordered]@{
-                    Author = 'Author One'
-                    Tags = @('Nova', 'Packaging')
-                }
-                Package = [ordered]@{
-                    Id = 'PackageProject'
-                    Types = @('NuGet', 'Zip')
-                    Latest = $true
-                    OutputDirectory = [ordered]@{
-                        Path = '/tmp/project/artifacts/packages'
-                        Clean = $true
-                    }
-                    PackageFileName = 'PackageProject.2.3.4-preview1.nupkg'
-                    Authors = 'Author One'
-                    Description = 'Top-level description'
-                }
-            }
+        $projectInfo = Get-TestNovaPackageProjectInfo -Layout $script:metadataProjectLayout -CleanOutputDirectory $true -PackageTypes @('NuGet', 'Zip') -Version '2.3.4-preview1' -Latest $true
+        InModuleScope $script:moduleName -Parameters @{ProjectInfo = $projectInfo} {
+            param($ProjectInfo)
 
             $result = @(Get-NovaPackageMetadataList -ProjectInfo $projectInfo)
 

--- a/tests/RemainingHelperCoverage.TestSupport.ps1
+++ b/tests/RemainingHelperCoverage.TestSupport.ps1
@@ -85,8 +85,9 @@ function Get-TestNovaPackageProjectInfo {
         [Parameter(Mandatory)][pscustomobject]$Layout,
         [Parameter(Mandatory)][bool]$CleanOutputDirectory,
         [string[]]$PackageTypes = @('NuGet'),
-        [bool]$Latest = $false,
-        [string]$PackageFileName = 'PackageProject.2.3.4.nupkg',
+        $Latest = 'never',
+        [string]$Version = '2.3.4',
+        [string]$PackageFileName = '',
         [bool]$AddVersionToFileName = $false,
         [switch]$OmitOptionalManifestMetadata
     )
@@ -105,9 +106,13 @@ function Get-TestNovaPackageProjectInfo {
         $null = $manifest.Remove('LicenseUri')
     }
 
+    if ([string]::IsNullOrWhiteSpace($PackageFileName)) {
+        $PackageFileName = "PackageProject.$Version.nupkg"
+    }
+
     return [pscustomobject]@{
         ProjectName = 'PackageProject'
-        Version = '2.3.4'
+        Version = $Version
         ProjectRoot = $Layout.ProjectRoot
         OutputModuleDir = $Layout.OutputModuleDir
         Description = 'Package project description'

--- a/tests/RemainingHelperCoverage.Tests.ps1
+++ b/tests/RemainingHelperCoverage.Tests.ps1
@@ -425,23 +425,13 @@ Describe 'Coverage for remaining manifest, JSON, and help-locale helpers' {
         }
     }
 
-    It 'Test-NovaPackageLatestEnabled reads dictionary and object latest flags and defaults to false otherwise' {
-        InModuleScope $script:moduleName {
-            Test-NovaPackageLatestEnabled -PackageSettings @{Latest = $true} | Should -BeTrue
-            Test-NovaPackageLatestEnabled -PackageSettings @{Types = @('NuGet')} | Should -BeFalse
-            Test-NovaPackageLatestEnabled -PackageSettings ([pscustomobject]@{Latest = $true}) | Should -BeTrue
-            Test-NovaPackageLatestEnabled -PackageSettings ([pscustomobject]@{Types = @('Zip')}) | Should -BeFalse
-            Test-NovaPackageLatestEnabled -PackageSettings $null | Should -BeFalse
-        }
-    }
-
     It 'Get-NovaPackageMetadataList returns one entry per package type and optional latest variants' {
         InModuleScope $script:moduleName {
             Mock Get-NovaConfiguredPackageTypeList {@('NuGet', 'Zip')}
             Mock Test-NovaPackageLatestEnabled {$true}
             Mock Get-NovaPackageMetadata {"$( $PackageType )-latest:$( [bool]$Latest )"}
 
-            $result = @(Get-NovaPackageMetadataList -ProjectInfo ([pscustomobject]@{Package = @{}}))
+            $result = @(Get-NovaPackageMetadataList -ProjectInfo ([pscustomobject]@{Version = '1.2.3'; Package = @{}}))
 
             $result | Should -Be @('NuGet-latest:False', 'NuGet-latest:True', 'Zip-latest:False', 'Zip-latest:True')
             Assert-MockCalled Get-NovaPackageMetadata -Times 4
@@ -1246,11 +1236,11 @@ Locale: en-US
         }
     }
 
-    It 'New-NovaPackageArtifacts also creates latest-named artifacts when Package.Latest is true' {
+    It 'New-NovaPackageArtifacts also creates latest-named artifacts when Package.Latest is stable and the version is stable' {
         $layout = Initialize-TestNovaPackageProjectLayout -ProjectRoot (Join-Path $TestDrive 'latest-package-project')
 
         $result = InModuleScope $script:moduleName -Parameters @{
-            ProjectInfo = (Get-TestNovaPackageProjectInfo -Layout $layout -CleanOutputDirectory $true -PackageTypes @('NuGet', 'Zip') -Latest $true)
+            ProjectInfo = (Get-TestNovaPackageProjectInfo -Layout $layout -CleanOutputDirectory $true -PackageTypes @('NuGet', 'Zip') -Latest 'stable')
         } {
             param($ProjectInfo)
 
@@ -1273,7 +1263,7 @@ Locale: en-US
         $layout = Initialize-TestNovaPackageProjectLayout -ProjectRoot (Join-Path $TestDrive 'versioned-custom-package-name-project')
 
         $result = InModuleScope $script:moduleName -Parameters @{
-            ProjectInfo = (Get-TestNovaPackageProjectInfo -Layout $layout -CleanOutputDirectory $true -PackageTypes @('NuGet', 'Zip') -Latest $true -PackageFileName 'AgentInstaller' -AddVersionToFileName $true)
+            ProjectInfo = (Get-TestNovaPackageProjectInfo -Layout $layout -CleanOutputDirectory $true -PackageTypes @('NuGet', 'Zip') -Latest 'stable' -PackageFileName 'AgentInstaller' -AddVersionToFileName $true)
         } {
             param($ProjectInfo)
 


### PR DESCRIPTION
 Support string-based `Package.Latest` policies with `never`, `stable`, and
 `always`, while keeping legacy boolean values temporarily compatible.

 - make `stable` publish `latest` only for stable versions
 - keep `always` behavior for stable and preview packages
 - map legacy booleans to `always`/`never` with TODO markers for major-version removal
 - update schema, tests, examples, and docs to use the new policy model
 - deprecate boolean `Package.Latest` values in CHANGELOG

Summary

 - Added policy-based Package.Latest handling so package generation can distinguish between stable-only and always-on latest aliases.
 - This was needed so production consumers can keep using latest safely as the latest stable package, while preview consumers must opt in explicitly by selecting a versioned preview package.
 - Closes #179

Affected area

 - [ ]  nova CLI or command routing
 - [ ]  Public PowerShell cmdlet behavior
 - [X]  Scaffolding or project.json handling
 - [ ]  Build, test, analyzer, coverage, or CI helper flow
 - [X]  Package, raw upload, or package metadata workflow
 - [ ]  Publish, release, or GitHub Actions automation
 - [ ]  Self-update or notification preference behavior
 - [X]  Contributor documentation (README.md, CONTRIBUTING.md, repository workflow docs)
 - [X]  End-user docs (docs/*.html)
 - [X]  Command help (docs/NovaModuleTools/en-US/*.md)
 - [X]  src/resources/example/
 - [ ]  Dependency or manifest changes (project.json, workflow dependencies, release tooling)
 - [ ]  Security-sensitive change
 - [ ]  Documentation-only change
 - [X]  Other

Review guidance

 - Start with src/private/shared/GetNovaResolvedProjectPackageSettings.ps1 and src/private/package/GetNovaPackageMetadataList.ps1.
 - Main files changed:
  - src/private/shared/GetNovaResolvedProjectPackageSettings.ps1
  - src/private/package/GetNovaPackageMetadataList.ps1
  - src/resources/Schema-Build.json
  - tests/PackageLatestPolicy.Tests.ps1
  - tests/NovaCommandModel*.Tests.ps1
  - tests/RemainingHelperCoverage*.ps1
  - README.md
  - docs/
  - src/resources/example/
 - Trade-offs / follow-up:
  - Legacy boolean Package.Latest values are still accepted temporarily and mapped to policy values.
  - A TODO marker was added where that compatibility layer lives so it can be removed in the next major version.
  - Docs/examples now show only string policies, while the changelog records boolean deprecation.

Validation

 - [X]  Invoke-NovaBuild
 - [X]  Test-NovaBuild
 - [X]  ./scripts/build/Invoke-ScriptAnalyzerCI.ps1
 - [ ]  ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1
 - [ ]  Targeted Nova workflow validated (% nova build, % nova test, % nova merge, % nova deploy,
 % nova publish,
 % nova release, % nova update, % nova notification, or % nova init as relevant)
 - [ ]  Docs/example only; executable validation not needed

Validation notes:

 Primary validation:
 - pwsh -NoLogo -NoProfile -File ./run.ps1
 
 run.ps1 executes:
 - Invoke-NovaBuild
 - ./scripts/build/Invoke-ScriptAnalyzerCI.ps1
 - Test-NovaBuild
 
 Result:
 - PSScriptAnalyzer: no findings
 - Pester: 683 passed, 0 failed, 0 skipped
 
 Targeted regression coverage also added and exercised in:
 - tests/PackageLatestPolicy.Tests.ps1
 
 CodeScene:
 - pre_commit_code_health_safeguard passed after moving new assertions into a dedicated test file to keep large legacy test files under the Code Health threshold.

Documentation and release follow-up

 - [X]  README.md reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
 - [ ]  CONTRIBUTING.md reviewed and updated if contribution expectations or review guidance changed
 - [X]  CHANGELOG.md reviewed and updated if the change matters to users, maintainers, or contributors
 - [X]  docs/NovaModuleTools/en-US/ help updated if a public command or CLI behavior changed
 - [X]  docs/*.html updated if end-user workflows or examples changed
 - [X]  src/resources/example/ reviewed and updated if the real-world project layout, package model, or upload workflow
 changed
 - [ ]  No documentation, changelog, or example updates were needed

Maintainability, compatibility, and risk

 - [X]  Code Health / maintainability impact considered
 - [X]  No breaking change
 - [ ]  Breaking change
 - [ ]  Security-sensitive change
 - [X]  CI, workflow, or release-pipeline impact
 - [ ]  Dependency-review impact

Risk, rollout, or rollback notes:

 Compatibility:
 - No immediate breaking change.
 - Existing boolean Package.Latest values still work:
   - true  => "always"
   - false => "never"
 
 Behavior change:
 - Recommended config is now string-based:
   - "never"
   - "stable"
   - "always"
 - With "stable", preview package runs no longer create/update *.latest.* artifacts.
 
 Migration:
 - Existing projects can keep working unchanged for now.
 - Maintainers should move docs/examples/configs to string values.
 - Boolean support is deprecated and documented in CHANGELOG for later major-version removal.
 
 Rollback:
 - Reverting this change restores the old boolean-only behavior where Latest=true always emits latest artifacts, including preview package runs.