### PR TITLE
Feature/183 introduce a new root level release notemd that is separate from changelogmd

### DIFF
--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -1,3 +1,8 @@
+---
+name: architect
+description: Designs and scopes NovaModuleTools changes through a discussion-first flow before implementation starts
+---
+
 # NovaModuleTools architect agent
 
 ## Purpose
@@ -21,19 +26,21 @@ release automation.
 
 - `README.md`
 - `CONTRIBUTING.md`
+- `.github/copilot-instructions.md`
 - `.github/prompts/design-change.prompt.md`
-- `.github/instructions/*.md`
+- `.github/instructions/*.instructions.md`
 - `tests/ArchitectureGuardrails.Tests.ps1`
 - Relevant `src/public/` and `src/private/<domain>/` files
 - Relevant `.github/workflows/*.yml`
 
 ## Skills to use
 
-- `powershell-module-development.skill.md`
-- `github-actions.skill.md`
-- `release-and-changelog.skill.md`
-- `codescene-quality.skill.md`
-- `markdown-authoring.skill.md`
+- `/powershell-module-development`
+- `/github-actions`
+- `/release-and-changelog`
+- `/codescene-quality`
+- `/guiding-refactoring-with-code-health`
+- `/markdown-authoring`
 
 ## Constraints
 

--- a/.github/agents/docs-site.agent.md
+++ b/.github/agents/docs-site.agent.md
@@ -1,3 +1,8 @@
+---
+name: docs-site
+description: Keeps NovaModuleTools website documentation accurate and clearly separated from cmdlet help and contributor docs
+---
+
 # NovaModuleTools docs site agent
 
 ## Purpose
@@ -23,10 +28,10 @@ cmdlet help and contributor documentation.
 
 ## Skills to use
 
-- `docs-site-html.skill.md`
-- `markdown-authoring.skill.md`
-- `powershell-module-development.skill.md`
-- `release-and-changelog.skill.md`
+- `/docs-site-html`
+- `/markdown-authoring`
+- `/powershell-module-development`
+- `/release-and-changelog`
 
 ## Constraints
 

--- a/.github/agents/powershell-developer.agent.md
+++ b/.github/agents/powershell-developer.agent.md
@@ -1,3 +1,8 @@
+---
+name: powershell-developer
+description: Implements NovaModuleTools PowerShell and helper changes with matching tests and documentation
+---
+
 # NovaModuleTools PowerShell developer agent
 
 ## Purpose
@@ -19,9 +24,11 @@ Implement PowerShell command and helper changes in the NovaModuleTools style.
 
 ## Skills to use
 
-- `powershell-module-development.skill.md`
-- `pester-testing.skill.md`
-- `codescene-quality.skill.md`
+- `/powershell-module-development`
+- `/pester-testing`
+- `/codescene-quality`
+- `/guiding-refactoring-with-code-health`
+- `/safeguarding-ai-generated-code`
 
 ## Constraints
 

--- a/.github/agents/release-manager.agent.md
+++ b/.github/agents/release-manager.agent.md
@@ -1,3 +1,8 @@
+---
+name: release-manager
+description: Handles NovaModuleTools versioning, changelog, release-note, and publish-flow changes safely
+---
+
 # NovaModuleTools release manager agent
 
 ## Purpose
@@ -23,10 +28,10 @@ Handle versioning, changelog shaping, release-flow documentation, and publish au
 
 ## Skills to use
 
-- `release-and-changelog.skill.md`
-- `markdown-authoring.skill.md`
-- `github-actions.skill.md`
-- `pester-testing.skill.md`
+- `/release-and-changelog`
+- `/markdown-authoring`
+- `/github-actions`
+- `/pester-testing`
 
 ## Constraints
 
@@ -34,8 +39,8 @@ Handle versioning, changelog shaping, release-flow documentation, and publish au
 - Keep Keep a Changelog structure intact.
 - Distinguish contributor docs from end-user docs.
 - Treat `.github/pull_request_template.md` as the authoritative format for structured release summaries.
-- When the release summary is returned as Markdown or copy-ready UI output, it must follow
-  `markdown-authoring.skill.md`.
+- When the release summary is returned as Markdown or copy-ready UI output, it must follow the `markdown-authoring`
+  skill (`.github/skills/markdown-authoring/SKILL.md`).
 
 ## Definition of done
 

--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -1,3 +1,8 @@
+---
+name: reviewer
+description: Reviews NovaModuleTools changes for correctness, maintainability, validation, and documentation completeness
+---
+
 # NovaModuleTools reviewer agent
 
 ## Purpose
@@ -22,12 +27,13 @@ Review changes for correctness, maintainability, test coverage, workflow safety,
 
 ## Skills to use
 
-- `codescene-quality.skill.md`
-- `docs-site-html.skill.md`
-- `markdown-authoring.skill.md`
-- `pester-testing.skill.md`
-- `github-actions.skill.md`
-- `release-and-changelog.skill.md`
+- `/codescene-quality`
+- `/safeguarding-ai-generated-code`
+- `/docs-site-html`
+- `/markdown-authoring`
+- `/pester-testing`
+- `/github-actions`
+- `/release-and-changelog`
 
 ## Constraints
 

--- a/.github/agents/test-engineer.agent.md
+++ b/.github/agents/test-engineer.agent.md
@@ -1,3 +1,8 @@
+---
+name: test-engineer
+description: Improves NovaModuleTools Pester coverage, test structure, and CI coverage-gate behavior
+---
+
 # NovaModuleTools test engineer agent
 
 ## Purpose
@@ -20,9 +25,11 @@ Improve or maintain the repository's Pester coverage, coverage-gate behavior, an
 
 ## Skills to use
 
-- `pester-testing.skill.md`
-- `codescene-quality.skill.md`
-- `github-actions.skill.md`
+- `/pester-testing`
+- `/codescene-quality`
+- `/github-actions`
+- `/guiding-refactoring-with-code-health`
+- `/safeguarding-ai-generated-code`
 
 ## Constraints
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,7 +45,7 @@ treated as final.
 - Keep changes small, reviewable, and easy to validate.
 - Do not invent behavior that is not visible in source, tests, docs, workflows, or issues.
 - Preserve the distinction between PowerShell cmdlet UX and `nova` CLI UX.
-- Review `README.md`, `CONTRIBUTING.md`, and `CHANGELOG.md` after every meaningful change.
+- Review `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, and `RELEASE_NOTE.md` after every meaningful change.
 - Update tests when behavior changes.
 - Prefer existing helpers and support files over ad hoc duplication.
 - Treat Code Health as authoritative for maintainability in this repository.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,8 +1,8 @@
-# NovaModuleTools repository instructions
+# NovaModuleTools Copilot instructions
 
 ## Purpose
 
-Use this file as the repository-local entry point for Copilot or other AI agents working in NovaModuleTools.
+Use this file as the repository-wide Copilot instruction entry point for NovaModuleTools.
 
 NovaModuleTools is not a generic PowerShell repo. It has a strong split between public commands, private helpers,
 Pester-heavy testing, GitHub Actions automation, CodeScene coverage gates, and Keep a Changelog / SemVer release flow.
@@ -15,7 +15,11 @@ Read these files before making non-trivial changes:
 2. `CONTRIBUTING.md`
 3. `.github/pull_request_template.md`
 4. The relevant file in `.github/instructions/`
-5. The relevant file in `.github/skills/`
+5. The relevant skill under `.github/skills/<skill-name>/SKILL.md`
+
+Prompt templates under `.github/prompts/*.prompt.md` are not auto-loaded. Reference them explicitly in chat when you
+want
+to use one of the repository's reusable task prompts.
 
 For new or not-yet-scoped work, start with `.github/agents/architect.agent.md` and
 `.github/prompts/design-change.prompt.md`. That flow should stay conversational first: analyze the request, ask
@@ -70,7 +74,7 @@ treated as final.
 ## Markdown output guidance
 
 - When the output is intended to be copied as Markdown from the UI or written to a Markdown file, follow
-  `.github/skills/markdown-authoring.skill.md`.
+  the `markdown-authoring` skill (`.github/skills/markdown-authoring/SKILL.md`).
 - Apply that rule especially to release summaries, review summaries, contributor-facing Markdown docs, prompt output,
   and
   PR-template-shaped text.
@@ -89,6 +93,8 @@ When CodeScene tooling is available:
 - run the pre-commit safeguard on AI-touched changes before suggesting a commit
 - run a branch/change-set analysis before suggesting a PR or declaring a larger change ready
 - if CodeScene reports a regression, refactor instead of treating the work as done
+- use the `guiding-refactoring-with-code-health` skill for small, measured Code Health-driven refactors
+- use the `safeguarding-ai-generated-code` skill when deciding whether AI-touched work is ready for commit or PR handoff
 
 For documentation-only changes, executable validation may be skipped if no code path or workflow behavior changed.
 
@@ -107,8 +113,8 @@ For documentation-only changes, executable validation may be skipped if no code 
 
 ## Related guidance
 
-- `.github/instructions/powershell-coding-standards.md`
-- `.github/instructions/testing-policy.md`
-- `.github/instructions/release-policy.md`
-- `.github/instructions/documentation-separation.md`
-- `.github/skills/markdown-authoring.skill.md`
+- `.github/instructions/powershell-coding-standards.instructions.md`
+- `.github/instructions/testing-policy.instructions.md`
+- `.github/instructions/release-policy.instructions.md`
+- `.github/instructions/documentation-separation.instructions.md`
+- `.github/skills/markdown-authoring/SKILL.md`

--- a/.github/instructions/documentation-separation.instructions.md
+++ b/.github/instructions/documentation-separation.instructions.md
@@ -1,3 +1,7 @@
+---
+applyTo: "docs/**/*.html,docs/assets/**/*.js,docs/NovaModuleTools/en-US/**/*.md,README.md,CONTRIBUTING.md,CHANGELOG.md,RELEASE_NOTE.md"
+---
+
 # NovaModuleTools documentation separation
 
 ## Purpose

--- a/.github/instructions/powershell-coding-standards.instructions.md
+++ b/.github/instructions/powershell-coding-standards.instructions.md
@@ -1,3 +1,7 @@
+---
+applyTo: "src/**/*.ps1,tests/**/*.ps1,scripts/**/*.ps1,run.ps1,reload.ps1"
+---
+
 # NovaModuleTools PowerShell coding standards
 
 ## Scope

--- a/.github/instructions/release-policy.instructions.md
+++ b/.github/instructions/release-policy.instructions.md
@@ -15,6 +15,10 @@ automation.
 - Treat `CHANGELOG.md` as the exhaustive release history.
 - Treat `RELEASE_NOTE.md` as the interface-focused summary for public cmdlet, CLI, configuration, and migration changes.
 - Keep `## [Unreleased]` valid and readable.
+- If `RELEASE_NOTE.md` has no public API or workflow changes under `## [Unreleased]`, keep the exact placeholder under
+  `### Added`: `No public API or workflow changes in this release. Internal maintenance only.`
+- If `RELEASE_NOTE.md` has real release-note entries, do not keep that placeholder.
+- Do not add compare-link footer URLs to `RELEASE_NOTE.md`.
 - For unreleased feature iterations, update the existing `Added` entry instead of adding an internal-history `Changed`
   entry.
 

--- a/.github/instructions/release-policy.instructions.md
+++ b/.github/instructions/release-policy.instructions.md
@@ -1,3 +1,7 @@
+---
+applyTo: "CHANGELOG.md,RELEASE_NOTE.md,project.json,.github/workflows/Publish.yml,.github/pull_request_template.md,src/public/InvokeNovaRelease.ps1,src/public/PublishNovaModule.ps1,src/public/UpdateNovaModuleVersion.ps1,tests/**/*Release*.ps1,tests/**/*Package*.ps1"
+---
+
 # NovaModuleTools release policy
 
 ## Scope
@@ -8,7 +12,8 @@ automation.
 ## Versioning rules
 
 - Follow Semantic Versioning intent.
-- Treat `CHANGELOG.md` as authoritative for release notes.
+- Treat `CHANGELOG.md` as the exhaustive release history.
+- Treat `RELEASE_NOTE.md` as the interface-focused summary for public cmdlet, CLI, configuration, and migration changes.
 - Keep `## [Unreleased]` valid and readable.
 - For unreleased feature iterations, update the existing `Added` entry instead of adding an internal-history `Changed`
   entry.
@@ -23,7 +28,7 @@ automation.
 
 ## Documentation rules
 
-- Review `README.md`, `CONTRIBUTING.md`, and `CHANGELOG.md` for workflow or release changes.
+- Review `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, and `RELEASE_NOTE.md` for workflow or release changes.
 - Update command help in `docs/NovaModuleTools/en-US/` when public command behavior changes.
 - Update `docs/*.html` only when end-user behavior or examples changed.
 - Use `.github/pull_request_template.md` as the authoritative structure when preparing a release summary for review.

--- a/.github/instructions/testing-policy.instructions.md
+++ b/.github/instructions/testing-policy.instructions.md
@@ -1,3 +1,7 @@
+---
+applyTo: "tests/**/*.ps1,scripts/build/**/*.ps1,.github/workflows/Tests.yml,.github/actions/check-coverage/action.yml"
+---
+
 # NovaModuleTools testing policy
 
 ## Scope

--- a/.github/prompts/design-change.prompt.md
+++ b/.github/prompts/design-change.prompt.md
@@ -19,7 +19,9 @@ deferred, split into follow-up work, or excluded from the first implementation p
 
 1. Clarify the real problem first. Ask focused follow-up questions when scope, public-surface impact, ownership, or
    rollout direction is unclear.
-2. Read `README.md`, `CONTRIBUTING.md`, `.github/instructions/*.md`, and the most relevant `.github/skills/*.md` files.
+2. Read `README.md`, `CONTRIBUTING.md`, `.github/copilot-instructions.md`, the relevant
+   `.github/instructions/*.instructions.md` files, and the most relevant skill definitions under
+   `.github/skills/*/SKILL.md`.
 3. Inspect the affected public command, private helper domain, tests, docs, workflows, or release files without editing
    them.
 4. Decide whether the request affects public cmdlets, `% nova` CLI behavior, `project.json`, CI/workflows, command
@@ -69,7 +71,7 @@ Once the user confirms the scope and says the discussion is done, or explicitly 
 - Preserve the distinction between public PowerShell cmdlets and `% nova` CLI behavior.
 - Keep contributor docs, command help, website docs, changelog entries, and release notes separated by audience.
 - If the final design summary or GitHub issue draft is returned as Markdown or copy-ready UI output, format it according
-  to `markdown-authoring.skill.md`.
+  to the `markdown-authoring` skill (`.github/skills/markdown-authoring/SKILL.md`).
 - Draft issue text in English unless the user explicitly asks for another language.
 - If the task still has unresolved choices, end the turn with the next best question or the next design decision the
   user should make.

--- a/.github/prompts/implement-issue.prompt.md
+++ b/.github/prompts/implement-issue.prompt.md
@@ -12,7 +12,7 @@ Implement the issue in the NovaModuleTools repository using the repository-local
 
 1. If scope, acceptance criteria, or ownership are still unclear, start with `.github/prompts/design-change.prompt.md`
    and `architect.agent.md` before implementing.
-2. Read `README.md`, `CONTRIBUTING.md`, and `.github/pull_request_template.md`.
+2. Read `README.md`, `CONTRIBUTING.md`, `.github/copilot-instructions.md`, and `.github/pull_request_template.md`.
 3. Inspect the relevant public command, matching private helper domain, tests, and docs.
 4. If the issue is release-, workflow-, or coverage-related, also inspect the matching `.github/workflows/*.yml` and
    `scripts/build/ci/*.ps1` files.
@@ -22,15 +22,16 @@ Implement the issue in the NovaModuleTools repository using the repository-local
 8. If a commit message is requested, derive it from `$GIT_BRANCH_NAME` and the implemented change using the repository's
    Conventional Commit rules.
 9. Run the relevant validation, then summarize what changed, why, and how it was verified.
-10. If that summary is returned as Markdown or copy-ready UI output, format it according to
-   `markdown-authoring.skill.md`.
+10. If that summary is returned as Markdown or copy-ready UI output, format it according to the `markdown-authoring`
+    skill (`.github/skills/markdown-authoring/SKILL.md`).
 
 ## Repository-specific reminders
 
 - Keep PowerShell cmdlet UX and `nova` CLI UX distinct.
 - Do not silently bypass warnings or release safeguards.
 - Prefer reuse of existing helpers and test-support files over duplication.
-- Follow `markdown-authoring.skill.md` when the issue summary or final handoff is intended to be pasted as Markdown.
+- Follow the `markdown-authoring` skill (`.github/skills/markdown-authoring/SKILL.md`) when the issue summary or final
+  handoff is intended to be pasted as Markdown.
 - Commit message suggestions must:
     - be in English
     - use Conventional Commit format

--- a/.github/prompts/implement-issue.prompt.md
+++ b/.github/prompts/implement-issue.prompt.md
@@ -18,7 +18,8 @@ Implement the issue in the NovaModuleTools repository using the repository-local
    `scripts/build/ci/*.ps1` files.
 5. Implement the smallest maintainable fix.
 6. Add or update tests.
-7. Review `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, help docs, and `docs/*.html` as applicable.
+7. Review `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, `RELEASE_NOTE.md`, help docs, and `docs/*.html` as
+   applicable.
 8. If a commit message is requested, derive it from `$GIT_BRANCH_NAME` and the implemented change using the repository's
    Conventional Commit rules.
 9. Run the relevant validation, then summarize what changed, why, and how it was verified.

--- a/.github/prompts/prepare-release.prompt.md
+++ b/.github/prompts/prepare-release.prompt.md
@@ -11,8 +11,8 @@ Prepare release-related changes in NovaModuleTools without publishing or tagging
 4. Update changelog and contributor docs as needed.
 5. Validate the relevant release or versioning path.
 6. Summarize the result using the exact structure from `.github/pull_request_template.md`.
-7. Make the summary concise, reviewer-focused, directly reusable, and compliant with `markdown-authoring.skill.md` when
-   the output is returned as Markdown.
+7. Make the summary concise, reviewer-focused, directly reusable, and compliant with the `markdown-authoring` skill
+   (`.github/skills/markdown-authoring/SKILL.md`) when the output is returned as Markdown.
 
 ## Repository-specific reminders
 
@@ -21,4 +21,5 @@ Prepare release-related changes in NovaModuleTools without publishing or tagging
 - Do not push release commits.
 - Keep unreleased changelog entries aligned with the final intended behavior, not internal iteration history.
 - Treat `.github/pull_request_template.md` as the source of truth for release-preparation summaries.
-- If the summary must be pasted as one Markdown block in the UI, it should follow `markdown-authoring.skill.md`.
+- If the summary must be pasted as one Markdown block in the UI, it should follow the `markdown-authoring` skill
+  (`.github/skills/markdown-authoring/SKILL.md`).

--- a/.github/prompts/prepare-release.prompt.md
+++ b/.github/prompts/prepare-release.prompt.md
@@ -4,14 +4,19 @@ Prepare release-related changes in NovaModuleTools without publishing or tagging
 
 ## Required process
 
-1. Read `CHANGELOG.md`, `project.json`, `README.md`, `CONTRIBUTING.md`, `.github/pull_request_template.md`, and
-   `.github/workflows/Publish.yml`.
+1. Read `CHANGELOG.md`, `RELEASE_NOTE.md`, `project.json`, `README.md`, `CONTRIBUTING.md`,
+   `.github/pull_request_template.md`, and `.github/workflows/Publish.yml`.
 2. Inspect the touched versioning, package, publish, or release tests.
 3. Confirm whether the change affects stable releases, prereleases, or both.
-4. Update changelog and contributor docs as needed.
-5. Validate the relevant release or versioning path.
-6. Summarize the result using the exact structure from `.github/pull_request_template.md`.
-7. Make the summary concise, reviewer-focused, directly reusable, and compliant with the `markdown-authoring` skill
+4. Update changelog, release notes, and contributor docs as needed.
+5. Check whether `RELEASE_NOTE.md` needs the placeholder rule under `## [Unreleased]`:
+    - If there are no real public API or workflow changes, ensure `### Added` contains exactly
+      `No public API or workflow changes in this release. Internal maintenance only.`
+    - If there are real release-note entries, remove that placeholder.
+6. Keep `RELEASE_NOTE.md` free of compare-link footer URLs.
+7. Validate the relevant release or versioning path.
+8. Summarize the result using the exact structure from `.github/pull_request_template.md`.
+9. Make the summary concise, reviewer-focused, directly reusable, and compliant with the `markdown-authoring` skill
    (`.github/skills/markdown-authoring/SKILL.md`) when the output is returned as Markdown.
 
 ## Repository-specific reminders
@@ -20,6 +25,8 @@ Prepare release-related changes in NovaModuleTools without publishing or tagging
 - Do not create tags.
 - Do not push release commits.
 - Keep unreleased changelog entries aligned with the final intended behavior, not internal iteration history.
+- Keep `CHANGELOG.md` exhaustive and keep `RELEASE_NOTE.md` limited to public interface, configuration, and migration
+  changes.
 - Treat `.github/pull_request_template.md` as the source of truth for release-preparation summaries.
 - If the summary must be pasted as one Markdown block in the UI, it should follow the `markdown-authoring` skill
   (`.github/skills/markdown-authoring/SKILL.md`).

--- a/.github/prompts/review-change.prompt.md
+++ b/.github/prompts/review-change.prompt.md
@@ -9,7 +9,8 @@ Review a NovaModuleTools change set with emphasis on correctness, maintainabilit
 3. Check whether tests, docs, and changelog updates match the change.
 4. Call out the smallest set of meaningful issues first.
 5. Note any missing validation or follow-up work.
-6. If the review is returned as Markdown or copy-ready UI text, format it according to `markdown-authoring.skill.md`.
+6. If the review is returned as Markdown or copy-ready UI text, format it according to the `markdown-authoring` skill
+   (`.github/skills/markdown-authoring/SKILL.md`).
 
 ## Repository-specific reminders
 
@@ -17,4 +18,5 @@ Review a NovaModuleTools change set with emphasis on correctness, maintainabilit
 - Watch for CLI vs PowerShell wording drift.
 - Watch for CodeScene maintainability regressions in tests.
 - Treat publish/release automation edits as high-risk even when the diff is small.
-- Follow `markdown-authoring.skill.md` when the review output is intended to be pasted as Markdown.
+- Follow the `markdown-authoring` skill (`.github/skills/markdown-authoring/SKILL.md`) when the review output is
+  intended to be pasted as Markdown.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -53,11 +53,13 @@ If package/upload/release behavior changed, note the exact scenario you exercise
 - [ ] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
 - [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
 - [ ] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
+- [ ] `RELEASE_NOTE.md` reviewed and updated if the change affects public cmdlet usage, CLI usage, configuration
+  semantics, or migration expectations
 - [ ] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
 - [ ] `docs/*.html` updated if end-user workflows or examples changed
 - [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
   changed
-- [ ] No documentation, changelog, or example updates were needed
+- [ ] No documentation, changelog, release-note, or example updates were needed
 
 ## Maintainability, compatibility, and risk
 

--- a/.github/skills/codescene-quality/SKILL.md
+++ b/.github/skills/codescene-quality/SKILL.md
@@ -1,8 +1,19 @@
+---
+name: codescene-quality
+description: Guidance for improving NovaModuleTools CodeScene Code Health, duplication, and changed-code coverage outcomes.
+---
+
 # Skill: CodeScene quality and coverage
 
 ## When to use
 
 Use this skill when CodeScene reports low Code Health, duplication, or changed-code coverage failures.
+
+Use the narrower sibling skills when the task is more specific:
+
+- Use `/guiding-refactoring-with-code-health` when refactoring an unhealthy file and choosing small structural steps.
+- Use `/safeguarding-ai-generated-code` when AI-touched changes need Code Health gates before commit, handoff, or PR
+  readiness.
 
 ## Relevant files and tools
 

--- a/.github/skills/docs-site-html/SKILL.md
+++ b/.github/skills/docs-site-html/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: docs-site-html
+description: Guidance for NovaModuleTools website documentation so docs/*.html stay accurate and clearly separated from cmdlet help and contributor docs.
+---
+
 # Skill: docs site HTML
 
 ## When to use

--- a/.github/skills/github-actions/SKILL.md
+++ b/.github/skills/github-actions/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: github-actions
+description: Guidance for changing NovaModuleTools GitHub Actions workflows, CI artifact flow, or reusable workflow actions.
+---
+
 # Skill: GitHub Actions and CI/CD
 
 ## When to use

--- a/.github/skills/guiding-refactoring-with-code-health/SKILL.md
+++ b/.github/skills/guiding-refactoring-with-code-health/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: guiding-refactoring-with-code-health
+description: Use when refactoring unhealthy code and needing Code Health findings to choose small safe steps and verify improvement.
+---
+
+# Guiding Refactoring With Code Health
+
+## Overview
+
+Use Code Health as the control signal for refactoring. The agent should first understand why a file is hard to work
+with, establish a measurable baseline, then improve it in small structural steps and verify that each step helped. The
+goal is not just cleaner code, but code that is easier for both humans and agents to understand and modify safely.
+
+## When to use
+
+- A file is hard to read, risky to change, or repeatedly attracts defects.
+- The user asks for refactoring help and wants an objective way to measure progress.
+- A safeguard or review points to complexity, size, low cohesion, or deep nesting.
+
+Do not use this skill when the task is to rank project-wide priorities. Use CodeScene's project-level debt and hotspot
+tools instead.
+
+## Quick reference
+
+- `code_health_review`: Detailed maintainability findings for a file.
+- `code_health_score`: Numeric baseline and trend check across refactoring iterations.
+
+## Implementation
+
+1. Run `code_health_review` on the target file.
+2. Record the current `code_health_score` so the refactoring starts from a measurable baseline.
+3. Identify the highest-leverage structural problems, such as excessive responsibilities, deep nesting, low cohesion, or
+   hard-to-follow control flow.
+4. Propose 3 to 5 small structural refactor steps, not a single rewrite.
+5. After each meaningful step, re-run `code_health_review` to see whether the targeted structural problems were reduced.
+6. Use `code_health_score` as the compact checkpoint to confirm directional improvement across iterations.
+7. Stop only when the targeted structural issues are substantially reduced and the score has measurably improved, or
+   when
+   the user explicitly accepts a partial uplift.
+
+## Common mistakes
+
+- Refactoring without a baseline review.
+- Refactoring without recording the initial score.
+- Making a large rewrite that hides whether things improved.
+- Counting cosmetic cleanup as meaningful progress when the structural problems remain.
+- Using score checks alone without re-running the detailed review.
+- Forgetting to re-measure after each meaningful step.

--- a/.github/skills/markdown-authoring/SKILL.md
+++ b/.github/skills/markdown-authoring/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: markdown-authoring
+description: Guidance for producing valid, copy-safe Markdown files and UI-ready Markdown output in NovaModuleTools.
+---
+
 # Skill: markdown authoring
 
 ## When to use
@@ -9,9 +14,10 @@ UI, such as release summaries, PR-template-shaped text, contributor docs, or reu
 
 - `.github/pull_request_template.md`
 - `.github/prompts/*.md`
-- `.github/instructions/*.md`
+- `.github/copilot-instructions.md`
+- `.github/instructions/*.instructions.md`
 - `.github/agents/*.md`
-- `.github/skills/*.md`
+- `.github/skills/*/SKILL.md`
 - `README.md`
 - `CONTRIBUTING.md`
 - `CHANGELOG.md`

--- a/.github/skills/pester-testing/SKILL.md
+++ b/.github/skills/pester-testing/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: pester-testing
+description: Guidance for adding or refactoring NovaModuleTools Pester coverage, regression tests, and test support structure.
+---
+
 # Skill: Pester testing
 
 ## When to use

--- a/.github/skills/powershell-module-development/SKILL.md
+++ b/.github/skills/powershell-module-development/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: powershell-module-development
+description: Guidance for changing NovaModuleTools public commands, private helpers, CLI routing, packaging behavior, or project.json resolution. Use when implementing or refactoring NovaModuleTools PowerShell/module behavior.
+---
+
 # Skill: PowerShell module development
 
 ## When to use

--- a/.github/skills/release-and-changelog/SKILL.md
+++ b/.github/skills/release-and-changelog/SKILL.md
@@ -26,6 +26,10 @@ Use this skill when working on semantic versioning, release automation, package 
 
 - Keep unreleased entries readable and outcome-focused.
 - Keep `CHANGELOG.md` exhaustive and keep `RELEASE_NOTE.md` limited to interface-facing change summaries.
+- If `RELEASE_NOTE.md` has no public API or workflow changes under `## [Unreleased]`, keep the exact placeholder under
+  `### Added`: `No public API or workflow changes in this release. Internal maintenance only.`
+- If `RELEASE_NOTE.md` has real release-note entries, remove that placeholder.
+- Keep `RELEASE_NOTE.md` free of compare-link footer URLs.
 - Use `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, and `Security` intentionally.
 - Update an existing unreleased `Added` entry when a feature is still evolving before release.
 - Verify whether stable and preview behavior differ.
@@ -35,6 +39,7 @@ Use this skill when working on semantic versioning, release automation, package 
 
 - Logging internal iteration history in the changelog instead of final unreleased behavior
 - Copying internal-only changelog detail into `RELEASE_NOTE.md` when public interfaces are unchanged
+- Leaving the no-public-changes placeholder in place after real release-note entries were added
 - Forgetting that `main` and `develop` have different publish/version roles
 - Changing package or release defaults without corresponding tests
 

--- a/.github/skills/release-and-changelog/SKILL.md
+++ b/.github/skills/release-and-changelog/SKILL.md
@@ -1,13 +1,19 @@
+---
+name: release-and-changelog
+description: Guidance for NovaModuleTools semantic versioning, changelog handling, release notes, and publish-flow changes.
+---
+
 # Skill: release and changelog management
 
 ## When to use
 
-Use this skill when working on semantic versioning, release automation, package metadata, prerelease flow, or
-`CHANGELOG.md`.
+Use this skill when working on semantic versioning, release automation, package metadata, prerelease flow,
+`CHANGELOG.md`, or `RELEASE_NOTE.md`.
 
 ## Relevant files
 
 - `CHANGELOG.md`
+- `RELEASE_NOTE.md`
 - `project.json`
 - `.github/pull_request_template.md`
 - `.github/workflows/Publish.yml`
@@ -19,6 +25,7 @@ Use this skill when working on semantic versioning, release automation, package 
 ## Expected practices
 
 - Keep unreleased entries readable and outcome-focused.
+- Keep `CHANGELOG.md` exhaustive and keep `RELEASE_NOTE.md` limited to interface-facing change summaries.
 - Use `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, and `Security` intentionally.
 - Update an existing unreleased `Added` entry when a feature is still evolving before release.
 - Verify whether stable and preview behavior differ.
@@ -27,11 +34,12 @@ Use this skill when working on semantic versioning, release automation, package 
 ## Common pitfalls
 
 - Logging internal iteration history in the changelog instead of final unreleased behavior
+- Copying internal-only changelog detail into `RELEASE_NOTE.md` when public interfaces are unchanged
 - Forgetting that `main` and `develop` have different publish/version roles
 - Changing package or release defaults without corresponding tests
 
 ## Verification
 
-- Review `CHANGELOG.md`, workflow docs, and affected tests together
+- Review `CHANGELOG.md`, `RELEASE_NOTE.md`, workflow docs, and affected tests together
 - Run targeted versioning/package tests when behavior changed
 - Run `./run.ps1` for code changes

--- a/.github/skills/safeguarding-ai-generated-code/SKILL.md
+++ b/.github/skills/safeguarding-ai-generated-code/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: safeguarding-ai-generated-code
+description: Use when AI-generated or AI-modified changes need a Code Health gate before commit, handoff, or pull request.
+---
+
+# Safeguarding AI-Generated Code
+
+## Overview
+
+Use Code Health safeguards before declaring AI-touched code ready. The goal is to catch maintainability regressions
+early
+and prevent agents from normalizing technical debt.
+
+## When to use
+
+- The agent changed code and is about to suggest a commit.
+- The user asks whether a branch or staged changes are safe to merge.
+- The workflow needs a quality gate for AI-generated code.
+
+Do not use this skill for broad refactoring discovery or project-level prioritization.
+
+## Quick reference
+
+- `code_health_review`: Review each AI-modified file immediately after the change.
+- `pre_commit_code_health_safeguard`: Check staged or modified files before commit.
+- `analyze_change_set`: Check a branch or PR-style change set against a base ref.
+
+## Implementation
+
+1. After each AI modification to a file, run `code_health_review` on that file.
+2. If the review reports maintainability problems or regression risk, refactor the file in small steps and review it
+   again.
+3. Run `pre_commit_code_health_safeguard` before commit-oriented recommendations as a broader gate across staged or
+   modified files.
+4. Run `analyze_change_set` before PR-oriented recommendations as a final branch-level gate.
+5. If either later gate reports a regression, inspect the affected files with `code_health_review` and keep iterating
+   until the issue is removed or the user explicitly accepts the risk.
+
+## Common mistakes
+
+- Waiting until commit time to run the first Code Health check.
+- Treating safeguard output as optional guidance instead of a release gate.
+- Declaring work done after a failing safeguard.
+- Jumping straight to broad rewrites instead of inspecting the flagged files first.
+- Treating an accepted risk as invisible; call it out explicitly.

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -72,6 +72,7 @@ jobs:
           Invoke-NovaRelease -Repository PSGallery -ApiKey $env:PSGALLERY_API -SkipTests
           $version = Get-NovaProjectInfo -Version
           $result = Move-UnreleasedChangelog -Version $version
+          Move-UnreleasedChangelog -Path ./RELEASE_NOTE.md -Version $version | Out-Null
 
           "release_version=$version" >> $env:GITHUB_OUTPUT
 

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -33,11 +33,14 @@ jobs:
       - name: Run NovaModuleTools CI test and coverage workflow
         run: ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1 -OutputDirectory ./artifacts
 
-      - name: Validate repository changelog with Test-KeepAChangelogFile
+      - name: Validate release history files with Test-KeepAChangelogFile
         run: |
-          $result = Test-KeepAChangelogFile -Path ./CHANGELOG.md
-          if (-not $result.IsValid) {
-            throw ($result.Errors -join [Environment]::NewLine)
+          foreach ($path in @('./CHANGELOG.md', './RELEASE_NOTE.md')) {
+            $result = Test-KeepAChangelogFile -Path $path
+            if (-not $result.IsValid) {
+              $errors = $result.Errors -join [Environment]::NewLine
+              throw "Validation failed for $path$([Environment]::NewLine)$errors"
+            }
           }
 
       - name: Upload CI artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   explicitly, while the published `NovaModuleTools` manifest continues to declare that dependency for installed
   workflows.
 
+### Documentation
+
+- Added a root-level `RELEASE_NOTE.md` that is separate from `CHANGELOG.md`.
+    - `CHANGELOG.md` remains the exhaustive release history.
+    - `RELEASE_NOTE.md` now captures only public cmdlet, CLI, configuration, and migration-impacting changes, including
+      backfilled summaries for the existing released versions in `CHANGELOG.md`.
+    - `Tests.yml` now validates both files, and `Publish.yml` now finalizes both files during stable release
+      preparation.
+    - The public release-notes page now renders `RELEASE_NOTE.md` instead of the full changelog feed.
+
 ### Security
 
 ## [2.3.1] - 2026-05-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,13 +28,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Adds repository-local PowerShell style guidance for indentation, spacing, braces/wrapping, and blank-line usage.
     - Adds a dedicated docs-site agent and documentation-separation guidance so website docs keep a clear CLI-vs-cmdlet
       split.
+    - Makes the repository agent files valid Copilot custom-agent profiles by adding the required YAML frontmatter so
+      they load correctly in `/agent`.
     - Makes the release-manager flow own PR-template-based release summaries and removes the old standalone
       PR-description
       prompt.
     - Adds reusable markdown-authoring guidance so copy-ready Markdown output can use safe outer `~~~` fences without
       breaking inner triple-backtick code blocks.
-    - Makes the relevant agent and prompt outputs explicitly point to `markdown-authoring.skill.md` when they produce
+    - Aligns the repository guidance with actual Copilot CLI formats by using `.github/copilot-instructions.md`,
+      `.github/instructions/*.instructions.md`, and `.github/skills/<skill-name>/SKILL.md`, while keeping
+      `.github/prompts/*.prompt.md` as explicit prompt templates.
+    - Makes the relevant agent and prompt outputs explicitly point to the `markdown-authoring` skill when they produce
       Markdown summaries or UI-ready Markdown text.
+    - Adds focused CodeScene skills for refactoring with Code Health and for safeguarding AI-touched code before commit
+      or
+      PR readiness, instead of overloading the broader `codescene-quality` skill.
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Before making larger changes, read the contributor docs in:
 - [README.md#development-workflow](./README.md#development-workflow)
 - [README.md#repository-structure-and-ownership](./README.md#repository-structure-and-ownership)
 - [README.md#cicd-and-release-automation](./README.md#cicd-and-release-automation)
-- [.github/instructions/repository-instructions.md](./.github/instructions/repository-instructions.md)
+- [.github/copilot-instructions.md](./.github/copilot-instructions.md)
 - the relevant files under `.github/agents/`, `.github/skills/`, and `.github/prompts/` when you are using Copilot or
   another AI agent to help with repository work
 
@@ -37,10 +37,14 @@ Use it to explain intent clearly, record what you validated, and call out any re
 
 Repository-local agentic guidance now lives in `.github/`:
 
-- `.github/instructions/` for repository-wide rules and policies
+- `.github/copilot-instructions.md` for repository-wide Copilot instructions
+- `.github/instructions/` for path-specific `*.instructions.md` rules and policies
 - `.github/agents/` for focused agent responsibilities
-- `.github/skills/` for task-specific repo guidance
-- `.github/prompts/` for reusable NovaModuleTools task prompts
+- `.github/skills/` for task-specific Copilot skills stored as `<skill-name>/SKILL.md`
+- `.github/prompts/` for reusable NovaModuleTools prompt templates that you reference explicitly in chat
+
+The files in `.github/agents/` are repository-level Copilot custom agent profiles, so they should load in `/agent`
+when your Copilot session starts from the NovaModuleTools repository root.
 
 When you are shaping a new change, start with `architect.agent.md` and `design-change.prompt.md` so the first phase is a
 design conversation: analysis, clarifying questions, and solution options before any final scoped proposal or GitHub

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,8 @@ Please also make sure your contribution includes the right kind of follow-up wor
 - update help files in `docs/` when a command changes
 - update `README.md` when repository workflow, architecture, or contributor expectations change
 - update `CHANGELOG.md` when the change is relevant to users, maintainers, or future contributors
+- update `RELEASE_NOTE.md` when the change affects public cmdlet usage, CLI usage, configuration semantics, or migration
+  expectations
 - keep `src/resources/example/` useful if your change affects the real-world project layout or workflow
 
 Documentation ownership is intentionally split:
@@ -107,6 +109,11 @@ When updating documentation, write it for humans first. A reader should quickly 
 - why it changed
 - how to use it
 - whether existing behavior is affected
+
+For release history and release-note entries, keep the split explicit:
+
+- `CHANGELOG.md` records the full release history
+- `RELEASE_NOTE.md` records only public cmdlet, CLI, configuration, and migration-impacting changes
 
 For changelog entries, follow the existing project format:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This README is the single developer-documentation entry point for the repository
 Start here when you work on NovaModuleTools itself:
 
 - [CONTRIBUTING.md](./CONTRIBUTING.md) — contribution expectations and review checklist
-- [.github/instructions/repository-instructions.md](./.github/instructions/repository-instructions.md) —
+- [.github/copilot-instructions.md](./.github/copilot-instructions.md) —
   repository-local
   guidance for Copilot/AI agents and maintainers
 - [Development workflow](#development-workflow) — local setup, build, test, reload, and quality loop
@@ -42,7 +42,7 @@ Start here when you work on NovaModuleTools itself:
 Suggested reading order:
 
 1. Read [CONTRIBUTING.md](./CONTRIBUTING.md)
-2. Read [.github/instructions/repository-instructions.md](./.github/instructions/repository-instructions.md) when you
+2. Read [.github/copilot-instructions.md](./.github/copilot-instructions.md) when you
    want
    repository-local coding guidance for Copilot/AI-assisted work
 3. Follow [Development workflow](#development-workflow) for local iteration
@@ -56,11 +56,15 @@ This section describes how to work on the NovaModuleTools repository itself.
 
 Repository-local Copilot/AI guidance now lives under:
 
-- `.github/instructions/` - repository rules, PowerShell standards, testing policy, and release policy
+- `.github/copilot-instructions.md` - repository-wide Copilot instructions that apply across NovaModuleTools work
+- `.github/instructions/` - path-specific Copilot instructions stored as `*.instructions.md`
 - `.github/agents/` - focused agent roles for architecture, implementation, testing, release, and review work
-- `.github/skills/` - repo-specific skill guides for PowerShell, Pester, GitHub Actions, CodeScene, and release flow
+- `.github/skills/` - repo-specific Copilot skills stored as `<skill-name>/SKILL.md`
 - `.github/prompts/` - reusable task prompts such as design framing, issue implementation, CI fixes, coverage work, and
-  release prep
+  release prep; prompt files are referenced explicitly in chat, not auto-loaded like instructions or skills
+
+The files under `.github/agents/` are valid Copilot custom agent profiles and should be available from `/agent` when
+Copilot is started from the NovaModuleTools repository root.
 
 For new or still-fuzzy work, start with `architect.agent.md` together with `design-change.prompt.md`. That pair should
 lead with discussion, questions, and design options rather than a finished solution in the first reply. Use

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Repository-local Copilot/AI guidance now lives under:
 - `.github/skills/` - repo-specific Copilot skills stored as `<skill-name>/SKILL.md`
 - `.github/prompts/` - reusable task prompts such as design framing, issue implementation, CI fixes, coverage work, and
   release prep; prompt files are referenced explicitly in chat, not auto-loaded like instructions or skills
+- `CHANGELOG.md` and `RELEASE_NOTE.md` - exhaustive release history plus interface-focused release summaries
 
 The files under `.github/agents/` are valid Copilot custom agent profiles and should be available from `/agent` when
 Copilot is started from the NovaModuleTools repository root.
@@ -527,7 +528,8 @@ This section explains how the NovaModuleTools repository is organized and what e
 ├── src/                        # production PowerShell code and packaged resources
 ├── tests/                      # Pester suites and reusable test helpers
 ├── project.json                # NovaModuleTools project definition
-└── CHANGELOG.md                # release notes and unreleased change tracking
+├── CHANGELOG.md                # exhaustive release history and unreleased change tracking
+└── RELEASE_NOTE.md             # interface-focused release notes for public usage changes
 ```
 
 ### Source code layout
@@ -663,6 +665,7 @@ Responsibilities currently covered by the release pipeline include:
 
 - updating `project.json`
 - finalizing `CHANGELOG.md`
+- finalizing `RELEASE_NOTE.md`
 - creating release tags
 - committing release changes back to `main`
 - publishing to PowerShell Gallery
@@ -692,6 +695,8 @@ When you change CI, build, or release behavior:
 - update command help if public command behavior changes
 - update `README.md` when contributor workflow changes
 - update `CHANGELOG.md` when the change is relevant to users or maintainers
+- update `RELEASE_NOTE.md` when the change affects public cmdlet usage, CLI usage, configuration semantics, or migration
+  expectations
 
 ## Documentation ownership rules
 

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -1,0 +1,209 @@
+# Release notes
+
+This file summarizes public cmdlet, CLI, configuration, and migration changes for NovaModuleTools.
+`CHANGELOG.md` remains the exhaustive record of all changes in each release.
+
+Historical internal-only detail remains in `CHANGELOG.md`.
+This file now backfills the public-facing release summaries from the existing release history and should continue
+forward.
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+- `Package.Latest` in `project.json` now accepts the policy values `"never"`, `"stable"`, and `"always"`.
+    - Use `"stable"` when the floating `latest` package alias should follow stable package versions only.
+
+### Deprecated
+
+- Boolean `Package.Latest` values are deprecated and still map to `"always"` / `"never"` for now.
+    - Migrate to the string-based policy values before the next major version.
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [2.3.1] - 2026-05-08
+
+### Fixed
+
+- `nova bump` and `Update-NovaModuleVersion` now reuse parent Git repository history when a project lives in a nested
+  folder, instead of falling back to `Patch`.
+- Non-git bump flows now stop with a clear override-warning requirement instead of presenting `Patch | Commits: 0` as if
+  the value had been inferred automatically.
+
+## [2.3.0] - 2026-05-06
+
+### Changed
+
+- Prerelease self-update confirmation now defaults to `No`.
+    - `Update-NovaModuleTool`, `Update-NovaModuleTools`, and `% nova update` now require an explicit `Y` before a
+      prerelease self-update continues.
+
+### Fixed
+
+- Nova-managed CI/CD test flows now pull in `Pester 5.7.1` again through the published `NovaModuleTools` manifest.
+    - Existing CI/CD workflows no longer need their own `Pester` installation step just to keep project tests working.
+    - `Test-NovaBuild` now fails with a clear dependency error when `Pester` is missing.
+
+## [2.2.0] - 2026-05-06 [YANKED]
+
+This release was yanked because it removed the implicit `Pester` dependency before Nova's CI/CD test flow installed
+`Pester` explicitly. Projects using `NovaModuleTools 2.2.0` could fail to run tests in CI/CD unless maintainers added
+their own `Pester` installation step. The regression was fixed in `2.3.0`.
+
+### Changed
+
+- `Invoke-NovaRelease` now aligns with `Publish-NovaModule` and `% nova release` by accepting `-Local`, `-Repository`,
+  `-ModuleDirectoryPath`, and `-ApiKey` directly.
+    - Existing automation should move away from deprecated `-PublishOption` usage.
+- Stable `0.y.z` bump planning now stays on the major-zero line even when commit history implies a breaking change.
+    - Nova now plans the next minor version instead of auto-jumping to `1.0.0`.
+- `Update-NovaModuleVersion -Preview` and `% nova bump --preview` now enter the preview track deterministically from
+  stable versions.
+    - Stable versions always become the next patch preview, for example `0.2.0 -> 0.2.1-preview`.
+
+## [2.1.0] - 2026-04-29
+
+### Added
+
+- `Install-NovaCli` and a packaged `nova` launcher now let macOS and Linux users install and run `nova` directly from
+  zsh or bash.
+- Mutating Nova commands now support native `-WhatIf` / `-Confirm`, and the routed CLI now supports `--what-if`,
+  `--confirm`, and `--verbose` without dropping into PowerShell's `Suspend` prompt.
+- Self-update support is now available through `Update-NovaModuleTool`, `Update-NovaModuleTools`, and `nova update`,
+  with matching notification preference commands and CLI routes.
+- `nova version --installed` / `-i` now shows the installed NovaModuleTools version beside the current project version.
+- `Test-NovaBuild -Build` and `nova test --build` can now rebuild the project before running Pester.
+- `Update-NovaModuleVersion -Preview` and `nova bump --preview` now support explicit preview-version iteration.
+- `New-NovaModulePackage` / `nova package` and `Deploy-NovaPackage` / `nova deploy` now add generic package build and
+  raw upload workflows.
+- `-SkipTests` / `--skip-tests` and `-ContinuousIntegration` / `--continuous-integration` now support CI-oriented
+  package, publish, release, and versioning flows.
+
+### Changed
+
+- Nova now uses the Nova command model and a CLI-native help system as the primary workflow surface.
+- `Publish-NovaModule -Local` and `nova publish --local` now reload the published module from the local install path
+  into the current PowerShell session.
+
+### Removed
+
+- **BREAKING CHANGE**: Legacy `MT` commands were removed in favor of the Nova command model.
+- **BREAKING CHANGE**: `New-NovaModule` was renamed to `Initialize-NovaModule` without compatibility aliases.
+
+### Fixed
+
+- Invalid `nova help` invocations now return Nova's structured CLI validation errors.
+- Empty or unsupported `project.json` configuration now fails fast with clearer validation messages.
+
+## [1.9.1] - 2026-04-10
+
+### Added
+
+- Introduced the Nova command model and the `nova` root command together with the core public NovaModuleTools cmdlets.
+
+### Deprecated
+
+- `MT` commands and MT-branded documentation were deprecated in favor of the Nova command model.
+
+### Fixed
+
+- Resource lookup now behaves correctly when commands run from source or built `dist/` module contexts.
+
+## [1.8.0] - 2026-04-08
+
+### Added
+
+- Added `BuildRecursiveFolders`, `SetSourcePath`, and `FailOnDuplicateFunctionNames` project settings for more explicit
+  build control.
+
+### Changed
+
+- Build output is now generated in a deterministic file order, with `classes -> public -> private` load sequencing.
+
+## [1.3.0] - 2025-09-23
+
+### Added
+
+- Resource format files named `Name.format.ps1xml` are now imported automatically through the generated module
+  manifest.
+
+## [1.2.0] - 2025-09-17
+
+### Added
+
+- Added `src/classes` support, and `Initialize-NovaModule` now creates the classes directory for new projects.
+
+### Fixed
+
+- Version updates now support build tags and improved semantic-version handling.
+
+## [1.1.3] - 2025-09-14
+
+### Added
+
+- `Update-NovaModuleVersion` now supports preview tags, and project/build metadata now follows semver naming more
+  consistently.
+- Preview builds can now use `preview` or `prerelease` labels, for example `1.2.3-preview`.
+
+## [1.1.0] - 2025-08-28
+
+### Added
+
+- Generated module manifests now include `AliasesToExport`, so exported aliases load without extra manual import work.
+
+## [1.0.0] - 2025-03-11
+
+### Added
+
+- Added the optional `CopyResourcesToModuleRoot` project setting so resource files can be copied to the module root when
+  needed.
+
+### Fixed
+
+- **BREAKING CHANGE**: `ProjecUri` was corrected to `ProjectUri`, and existing projects need a manual setting update.
+
+## [0.0.9] - 2024-07-17
+
+### Fixed
+
+- `Invoke-NovaBuild` no longer fails when tag filters are empty.
+
+## [0.0.7] - 2024-07-17
+
+### Added
+
+- The `Manifest` section in `project.json` now supports the full set of `New-ModuleManifest` parameters.
+
+### Fixed
+
+- The example project README now points users to the supported repository-root and Gallery workflows.
+- Corrected the `ProjectUri` setting name in project metadata guidance.
+
+## [0.0.6] - 2024-07-08
+
+### Added
+
+- `Test-NovaBuild` now supports include/exclude tag filtering.
+
+## [0.0.5] - 2024-07-05
+
+### Added
+
+- Module initialization now prints more progress detail while a project is being created.
+
+### Fixed
+
+- New projects now initialize Git automatically when requested.
+- Skipping tests during project creation no longer leaves behind an empty `tests` folder.
+
+## [0.0.4] - 2024-06-25
+
+### Added
+
+- First PowerShell Gallery release of NovaModuleTools with the initial module workflow support.

--- a/docs/assets/release-notes.js
+++ b/docs/assets/release-notes.js
@@ -1,4 +1,4 @@
-const releaseNotesSourceUrl = 'https://raw.githubusercontent.com/stiwicourage/NovaModuleTools/refs/heads/develop/CHANGELOG.md';
+const releaseNotesSourceUrl = 'https://raw.githubusercontent.com/stiwicourage/NovaModuleTools/refs/heads/develop/RELEASE_NOTE.md';
 
 function getMarkedInstance() {
     return window.marked;

--- a/docs/release-notes.html
+++ b/docs/release-notes.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
-    <title>NovaModuleTools — Release notes for end-user workflow changes</title>
-    <meta content="Read NovaModuleTools release notes for developer-facing workflow changes, new commands, configuration updates, fixes, and documentation improvements."
+    <title>NovaModuleTools — Release notes for public workflow and configuration changes</title>
+    <meta content="Read NovaModuleTools release notes for public command, CLI, configuration, and upgrade-impacting changes."
           name="description">
     <meta content="index,follow,max-image-preview:large" name="robots">
     <meta content="#0b1020" name="theme-color">
@@ -12,14 +12,14 @@
     <link href="./assets/icon.png" rel="icon" type="image/png">
     <link href="./assets/icon.png" rel="apple-touch-icon">
     <meta content="article" property="og:type">
-    <meta content="NovaModuleTools — Release notes for end-user workflow changes" property="og:title">
-    <meta content="Read NovaModuleTools release notes for developer-facing workflow changes, new commands, configuration updates, fixes, and documentation improvements."
+    <meta content="NovaModuleTools — Release notes for public workflow and configuration changes" property="og:title">
+    <meta content="Read NovaModuleTools release notes for public command, CLI, configuration, and upgrade-impacting changes."
           property="og:description">
     <meta content="https://www.novamoduletools.com/release-notes.html" property="og:url">
     <meta content="https://www.novamoduletools.com/assets/icon.png" property="og:image">
     <meta content="summary" name="twitter:card">
-    <meta content="NovaModuleTools — Release notes for end-user workflow changes" name="twitter:title">
-    <meta content="Read NovaModuleTools release notes for developer-facing workflow changes, new commands, configuration updates, fixes, and documentation improvements."
+    <meta content="NovaModuleTools — Release notes for public workflow and configuration changes" name="twitter:title">
+    <meta content="Read NovaModuleTools release notes for public command, CLI, configuration, and upgrade-impacting changes."
           name="twitter:description">
     <link href="./assets/site.css" rel="stylesheet">
     <script type="application/ld+json">
@@ -65,10 +65,9 @@
 <main class="page-shell">
     <section class="guide-hero">
         <p class="eyebrow">Release notes</p>
-        <h1>Track what changed in NovaModuleTools</h1>
-        <p class="lead">Use this page to see workflow changes that matter to developers using NovaModuleTools: new
-            commands, changed configuration behavior, packaging and upload improvements, fixes, and documentation
-            updates.</p>
+        <h1>Track public changes in NovaModuleTools</h1>
+        <p class="lead">Use this page to see public command, CLI, configuration, and upgrade-impacting changes without
+            the internal CI, tooling, and maintenance detail from the full changelog.</p>
     </section>
 
     <section class="release-notes-shell">
@@ -103,8 +102,9 @@
 
 <footer class="footer">
     <div class="footer__inner">
-        <h2>Need more than a changelog entry?</h2>
-        <p>After you identify the version change you care about, use the workflow and reference pages on this site to
+        <h2>Need more than a release-note entry?</h2>
+        <p>After you identify the release-note entry you care about, use the workflow and reference pages on this site
+            to
             see the full current behavior and examples.</p>
         <div class="hero__actions">
             <a class="button button--primary" href="./commands.html">Open Command Reference</a>


### PR DESCRIPTION
## Summary
 
 - Added a root-level `RELEASE_NOTE.md` and split release history responsibilities so `CHANGELOG.md` stays exhaustive while `RELEASE_NOTE.md` carries only public cmdlet, CLI, configuration, and migration-facing notes.
 - Updated the release path so stable release preparation validates and finalizes both files, and updated contributor/end-user docs so the split is explicit and the hosted release-notes page now renders `RELEASE_NOTE.md`.
 - Backfilled `RELEASE_NOTE.md` with public-facing summaries for every actual released section currently present in `CHANGELOG.md`, while keeping compare-link footer URLs and internal-only detail out of the release-note file.
 - This change was needed so release notes are user-facing and concise without losing the full maintenance history in `CHANGELOG.md`.
 - Closes #183.
 
 ## Affected area
 
 - [ ] `nova` CLI or command routing
 - [ ] Public PowerShell cmdlet behavior
 - [ ] Scaffolding or `project.json` handling
 - [x] Build, test, analyzer, coverage, or CI helper flow
 - [ ] Package, raw upload, or package metadata workflow
 - [x] Publish, release, or GitHub Actions automation
 - [ ] Self-update or notification preference behavior
 - [x] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
 - [x] End-user docs (`docs/*.html`)
 - [ ] Command help (`docs/NovaModuleTools/en-US/*.md`)
 - [ ] `src/resources/example/`
 - [ ] Dependency or manifest changes (`project.json`, workflow dependencies, release tooling)
 - [ ] Security-sensitive change
 - [ ] Documentation-only change
 - [x] Other
 
 ## Review guidance
 
 - Start with `.github/workflows/Publish.yml`, `.github/workflows/Tests.yml`, `CHANGELOG.md`, and `RELEASE_NOTE.md`.
 - The main workflow change is on the stable `main` release path: `Publish.yml` still sources the annotated tag message from the changelog move result, but now also finalizes `RELEASE_NOTE.md`. The `develop` prerelease semantics were not changed.
 - Review the documentation split in `README.md`, `CONTRIBUTING.md`, `.github/prompts/prepare-release.prompt.md`, `.github/instructions/release-policy.instructions.md`, `.github/skills/release-and-changelog/SKILL.md`, `.github/pull_request_template.md`, and 
`docs/release-notes.html`.
 - Relevant release/publish coverage was reviewed in `tests/NovaCommandModel.ReleasePublish.Tests.ps1`; no new Pester coverage was added because the implementation change is workflow/documentation wiring around existing Keep a Changelog operations rather than a 
changed PowerShell release helper contract.
 - Trade-off: `RELEASE_NOTE.md` is intentionally a curated public summary, so it mirrors only actual release sections from `CHANGELOG.md` and does not reproduce internal-only detail or compare-link footer references.
 
 ## Validation
 
 - [ ] `Invoke-NovaBuild`
 - [ ] `Test-NovaBuild`
 - [ ] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
 - [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
 - [ ] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`,
   `% nova publish`,
   `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
 - [ ] Docs/example only; executable validation not needed
 
 Validation notes:
 
 ```text
 Executed:
 - pwsh -NoLogo -NoProfile -File ./run.ps1
 - pwsh -NoLogo -NoProfile -Command "Import-Module KeepAChangelog; Test-KeepAChangelogFile -Path ./CHANGELOG.md; Test-KeepAChangelogFile -Path ./RELEASE_NOTE.md"
 - Safe temp-copy exercise of Move-UnreleasedChangelog against both files to confirm release finalization behavior without mutating the working files
 - git --no-pager diff --check
 - CodeScene pre_commit_code_health_safeguard (passed)
 
 Observed release impact:
 - Stable/main release flow is directly affected because Publish.yml now finalizes both CHANGELOG.md and RELEASE_NOTE.md.
 - Prerelease/develop version semantics were reviewed and left unchanged.
 ```
 
 ## Documentation and release follow-up
 
 - [x] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
 - [x] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
 - [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
 - [x] `RELEASE_NOTE.md` reviewed and updated if the change affects public cmdlet usage, CLI usage, configuration semantics, or migration expectations
 - [ ] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
 - [x] `docs/*.html` updated if end-user workflows or examples changed
 - [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow
   changed
 - [ ] No documentation, changelog, release-note, or example updates were needed
 
 ## Maintainability, compatibility, and risk
 
 - [x] Code Health / maintainability impact considered
 - [x] No breaking change
 - [ ] Breaking change
 - [ ] Security-sensitive change
 - [x] CI, workflow, or release-pipeline impact
 - [ ] Dependency-review impact
 
 Risk, rollout, or rollback notes:
 
 ```text
 Risk is concentrated in the stable release automation path because Publish.yml now mutates two release-history files instead of one.
 The change is intentionally narrow:
 - CHANGELOG.md remains the authoritative exhaustive history
 - RELEASE_NOTE.md remains footer-link-free and public-facing
 - The annotated tag message still comes from the changelog move result
 - develop prerelease behavior and branch semantics were not changed
 
 Rollback is straightforward:
 - revert RELEASE_NOTE.md and the workflow/doc changes together
 - restore docs/assets/release-notes.js to read CHANGELOG.md again
 - restore Tests.yml / Publish.yml to single-file changelog handling if the split needs to be backed out
 ```
 
 > [!IMPORTANT]
 > Do not use a public pull request to disclose a vulnerability before coordinated handling.
 > Use the private reporting path in `SECURITY.md` for new security issues.