### PR TITLE
Add nova copilot command for Agentic Copilot workflow

### DIFF
--- a/.github/agents/docs-site.agent.md
+++ b/.github/agents/docs-site.agent.md
@@ -14,6 +14,7 @@ Keep the GitHub Pages documentation under `docs/*.html` accurate, user-focused, 
 - Update `docs/*.html` when end-user workflows, examples, or website wording change.
 - Preserve the separation between CLI-oriented website docs and PowerShell cmdlet help.
 - Check whether source, tests, help docs, and website docs still agree after a change.
+- Keep command-surface-toggle pages honest by splitting CLI-only and PowerShell-only wording into the matching `data-command-visibility` blocks instead of mixing both spellings in shared prose.
 
 ## Inputs to inspect
 
@@ -37,15 +38,18 @@ Keep the GitHub Pages documentation under `docs/*.html` accurate, user-focused, 
 - Treat `docs/*.html` as end-user website docs, not cmdlet help.
 - Keep CLI and cmdlet surfaces clearly separated.
 - Mention PowerShell-only commands in CLI-oriented docs only when there is no CLI equivalent for that scenario, such as installing NovaModuleTools with `Install-Module`.
+- On pages with the surface toggle, only show `--option` spellings in command-line-visible blocks and only show `-Parameter` spellings in PowerShell-visible blocks unless the wording is fully surface-neutral.
 
 ## Definition of done
 
 - The changed website docs reflect the current behavior.
 - CLI-oriented docs do not drift into cmdlet-help wording.
+- Surface-specific labels, flags, and parameter names match the active website command surface.
 - Relevant contributor docs and changelog were reviewed for follow-up impact.
 
 ## Must not do
 
 - Must not mix cmdlet syntax into CLI docs when a CLI variant exists.
+- Must not leave shared always-visible HTML copy with both CLI flags and PowerShell parameters when the page already has the command-surface toggle.
 - Must not use `docs/*.html` as a duplicate of `docs/NovaModuleTools/en-US/*.md`.
 - Must not leave installation/documentation exceptions implicit; state them clearly.

--- a/.github/instructions/documentation-separation.instructions.md
+++ b/.github/instructions/documentation-separation.instructions.md
@@ -20,6 +20,10 @@ NovaModuleTools has multiple documentation surfaces with different audiences. Ke
 - Do not write cmdlet help markdown as if it were `nova` CLI documentation.
 - Use CLI syntax in CLI-oriented website docs when a CLI variant exists.
 - Use cmdlet syntax in help markdown and PowerShell-specific contributor guidance.
+- On website pages that support the command-surface toggle, keep surface-specific wording behind the matching visibility gate.
+    - CLI-only flags, labels, and guidance belong in elements marked with `data-command-visibility="command-line"`.
+    - PowerShell-only parameters, labels, and guidance belong in elements marked with `data-command-visibility="powershell"`.
+    - Shared prose should stay surface-neutral instead of mixing `--option` and `-Parameter` spellings in the same always-visible paragraph.
 
 ## Allowed exception
 
@@ -33,6 +37,7 @@ NovaModuleTools has multiple documentation surfaces with different audiences. Ke
 - Does this page describe a `nova` workflow or a PowerShell cmdlet workflow?
 - If a `nova` command exists, is the website doc using it instead of the cmdlet?
 - If a cmdlet is shown in website docs, is it there because no CLI variant exists?
+- If the page uses the command-surface toggle, do the visible labels, flags, and parameter names match the selected surface?
 - Would an end user mistake this page for cmdlet help?
 
 ## Follow-up expectations

--- a/.github/skills/docs-site/SKILL.md
+++ b/.github/skills/docs-site/SKILL.md
@@ -24,11 +24,13 @@ Use this skill when changing `docs/*.html`, end-user examples, installation guid
 - Use CLI-oriented examples when the workflow has a `nova` variant.
 - Mention PowerShell cmdlets only when no CLI equivalent exists for that scenario.
 - Keep installation guidance explicit about PowerShell-only steps such as `Install-Module`.
+- On pages with the command-surface toggle, keep option/parameter wording aligned with the active surface by using `data-command-visibility="command-line"` and `data-command-visibility="powershell"` blocks instead of one shared paragraph that mixes CLI flags with PowerShell parameters.
 - Recheck the matching command-help markdown when public behavior changes.
 
 ## Common pitfalls
 
 - Mixing `Get-/Set-/Invoke-/Install-` cmdlets into CLI docs where `nova` exists
+- Leaving `--option` text visible in PowerShell mode, or `-Parameter` text visible in command-line mode, because the surrounding prose was not split by `data-command-visibility`
 - Duplicating cmdlet help text in website docs instead of adapting it for end users
 - Forgetting that `docs/NovaModuleTools/en-US/*.md` and `docs/*.html` serve different audiences
 - Updating website docs without reviewing changelog or contributor-doc impact
@@ -36,5 +38,6 @@ Use this skill when changing `docs/*.html`, end-user examples, installation guid
 ## Verification
 
 - Read the touched HTML page as an end-user flow
+- Toggle the page mentally between PowerShell and command-line surfaces and confirm the visible option/parameter names still match that surface
 - Check whether the same behavior is documented consistently in help markdown or contributor docs
 - Use docs-only validation when no executable behavior changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
+- Added `Invoke-NovaAgenticCopilotScaffold` and `% nova copilot` for applying or refreshing Nova's managed Agentic Copilot scaffold in an existing project root.
+    - The workflow reads `ProjectName` and `Description` from `project.json`, requires a `ShortName` on every run for token replacement, and fails clearly when the project metadata or short name is invalid.
+    - Nova refreshes only the approved managed Agentic Copilot paths under `.github/` plus `AGENTS.md` and `CONTRIBUTING.md`, while `README.md`, `CHANGELOG.md`, and `RELEASE_NOTE.md` are created only when they are missing.
+    - The new cmdlet and CLI route prompt before overwriting managed scaffold content by default, and support non-interactive execution only through `-OverrideWarning` / `--override-warning` / `-o`.
+
 ### Changed
 
 ### Deprecated
@@ -433,4 +438,3 @@ This release was yanked because it removed the implicit `Pester` dependency, bef
 [0.0.6]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.5...Version_0.0.6
 [0.0.5]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.4...Version_0.0.5
 [0.0.4]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.3...Version_0.0.4
-

--- a/README.md
+++ b/README.md
@@ -176,6 +176,19 @@ Direct PowerShell cmdlets such as `Publish-NovaModule`, `Deploy-NovaPackage`, an
 
 The module does not export a PowerShell alias named `nova`. Install the bundled launcher with `Install-NovaCli` when you want `% nova ...` available directly from your shell.
 
+### Apply or refresh the Agentic Copilot scaffold
+
+Use the dedicated scaffold command when you want to add Nova's maintained Agentic Copilot workflow to an existing project, or refresh an older scaffold to Nova's latest managed version:
+
+```powershell
+PS> Invoke-NovaAgenticCopilotScaffold -ShortName NMT
+% nova copilot --short-name NMT
+```
+
+The target directory must contain a valid `project.json`. Nova reads `ProjectName` and `Description` from that file, requires `ShortName` on every run for token replacement, and refreshes only the Nova-managed Agentic Copilot paths under `.github/` plus `AGENTS.md` and `CONTRIBUTING.md`. Existing `README.md`, `CHANGELOG.md`, and `RELEASE_NOTE.md` are preserved and are created only when they are missing.
+
+By default the scaffold flow prompts before it overwrites the managed paths. Use `-OverrideWarning` or `--override-warning` only when you intentionally want a non-interactive apply. The CLI also supports the short form `% nova copilot -n NMT -o`. Use `-WhatIf` or `--what-if` when you want to preview the operation without changing files.
+
 ### Reload the built module while iterating
 
 Use the built output during development so you validate the same shape CI uses:

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -6,6 +6,11 @@ This file summarizes the release notes for NovaModuleTools. **UNRELEASED** chang
 
 ### Added
 
+- Added `Invoke-NovaAgenticCopilotScaffold` and `% nova copilot` for adding or refreshing Nova's managed Agentic Copilot workflow in an existing project.
+    - The workflow reads `ProjectName` and `Description` from `project.json`, requires an explicit `ShortName` on every run, and stops with a clear validation error when the target project metadata is missing or invalid.
+    - Nova refreshes only its managed Agentic Copilot files and folders, while `README.md`, `CHANGELOG.md`, and `RELEASE_NOTE.md` are created only when they are missing.
+    - The command prompts before overwrite by default and supports non-interactive execution only through `-OverrideWarning` / `--override-warning` / `-o`.
+
 ### Changed
 
 ### Deprecated
@@ -195,4 +200,3 @@ This release was yanked because it removed the implicit `Pester` dependency befo
 ## [0.0.4] - 2024-06-25
 ### Added
 - First PowerShell Gallery release of NovaModuleTools with the initial module workflow support.
-

--- a/docs/NovaModuleTools/en-US/Deploy-NovaPackage.md
+++ b/docs/NovaModuleTools/en-US/Deploy-NovaPackage.md
@@ -1,7 +1,7 @@
 ---
 document type: cmdlet
 external help file: NovaModuleTools-Help.xml
-HelpUri: ''
+HelpUri: 'https://www.novamoduletools.com/packaging-and-delivery.html#upload'
 Locale: en-US
 Module Name: NovaModuleTools
 ms.date: 04/25/2026

--- a/docs/NovaModuleTools/en-US/Get-NovaProjectInfo.md
+++ b/docs/NovaModuleTools/en-US/Get-NovaProjectInfo.md
@@ -1,7 +1,7 @@
 ---
 document type: cmdlet
 external help file: NovaModuleTools-Help.xml
-HelpUri: ''
+HelpUri: 'https://www.novamoduletools.com/project-json-reference.html'
 Locale: en-US
 Module Name: NovaModuleTools
 ms.date: 05/06/2026

--- a/docs/NovaModuleTools/en-US/Get-NovaUpdateNotificationPreference.md
+++ b/docs/NovaModuleTools/en-US/Get-NovaUpdateNotificationPreference.md
@@ -1,7 +1,7 @@
 ---
 document type: cmdlet
 external help file: NovaModuleTools-Help.xml
-HelpUri: ''
+HelpUri: 'https://www.novamoduletools.com/versioning-and-updates.html#notification-preferences'
 Locale: en-US
 Module Name: NovaModuleTools
 ms.date: 04/25/2026

--- a/docs/NovaModuleTools/en-US/Initialize-NovaModule.md
+++ b/docs/NovaModuleTools/en-US/Initialize-NovaModule.md
@@ -1,7 +1,7 @@
 ---
 document type: cmdlet
 external help file: NovaModuleTools-Help.xml
-HelpUri: ''
+HelpUri: 'https://www.novamoduletools.com/core-workflows.html#scaffold'
 Locale: en-US
 Module Name: NovaModuleTools
 ms.date: 04/25/2026

--- a/docs/NovaModuleTools/en-US/Install-NovaCli.md
+++ b/docs/NovaModuleTools/en-US/Install-NovaCli.md
@@ -1,7 +1,7 @@
 ---
 document type: cmdlet
 external help file: NovaModuleTools-Help.xml
-HelpUri: ''
+HelpUri: 'https://www.novamoduletools.com/commands.html#setup-and-project'
 Locale: en-US
 Module Name: NovaModuleTools
 ms.date: 04/25/2026

--- a/docs/NovaModuleTools/en-US/Invoke-NovaAgenticCopilotScaffold.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaAgenticCopilotScaffold.md
@@ -1,0 +1,207 @@
+---
+document type: cmdlet
+external help file: NovaModuleTools-Help.xml
+HelpUri: 'https://www.novamoduletools.com/core-workflows.html#agentic-copilot'
+Locale: en-US
+Module Name: NovaModuleTools
+ms.date: 05/20/2026
+PlatyPS schema version: 2024-05-01
+title: Invoke-NovaAgenticCopilotScaffold
+---
+
+# Invoke-NovaAgenticCopilotScaffold
+
+## SYNOPSIS
+
+Apply or refresh Nova's managed Agentic Copilot scaffold in an existing project.
+
+## SYNTAX
+
+### __AllParameterSets
+
+```text
+Invoke-NovaAgenticCopilotScaffold [[-Path] <string>] [-ShortName] <string> [-OverrideWarning]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+`Invoke-NovaAgenticCopilotScaffold` applies Nova's maintained Agentic Copilot scaffold to an existing project root.
+
+The command reads `ProjectName` and `Description` from the target `project.json`, requires a `ShortName` on every run for token replacement, and refreshes only Nova-managed Agentic Copilot paths. Existing `README.md`, `CHANGELOG.md`, and `RELEASE_NOTE.md` are preserved and are created only when they are missing.
+
+By default the workflow shows an overwrite warning before it updates the managed scaffold paths. Use `-OverrideWarning` only when you intentionally want a non-interactive apply or refresh.
+
+The target path must contain a valid `project.json`. Invalid project metadata or an invalid short name stops the command with a clear validation error.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```text
+PS> Invoke-NovaAgenticCopilotScaffold -ShortName NMT
+```
+
+Apply or refresh the Nova-managed Agentic Copilot scaffold in the current project root after the overwrite warning is confirmed.
+
+### EXAMPLE 2
+
+```text
+PS> Invoke-NovaAgenticCopilotScaffold -Path ~/Work/MyModule -ShortName NMT -OverrideWarning
+```
+
+Apply or refresh the managed scaffold in a specific project root without showing the overwrite warning prompt.
+
+### EXAMPLE 3
+
+```text
+PS> Invoke-NovaAgenticCopilotScaffold -ShortName NMT -WhatIf
+```
+
+Preview the managed scaffold apply workflow without writing or overwriting files.
+
+## PARAMETERS
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- cf
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -OverrideWarning
+
+Skip the overwrite warning prompt and continue directly with the managed scaffold apply or refresh workflow.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -Path
+
+Project root that contains the existing `project.json` file. Defaults to the current location.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 0
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -ShortName
+
+Short placeholder name used in generated guidance tokens such as `Invoke-<ShortName>*`. Use a value that starts with a letter and contains only letters or numbers.
+
+```yaml
+Type: System.String
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 1
+  IsRequired: true
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -WhatIf
+
+Runs the command in a mode that only reports what would happen without performing the actions.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: ''
+SupportsWildcards: false
+Aliases:
+- wi
+ParameterSets:
+- Name: (All)
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable, -ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+You can't pipe objects to this cmdlet.
+
+## OUTPUTS
+
+### None
+
+This cmdlet does not emit an output object.
+
+## NOTES
+
+This workflow does not persist `ShortName` to `project.json` and does not infer it from any existing scaffold files. It refreshes only these Nova-managed paths:
+
+- `.github/agents/`
+- `.github/instructions/`
+- `.github/prompts/`
+- `.github/skills/`
+- `.github/copilot-instructions.md`
+- `.github/pull_request_template.md`
+- `AGENTS.md`
+- `CONTRIBUTING.md`
+
+`README.md`, `CHANGELOG.md`, and `RELEASE_NOTE.md` are created only when they are missing.
+
+## RELATED LINKS
+
+- https://github.com/stiwicourage/NovaModuleTools/blob/main/docs/NovaModuleTools/en-US/Initialize-NovaModule.md
+- https://github.com/stiwicourage/NovaModuleTools/blob/main/docs/NovaModuleTools/en-US/Get-NovaProjectInfo.md

--- a/docs/NovaModuleTools/en-US/Invoke-NovaBuild.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaBuild.md
@@ -1,7 +1,7 @@
 ---
 document type: cmdlet
 external help file: NovaModuleTools-Help.xml
-HelpUri: ''
+HelpUri: 'https://www.novamoduletools.com/core-workflows.html#build'
 Locale: en-US
 Module Name: NovaModuleTools
 ms.date: 04/25/2026

--- a/docs/NovaModuleTools/en-US/Invoke-NovaRelease.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaRelease.md
@@ -1,7 +1,7 @@
 ---
 document type: cmdlet
 external help file: NovaModuleTools-Help.xml
-HelpUri: ''
+HelpUri: 'https://www.novamoduletools.com/packaging-and-delivery.html#release'
 Locale: en-US
 Module Name: NovaModuleTools
   ms.date: 05/03/2026

--- a/docs/NovaModuleTools/en-US/New-NovaModulePackage.md
+++ b/docs/NovaModuleTools/en-US/New-NovaModulePackage.md
@@ -1,7 +1,7 @@
 ---
 document type: cmdlet
 external help file: NovaModuleTools-Help.xml
-HelpUri: ''
+HelpUri: 'https://www.novamoduletools.com/packaging-and-delivery.html#pack'
 Locale: en-US
 Module Name: NovaModuleTools
   ms.date: 04/26/2026

--- a/docs/NovaModuleTools/en-US/Publish-NovaModule.md
+++ b/docs/NovaModuleTools/en-US/Publish-NovaModule.md
@@ -1,7 +1,7 @@
 ---
 document type: cmdlet
 external help file: NovaModuleTools-Help.xml
-HelpUri: ''
+HelpUri: 'https://www.novamoduletools.com/packaging-and-delivery.html#publish'
 Locale: en-US
 Module Name: NovaModuleTools
   ms.date: 04/26/2026

--- a/docs/NovaModuleTools/en-US/Set-NovaUpdateNotificationPreference.md
+++ b/docs/NovaModuleTools/en-US/Set-NovaUpdateNotificationPreference.md
@@ -1,7 +1,7 @@
 ---
 document type: cmdlet
 external help file: NovaModuleTools-Help.xml
-HelpUri: ''
+HelpUri: 'https://www.novamoduletools.com/versioning-and-updates.html#notification-preferences'
 Locale: en-US
 Module Name: NovaModuleTools
 ms.date: 04/25/2026

--- a/docs/NovaModuleTools/en-US/Test-NovaBuild.md
+++ b/docs/NovaModuleTools/en-US/Test-NovaBuild.md
@@ -1,7 +1,7 @@
 ---
 document type: cmdlet
 external help file: NovaModuleTools-Help.xml
-HelpUri: ''
+HelpUri: 'https://www.novamoduletools.com/core-workflows.html#test'
 Locale: en-US
 Module Name: NovaModuleTools
 ms.date: 04/26/2026

--- a/docs/NovaModuleTools/en-US/Update-NovaModuleTools.md
+++ b/docs/NovaModuleTools/en-US/Update-NovaModuleTools.md
@@ -1,7 +1,7 @@
 ---
 document type: cmdlet
 external help file: NovaModuleTools-Help.xml
-HelpUri: ''
+HelpUri: 'https://www.novamoduletools.com/versioning-and-updates.html#self-update'
 Locale: en-US
 Module Name: NovaModuleTools
 ms.date: 04/25/2026

--- a/docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md
+++ b/docs/NovaModuleTools/en-US/Update-NovaModuleVersion.md
@@ -1,7 +1,7 @@
 ---
 document type: cmdlet
 external help file: NovaModuleTools-Help.xml
-HelpUri: ''
+HelpUri: 'https://www.novamoduletools.com/versioning-and-updates.html#bump'
 Locale: en-US
 Module Name: NovaModuleTools
 ms.date: 04/25/2026

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -209,6 +209,52 @@ PS&gt; Initialize-NovaModule -Example -Path ~/Work</code></pre>
                     </article>
 
                     <article class="command-card">
+                        <h3>Apply or refresh the copilot workflow</h3>
+                        <div class="surface-note" data-command-visibility="command-line" hidden>
+                            <p><strong>Launcher route:</strong> <code>nova copilot</code></p>
+                        </div>
+                        <div class="surface-note" data-command-visibility="powershell">
+                            <p><strong>Cmdlet:</strong> <code>Invoke-NovaAgenticCopilotScaffold</code></p>
+                        </div>
+                        <p>Add Nova's maintained <strong>Agentic Copilot</strong> workflow to an existing project, or
+                            refresh an older Nova-managed scaffold to the current version.</p>
+                        <ul class="plain-list">
+                            <li><strong>Use when:</strong> the project already exists and you want Nova to add or refresh
+                                the managed Agentic guidance files without recreating the scaffold
+                            </li>
+                            <li><strong>Requires:</strong> a valid <code>project.json</code> and an explicit short name
+                                on every run for placeholders such as <code>Invoke-&lt;ShortName&gt;*</code></li>
+                            <li data-command-visibility="command-line" hidden><strong>Common options:</strong>
+                                <code>--short-name</code>, <code>--path</code>, <code>--what-if</code>, and
+                                <code>--override-warning</code> / <code>-o</code></li>
+                            <li data-command-visibility="powershell"><strong>Common parameters:</strong>
+                                <code>-ShortName</code>, <code>-Path</code>, <code>-WhatIf</code>, and
+                                <code>-OverrideWarning</code></li>
+                            <li><strong>Default safety:</strong> Nova prompts before overwriting the managed scaffold
+                                paths and only creates <code>README.md</code>, <code>CHANGELOG.md</code>, and
+                                <code>RELEASE_NOTE.md</code> when they are missing
+                            </li>
+                        </ul>
+                        <div class="surface-example" data-command-example>
+                            <div class="surface-example__meta">
+                                <p class="surface-example__title">Apply the managed scaffold</p>
+                                <p class="surface-example__status">Showing: <span
+                                        data-command-surface-label>PowerShell</span></p>
+                            </div>
+                            <div class="surface-example__surface" data-command-surface="command-line" hidden>
+                                <pre><code>% nova copilot --short-name NMT
+% nova copilot --path ~/Work/MyModule --short-name NMT -o</code></pre>
+                            </div>
+                            <div class="surface-example__surface" data-command-surface="powershell">
+                                <pre><code>PS&gt; Invoke-NovaAgenticCopilotScaffold -ShortName NMT
+PS&gt; Invoke-NovaAgenticCopilotScaffold -Path ~/Work/MyModule -ShortName NMT -OverrideWarning</code></pre>
+                            </div>
+                        </div>
+                        <p><a class="text-link" href="./core-workflows.html#agentic-copilot">See the copilot apply
+                            guide</a></p>
+                    </article>
+
+                    <article class="command-card">
                         <h3>Inspect the current project</h3>
                         <div class="surface-note" data-command-visibility="command-line" hidden>
                             <p><strong>Launcher route:</strong> <code>nova info</code></p>

--- a/docs/core-workflows.html
+++ b/docs/core-workflows.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
-    <title>NovaModuleTools — Core workflows for scaffold, build, test, import, and reload</title>
-    <meta content="Follow the normal NovaModuleTools workflow for scaffolding, building, testing, importing, and reloading PowerShell modules during day-to-day development."
+    <title>NovaModuleTools — Core workflows for scaffold, copilot guidance, build, test, import, and reload</title>
+    <meta content="Follow the normal NovaModuleTools workflow for scaffolding, applying managed copilot guidance, building, testing, importing, and reloading PowerShell modules during day-to-day development."
           name="description">
     <meta content="index,follow,max-image-preview:large" name="robots">
     <meta content="#0b1020" name="theme-color">
@@ -12,14 +12,14 @@
     <link href="./assets/icon.png" rel="icon" type="image/png">
     <link href="./assets/icon.png" rel="apple-touch-icon">
     <meta content="article" property="og:type">
-    <meta content="NovaModuleTools — Core workflows for scaffold, build, test, import, and reload" property="og:title">
-    <meta content="Use this guide for the normal NovaModuleTools lifecycle: scaffold a project, build the module, run tests, import the built output, and reload safely after changes."
+    <meta content="NovaModuleTools — Core workflows for scaffold, copilot guidance, build, test, import, and reload" property="og:title">
+    <meta content="Use this guide for the normal NovaModuleTools lifecycle: scaffold a project, apply or refresh managed copilot guidance, build the module, run tests, import the built output, and reload safely after changes."
           property="og:description">
     <meta content="https://www.novamoduletools.com/core-workflows.html" property="og:url">
     <meta content="https://www.novamoduletools.com/assets/icon.png" property="og:image">
     <meta content="summary" name="twitter:card">
-    <meta content="NovaModuleTools — Core workflows for scaffold, build, test, import, and reload" name="twitter:title">
-    <meta content="Use this guide for the normal NovaModuleTools lifecycle: scaffold a project, build the module, run tests, import the built output, and reload safely after changes."
+    <meta content="NovaModuleTools — Core workflows for scaffold, copilot guidance, build, test, import, and reload" name="twitter:title">
+    <meta content="Use this guide for the normal NovaModuleTools lifecycle: scaffold a project, apply or refresh managed copilot guidance, build the module, run tests, import the built output, and reload safely after changes."
           name="twitter:description">
     <link href="./assets/site.css" rel="stylesheet">
     <script type="application/ld+json">
@@ -27,7 +27,7 @@
             "@context": "https://schema.org",
             "@type": "TechArticle",
             "headline": "NovaModuleTools core workflows",
-            "description": "The daily scaffold, build, test, import, and reload workflow for NovaModuleTools.",
+            "description": "The daily scaffold, managed copilot guidance, build, test, import, and reload workflow for NovaModuleTools.",
             "url": "https://www.novamoduletools.com/core-workflows.html"
         }
     </script>
@@ -77,7 +77,7 @@
 <main class="page-shell">
     <section class="guide-hero">
         <p class="eyebrow">How-to Guides</p>
-        <h1>Use the normal Nova loop: scaffold → build → test → import → reload</h1>
+        <h1>Use the normal Nova loop: scaffold → copilot guidance → build → test → import → reload</h1>
         <p class="lead">Most of your time with NovaModuleTools should stay in this loop. Once you are comfortable here,
             packaging, upload, publish, and release become much easier to reason about.</p>
     </section>
@@ -87,6 +87,7 @@
             <h2>On this page</h2>
             <ul class="toc-list">
                 <li><a href="#scaffold">Create the project</a></li>
+                <li><a href="#agentic-copilot">Apply the copilot workflow to an existing project</a></li>
                 <li><a href="#build">Build the module</a></li>
                 <li><a href="#test">Run the tests</a></li>
                 <li><a href="#import">Import the built output</a></li>
@@ -158,6 +159,41 @@ PS&gt; Initialize-NovaModule -Example -Path ~/Work</code></pre>
                 <p>Use the example scaffold when you want the shortest path to understanding a real project layout, test
                     suite, and package configuration. Use the minimal scaffold when you already know the structure you
                     want.</p>
+            </section>
+
+            <section class="content-section" id="agentic-copilot">
+                <h2>Apply the copilot workflow to an existing project</h2>
+                <p>Use this workflow when the project already exists and you want Nova to add or refresh its managed
+                    <strong>Agentic Copilot</strong> guidance without recreating the module scaffold.</p>
+                <div class="surface-example" data-command-example>
+                    <div class="surface-example__meta">
+                        <p class="surface-example__title">Apply or refresh the managed scaffold</p>
+                        <p class="surface-example__status">Showing: <span data-command-surface-label>PowerShell</span>
+                        </p>
+                    </div>
+                    <div class="surface-example__surface" data-command-surface="powershell">
+                        <pre><code>PS&gt; Invoke-NovaAgenticCopilotScaffold -ShortName NMT
+PS&gt; Invoke-NovaAgenticCopilotScaffold -Path ~/Work/MyModule -ShortName NMT -OverrideWarning</code></pre>
+                    </div>
+                    <div class="surface-example__surface" data-command-surface="command-line" hidden>
+                        <pre><code>% nova copilot --short-name NMT
+% nova copilot --path ~/Work/MyModule --short-name NMT -o</code></pre>
+                    </div>
+                </div>
+                <p>The target directory must contain a valid <code>project.json</code>. Nova reads
+                    <code>ProjectName</code> and <code>Description</code> from that file and requires an explicit short
+                    name on every run for generated placeholders such as <code>Invoke-&lt;ShortName&gt;*</code>.</p>
+                <p>Nova refreshes only the managed Agentic guidance paths under <code>.github/</code> together with
+                    <code>AGENTS.md</code> and <code>CONTRIBUTING.md</code>. Existing <code>README.md</code>,
+                    <code>CHANGELOG.md</code>, and <code>RELEASE_NOTE.md</code> are preserved and are created only when
+                    they are missing.</p>
+                <p>By default Nova prompts before it overwrites the managed scaffold paths.</p>
+                <p data-command-visibility="powershell">Use <code>-OverrideWarning</code> only when you intentionally
+                    want a non-interactive apply, and use <code>-WhatIf</code> when you want to preview the changes
+                    first.</p>
+                <p data-command-visibility="command-line" hidden>Use <code>--override-warning</code> /
+                    <code>-o</code> only when you intentionally want a non-interactive apply, and use
+                    <code>--what-if</code> when you want to preview the changes first.</p>
             </section>
 
             <section class="content-section" id="build">

--- a/project.json
+++ b/project.json
@@ -44,7 +44,9 @@
       "Enabled": true,
       "Path": [
         "src/public/*.ps1",
-        "src/private/**/*.ps1"
+        "src/private/*.ps1",
+        "src/private/*/*.ps1",
+        "src/private/*/*/*.ps1"
       ],
       "CoveragePercentTarget": 99,
       "OutputPath": "artifacts/coverage.xml",

--- a/src/private/cli/ConvertFromNovaCopilotCliArgument.ps1
+++ b/src/private/cli/ConvertFromNovaCopilotCliArgument.ps1
@@ -1,0 +1,39 @@
+function ConvertFrom-NovaCopilotCliArgument {
+    [CmdletBinding()]
+    param(
+        [string[]]$Arguments
+    )
+
+    $Arguments = ConvertTo-NovaCliArgumentArray -BoundParameters $PSBoundParameters -Arguments $Arguments
+    $options = @{}
+    $index = 0
+
+    while ($index -lt $Arguments.Count) {
+        $token = $Arguments[$index]
+
+        switch -Regex ($token) {
+            '^(--path|-p)$' {
+                $options.Path = Get-NovaCliRequiredArgumentValue -Arguments $Arguments -Index ([ref]$index) -OptionName '--path'
+            }
+            '^(--short-name|-n)$' {
+                $options.ShortName = Get-NovaCliRequiredArgumentValue -Arguments $Arguments -Index ([ref]$index) -OptionName '--short-name'
+            }
+            '^(--override-warning|-o)$' {
+                $options.OverrideWarning = $true
+            }
+            '^(--what-if|-w)$' {
+                $options.WhatIf = $true
+            }
+            '^(--verbose|-v)$' {
+                $options.Verbose = $true
+            }
+            default {
+                Stop-NovaOperation -Message "Unknown argument: $token" -ErrorId 'Nova.Validation.UnknownCliArgument' -Category InvalidArgument -TargetObject $token
+            }
+        }
+
+        $index++
+    }
+
+    return $options
+}

--- a/src/private/cli/GetNovaCliCommandHelpDefinition.ps1
+++ b/src/private/cli/GetNovaCliCommandHelpDefinition.ps1
@@ -4,6 +4,7 @@ function Get-NovaCliHelpCommandNameList {
 
     return @(
         'init'
+        'copilot'
         'info'
         'version'
         'build'

--- a/src/private/cli/InvokeNovaCliCommandRoute.ps1
+++ b/src/private/cli/InvokeNovaCliCommandRoute.ps1
@@ -191,6 +191,9 @@ function Invoke-NovaCliCommandRoute {
         'init' {
             return Invoke-NovaCliInitCommand -Arguments $InvocationContext.Arguments -ForwardedParameters $mutatingCommonParameters -WhatIfEnabled:$InvocationContext.WhatIfEnabled
         }
+        'copilot' {
+            return Invoke-NovaCliCopilotCommand -Arguments $InvocationContext.Arguments -CommonParameters $InvocationContext.CommonParameters -MutatingCommonParameters $InvocationContext.MutatingCommonParameters
+        }
         'bump' {
             return Invoke-NovaCliBumpRouteCommand -InvocationContext $InvocationContext
         }

--- a/src/private/cli/InvokeNovaCliCopilotCommand.ps1
+++ b/src/private/cli/InvokeNovaCliCopilotCommand.ps1
@@ -1,0 +1,15 @@
+function Invoke-NovaCliCopilotCommand {
+    [CmdletBinding()]
+    param(
+        [string[]]$Arguments,
+        [Parameter(Mandatory)][hashtable]$CommonParameters,
+        [Parameter(Mandatory)][hashtable]$MutatingCommonParameters
+    )
+
+    $options = ConvertFrom-NovaCopilotCliArgument -Arguments $Arguments
+    $invocationParameters = Merge-NovaCliParameterSet -BaseParameters @{} -AdditionalParameters $CommonParameters
+    $invocationParameters = Merge-NovaCliParameterSet -BaseParameters $invocationParameters -AdditionalParameters $MutatingCommonParameters
+    $invocationParameters = Merge-NovaCliParameterSet -BaseParameters $invocationParameters -AdditionalParameters $options
+
+    return Invoke-NovaAgenticCopilotScaffold @invocationParameters
+}

--- a/src/private/scaffold/GetNovaAgenticCopilotScaffoldWorkflowContext.ps1
+++ b/src/private/scaffold/GetNovaAgenticCopilotScaffoldWorkflowContext.ps1
@@ -1,0 +1,106 @@
+function Assert-NovaAgenticCopilotShortName {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$ShortName
+    )
+
+    if ( [string]::IsNullOrWhiteSpace($ShortName)) {
+        Stop-NovaOperation -Message 'Project short name is required when applying the Agentic Copilot scaffold.' -ErrorId 'Nova.Validation.AgenticCopilotProjectShortNameMissing' -Category InvalidData -TargetObject 'ShortName'
+    }
+
+    if ($ShortName -notmatch '^[A-Za-z][A-Za-z0-9]*$') {
+        Stop-NovaOperation -Message 'Project short name is invalid. Use a short word that starts with a letter and contains only letters or numbers.' -ErrorId 'Nova.Validation.ScaffoldProjectShortNameInvalid' -Category InvalidData -TargetObject $ShortName
+    }
+}
+
+function Test-NovaAgenticCopilotProjectUsesPester {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo
+    )
+
+    return $ProjectInfo.PSObject.Properties.Name -contains 'Pester'
+}
+
+function Get-NovaAgenticCopilotManagedOverwritePathList {
+    [CmdletBinding()]
+    param()
+
+    return @(
+        '.github/agents/'
+        '.github/instructions/'
+        '.github/prompts/'
+        '.github/skills/'
+        '.github/copilot-instructions.md'
+        '.github/pull_request_template.md'
+        'AGENTS.md'
+        'CONTRIBUTING.md'
+    )
+}
+
+function Get-NovaAgenticCopilotAddOnlyPathList {
+    [CmdletBinding()]
+    param()
+
+    return @(
+        'README.md'
+        'CHANGELOG.md'
+        'RELEASE_NOTE.md'
+    )
+}
+
+function Get-NovaAgenticCopilotScaffoldPolicy {
+    [CmdletBinding()]
+    param()
+
+    return [pscustomobject]@{
+        ManagedOverwritePathList = @(Get-NovaAgenticCopilotManagedOverwritePathList)
+        AddOnlyPathList = @(Get-NovaAgenticCopilotAddOnlyPathList)
+    }
+}
+
+function Get-NovaAgenticCopilotScaffoldAnswerSet {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
+        [Parameter(Mandatory)][string]$ShortName
+    )
+
+    $enablePester = if (Test-NovaAgenticCopilotProjectUsesPester -ProjectInfo $ProjectInfo) {
+        'Yes'
+    } else {
+        'No'
+    }
+
+    return [ordered]@{
+        ProjectName = $ProjectInfo.ProjectName
+        Description = $ProjectInfo.Description
+        ProjectShortName = $ShortName
+        EnablePester = $enablePester
+    }
+}
+
+function Get-NovaAgenticCopilotScaffoldWorkflowContext {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$ShortName,
+        [switch]$OverrideWarningRequested
+    )
+
+    $projectInfo = Get-NovaProjectInfo -Path $Path
+    Assert-NovaAgenticCopilotShortName -ShortName $ShortName
+    $scaffoldPolicy = Get-NovaAgenticCopilotScaffoldPolicy
+
+    return [pscustomobject]@{
+        ProjectInfo = $projectInfo
+        ProjectRoot = $projectInfo.ProjectRoot
+        AnswerSet = Get-NovaAgenticCopilotScaffoldAnswerSet -ProjectInfo $projectInfo -ShortName $ShortName
+        OverrideWarningRequested = [bool]$OverrideWarningRequested
+        ManagedOverwritePathList = @($scaffoldPolicy.ManagedOverwritePathList)
+        AddOnlyPathList = @($scaffoldPolicy.AddOnlyPathList)
+        ScaffoldPolicy = $scaffoldPolicy
+        Target = $projectInfo.ProjectRoot
+        Action = 'Apply Nova Agentic Copilot scaffold'
+    }
+}

--- a/src/private/scaffold/InitializeNovaModuleAgenticCopilotScaffold.ps1
+++ b/src/private/scaffold/InitializeNovaModuleAgenticCopilotScaffold.ps1
@@ -109,6 +109,76 @@ function Test-NovaModuleAgenticCopilotTemplateFileEnabled {
     return $Answer.ContainsKey('EnablePester') -and $Answer.EnablePester -eq 'Yes'
 }
 
+function Test-NovaModuleAgenticCopilotPathMatchesPolicyEntry {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$RelativePath,
+        [Parameter(Mandatory)][string]$Entry
+    )
+
+    if ( $Entry.EndsWith('/', [System.StringComparison]::Ordinal)) {
+        return $RelativePath.StartsWith($Entry, [System.StringComparison]::OrdinalIgnoreCase)
+    }
+
+    return $RelativePath.Equals($Entry, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function Test-NovaModuleAgenticCopilotPathMatchesPolicyList {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$RelativePath,
+        [string[]]$EntryList = @()
+    )
+
+    foreach ($entry in @($EntryList)) {
+        if (Test-NovaModuleAgenticCopilotPathMatchesPolicyEntry -RelativePath $RelativePath -Entry $entry) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Get-NovaModuleAgenticCopilotDestinationWriteMode {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$RelativePath,
+        [AllowNull()][pscustomobject]$ScaffoldPolicy
+    )
+
+    if ($null -eq $ScaffoldPolicy) {
+        return 'Overwrite'
+    }
+
+    if (Test-NovaModuleAgenticCopilotPathMatchesPolicyList -RelativePath $RelativePath -EntryList $ScaffoldPolicy.ManagedOverwritePathList) {
+        return 'Overwrite'
+    }
+
+    if (Test-NovaModuleAgenticCopilotPathMatchesPolicyList -RelativePath $RelativePath -EntryList $ScaffoldPolicy.AddOnlyPathList) {
+        return 'AddIfMissing'
+    }
+
+    return 'Skip'
+}
+
+function Test-NovaModuleAgenticCopilotShouldWriteDestinationFile {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$DestinationPath,
+        [Parameter(Mandatory)][string]$WriteMode
+    )
+
+    if ($WriteMode -eq 'Overwrite') {
+        return $true
+    }
+
+    if ($WriteMode -eq 'AddIfMissing') {
+        return -not (Test-Path -LiteralPath $DestinationPath)
+    }
+
+    return $false
+}
+
 function ConvertTo-NovaModuleAgenticCopilotNormalizedFileContent {
     [CmdletBinding()]
     param(
@@ -169,7 +239,8 @@ function Initialize-NovaModuleAgenticCopilotScaffold {
     param(
         [Parameter(Mandatory)][hashtable]$Answer,
         [Parameter(Mandatory)][string]$ProjectRoot,
-        [switch]$Example
+        [switch]$Example,
+        [AllowNull()][pscustomobject]$ScaffoldPolicy = $null
     )
 
     $templateRoot = Get-NovaModuleAgenticCopilotTemplateRoot
@@ -188,6 +259,11 @@ function Initialize-NovaModuleAgenticCopilotScaffold {
         }
 
         $destinationPath = Join-Path $ProjectRoot ($relativePath -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+        $writeMode = Get-NovaModuleAgenticCopilotDestinationWriteMode -RelativePath $relativePath -ScaffoldPolicy $ScaffoldPolicy
+        if (-not (Test-NovaModuleAgenticCopilotShouldWriteDestinationFile -DestinationPath $destinationPath -WriteMode $writeMode)) {
+            continue
+        }
+
         $templateContent = Get-Content -LiteralPath $templateFile.FullName -Raw
         $destinationContent = Get-NovaModuleAgenticCopilotDestinationContent -RelativePath $relativePath -TemplateContent $templateContent -ScaffoldContext $scaffoldContext
         Write-NovaModuleAgenticCopilotDestinationFile -DestinationPath $destinationPath -Content $destinationContent

--- a/src/private/scaffold/InvokeNovaAgenticCopilotScaffoldWorkflow.ps1
+++ b/src/private/scaffold/InvokeNovaAgenticCopilotScaffoldWorkflow.ps1
@@ -1,0 +1,68 @@
+function Get-NovaAgenticCopilotScaffoldWarningMessage {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext
+    )
+
+    $messageLines = @(
+        "Nova will apply the managed Agentic Copilot scaffold in $( $WorkflowContext.ProjectRoot )."
+        ''
+        'These paths will be overwritten:'
+    )
+    $messageLines += @($WorkflowContext.ManagedOverwritePathList | ForEach-Object {"- $_"})
+    $messageLines += @(
+        ''
+        'These files will only be created when missing:'
+    )
+    $messageLines += @($WorkflowContext.AddOnlyPathList | ForEach-Object {"- $_"})
+    return $messageLines -join [Environment]::NewLine
+}
+
+function Read-NovaAgenticCopilotScaffoldWarningChoice {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Message
+    )
+
+    $choices = [System.Management.Automation.Host.ChoiceDescription[]]@(
+        [System.Management.Automation.Host.ChoiceDescription]::new('&Yes', 'Apply the scaffold.'),
+        [System.Management.Automation.Host.ChoiceDescription]::new('&No', 'Cancel the operation.')
+    )
+
+    return $Host.UI.PromptForChoice('Confirm', $Message, $choices, 1)
+}
+
+function Confirm-NovaAgenticCopilotScaffoldWarning {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext
+    )
+
+    if ($WorkflowContext.OverrideWarningRequested) {
+        Write-Verbose 'Continuing Agentic Copilot scaffold apply because OverrideWarning was specified.'
+        return
+    }
+
+    $selection = Read-NovaAgenticCopilotScaffoldWarningChoice -Message (Get-NovaAgenticCopilotScaffoldWarningMessage -WorkflowContext $WorkflowContext)
+    if ($selection -eq 0) {
+        return
+    }
+
+    Stop-NovaOperation -Message 'Operation cancelled.' -ErrorId 'Nova.Workflow.AgenticCopilotScaffoldCancelled' -Category OperationStopped -TargetObject $WorkflowContext.ProjectRoot
+}
+
+function Invoke-NovaAgenticCopilotScaffoldWorkflow {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$WorkflowContext,
+        [switch]$ShouldRun
+    )
+
+    if (-not $ShouldRun) {
+        return
+    }
+
+    Confirm-NovaAgenticCopilotScaffoldWarning -WorkflowContext $WorkflowContext
+    Initialize-NovaModuleAgenticCopilotScaffold -Answer $WorkflowContext.AnswerSet -ProjectRoot $WorkflowContext.ProjectRoot -ScaffoldPolicy $WorkflowContext.ScaffoldPolicy
+    Write-Message "Agentic Copilot scaffold applied to $( $WorkflowContext.ProjectInfo.ProjectName )" -color Green
+}

--- a/src/private/scaffold/InvokeNovaAgenticCopilotScaffoldWorkflow.ps1
+++ b/src/private/scaffold/InvokeNovaAgenticCopilotScaffoldWorkflow.ps1
@@ -21,7 +21,8 @@ function Get-NovaAgenticCopilotScaffoldWarningMessage {
 function Read-NovaAgenticCopilotScaffoldWarningChoice {
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][string]$Message
+        [Parameter(Mandatory)][string]$Message,
+        [Parameter()][object]$HostUi = $Host.UI
     )
 
     $choices = [System.Management.Automation.Host.ChoiceDescription[]]@(
@@ -29,7 +30,7 @@ function Read-NovaAgenticCopilotScaffoldWarningChoice {
         [System.Management.Automation.Host.ChoiceDescription]::new('&No', 'Cancel the operation.')
     )
 
-    return $Host.UI.PromptForChoice('Confirm', $Message, $choices, 1)
+    return $HostUi.PromptForChoice('Confirm', $Message, $choices, 1)
 }
 
 function Confirm-NovaAgenticCopilotScaffoldWarning {

--- a/src/public/InvokeNovaAgenticCopilotScaffold.ps1
+++ b/src/public/InvokeNovaAgenticCopilotScaffold.ps1
@@ -1,0 +1,16 @@
+function Invoke-NovaAgenticCopilotScaffold {
+    [CmdletBinding(SupportsShouldProcess = $true)]
+    param(
+        [string]$Path = (Get-Location).Path,
+        [Parameter(Mandatory)][string]$ShortName,
+        [switch]$OverrideWarning
+    )
+
+    $workflowContext = Get-NovaAgenticCopilotScaffoldWorkflowContext -Path $Path -ShortName $ShortName -OverrideWarningRequested:$OverrideWarning
+    $shouldRun = $PSCmdlet.ShouldProcess($workflowContext.Target, $workflowContext.Action)
+    if (-not $shouldRun -and -not $WhatIfPreference) {
+        return
+    }
+
+    Invoke-NovaAgenticCopilotScaffoldWorkflow -WorkflowContext $workflowContext -ShouldRun:$shouldRun
+}

--- a/src/resources/cli/NovaCliHelp.txt
+++ b/src/resources/cli/NovaCliHelp.txt
@@ -6,6 +6,7 @@ start a new module project
    init       Create a new Nova module scaffold
 
 work with the current project
+   copilot    Apply or refresh the Nova Agentic Copilot scaffold in the current project
    info       Show project information
    version    Show the current project version, or use --installed/-i for the locally installed project module version
    build      Build the module into the dist folder
@@ -25,8 +26,8 @@ global options
    --version, -v  Show the installed NovaModuleTools module name and version, including prerelease label when present
 
 routed command options
-   --verbose, -v  Show verbose output for build, test, package, deploy, bump, update, notification, publish, and release
-   --what-if, -w  Preview build, test, deploy, bump, update, notification, publish, and release without changing files
+   --verbose, -v  Show verbose output for copilot, build, test, package, deploy, bump, update, notification, publish, and release
+   --what-if, -w  Preview copilot, build, test, deploy, bump, update, notification, publish, and release without changing files
    --confirm, -c  Request confirmation before mutating routed commands; nova bump keeps its CLI-friendly confirmation prompt
 
 Examples:
@@ -37,6 +38,9 @@ Examples:
    nova init -p ~/Work
    nova init --example
    nova init -e --path ~/Work
+   nova copilot --short-name NMT
+   nova copilot --path ~/Work/MyModule --short-name NMT
+   nova copilot -n NMT -o
    nova info
    nova version
    nova version --installed

--- a/src/resources/cli/help/copilot.psd1
+++ b/src/resources/cli/help/copilot.psd1
@@ -1,0 +1,59 @@
+@{
+    Command = 'copilot'
+    Summary = 'Apply or refresh the Nova Agentic Copilot scaffold in the current project.'
+    Usage = 'nova copilot [<options>]'
+    Description = @(
+        'Apply or refresh Nova''s managed Agentic Copilot scaffold in an existing project root.',
+        'This command refreshes Nova-managed guidance paths and creates README.md, CHANGELOG.md, and RELEASE_NOTE.md only when they are missing.',
+        'Use --short-name to provide the placeholder short name used in generated guidance such as Invoke-<ShortName>*.',
+        'By default Nova prompts before overwriting the managed scaffold paths. Use --override-warning only when you intentionally want a non-interactive apply.',
+        'For more information, documentation, and examples, visit:',
+        'https://www.novamoduletools.com/core-workflows.html#agentic-copilot'
+    )
+    Options = @(
+        @{
+            Short = '-p'
+            Long = '--path'
+            Placeholder = '<path>'
+            Description = 'Use a specific project root instead of the current location.'
+        },
+        @{
+            Short = '-n'
+            Long = '--short-name'
+            Placeholder = '<name>'
+            Description = 'Provide the short placeholder name used in generated guidance content.'
+        },
+        @{
+            Short = '-o'
+            Long = '--override-warning'
+            Placeholder = ''
+            Description = 'Skip the overwrite warning prompt and apply the managed scaffold directly.'
+        },
+        @{
+            Short = '-v'
+            Long = '--verbose'
+            Placeholder = ''
+            Description = 'Show verbose output for this command.'
+        },
+        @{
+            Short = '-w'
+            Long = '--what-if'
+            Placeholder = ''
+            Description = 'Preview the scaffold apply workflow without changing files.'
+        }
+    )
+    Examples = @(
+        @{
+            Command = 'nova copilot --short-name NMT'
+            Description = 'Apply or refresh the Agentic Copilot scaffold in the current project.'
+        },
+        @{
+            Command = 'nova copilot --path ~/Work/MyModule --short-name NMT --override-warning'
+            Description = 'Apply the managed scaffold non-interactively in a specific project root.'
+        },
+        @{
+            Command = 'nova copilot -n NMT -o'
+            Description = 'Apply the managed scaffold non-interactively in the current project by using the short override flag.'
+        }
+    )
+}

--- a/tests/ArchitectureGuardrails.Tests.ps1
+++ b/tests/ArchitectureGuardrails.Tests.ps1
@@ -88,6 +88,7 @@ Describe 'Architecture guardrails' {
             [pscustomobject]@{Path = 'src/public/InitializeNovaModule.ps1'; ExpectedHelpers = @('Get-NovaModuleInitializationWorkflowContext', 'Invoke-NovaModuleInitializationWorkflow')}
             [pscustomobject]@{Path = 'src/public/InstallNovaCli.ps1'; ExpectedHelpers = @('Get-NovaCliInstallWorkflowContext', 'Invoke-NovaCliInstallWorkflow', 'Write-NovaModuleReleaseNotesLink')}
             [pscustomobject]@{Path = 'src/public/InvokeNovaBuild.ps1'; ExpectedHelpers = @('Get-NovaBuildWorkflowContext', 'Invoke-NovaBuildWorkflow')}
+            [pscustomobject]@{Path = 'src/public/InvokeNovaAgenticCopilotScaffold.ps1'; ExpectedHelpers = @('Get-NovaAgenticCopilotScaffoldWorkflowContext', 'Invoke-NovaAgenticCopilotScaffoldWorkflow')}
             [pscustomobject]@{Path = 'src/public/InvokeNovaCli.ps1'; ExpectedHelpers = @('Get-NovaCliInvocationContext', 'Invoke-NovaCliCommandRoute')}
             [pscustomobject]@{Path = 'src/public/InvokeNovaRelease.ps1'; ExpectedHelpers = @('Get-NovaDynamicReleaseParameterDictionary', 'Get-NovaProjectInfo', 'Get-NovaPublishWorkflowContext', 'Get-NovaReleasePublishOption', 'Get-NovaReleaseRequest', 'Get-NovaReleaseRequestedPath', 'Get-NovaShouldProcessForwardingParameter', 'Invoke-NovaReleaseWorkflow', 'Write-NovaPublishWorkflowContext')}
             [pscustomobject]@{Path = 'src/public/NewNovaModulePackage.ps1'; ExpectedHelpers = @('Get-NovaPackageWorkflowContext', 'Get-NovaShouldProcessForwardingParameter', 'Invoke-NovaPackageWorkflow')}

--- a/tests/ProjectPesterCoverageConfiguration.Tests.ps1
+++ b/tests/ProjectPesterCoverageConfiguration.Tests.ps1
@@ -1,0 +1,15 @@
+BeforeAll {
+    $projectRoot = Split-Path -Parent $PSScriptRoot
+    $script:projectJson = Get-Content -LiteralPath (Join-Path $projectRoot 'project.json') -Raw | ConvertFrom-Json -AsHashtable
+}
+
+Describe 'project.json Pester code coverage configuration' {
+    It 'uses explicit private-source globs so nested helpers stay measurable' {
+        $script:projectJson.Pester.CodeCoverage.Path | Should -Be @(
+            'src/public/*.ps1'
+            'src/private/*.ps1'
+            'src/private/*/*.ps1'
+            'src/private/*/*/*.ps1'
+        )
+    }
+}

--- a/tests/private/build/manifest/AssertManifestSchema.Tests.ps1
+++ b/tests/private/build/manifest/AssertManifestSchema.Tests.ps1
@@ -2,8 +2,12 @@ BeforeAll {
     $projectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)))
     . (Join-Path $projectRoot 'src/private/build/manifest/AssertManifestSchema.ps1')
 
-    function Stop-NovaOperation {param([string]$Message, [string]$ErrorId, $Category, $TargetObject)
-        throw $Message
+    function Stop-NovaOperation {
+        param([string]$Message, [string]$ErrorId, $Category, $TargetObject)
+
+        $exception = [System.Exception]::new($Message)
+        $record = [System.Management.Automation.ErrorRecord]::new($exception, $ErrorId, $Category, $TargetObject)
+        throw $record
     }
 }
 
@@ -13,8 +17,22 @@ Describe 'Assert-ManifestSchema' {
             Should -Not -Throw
     }
 
-    It 'throws when the manifest contains unknown keys' {
-        {Assert-ManifestSchema -Manifest @{Author = 'me'; Bogus = 1} -AllowedParameter @('Author')} |
-            Should -Throw
+    It 'throws a sorted error when the manifest contains unknown keys' {
+        $thrown = $null
+
+        try {
+            Assert-ManifestSchema -Manifest @{
+                Zebra = 1
+                Author = 'me'
+                Alpha = 2
+            } -AllowedParameter @('Author')
+        } catch {
+            $thrown = $_
+        }
+
+        $thrown | Should -Not -BeNullOrEmpty
+        $thrown.FullyQualifiedErrorId | Should -Be 'Nova.Configuration.ManifestUnknownParameter'
+        $thrown.Exception.Message | Should -Be 'Unknown parameter(s) in Manifest: Alpha, Zebra'
+        @($thrown.TargetObject) | Should -Be @('Alpha', 'Zebra')
     }
 }

--- a/tests/private/cli/ConvertFromNovaCopilotCliArgument.Tests.ps1
+++ b/tests/private/cli/ConvertFromNovaCopilotCliArgument.Tests.ps1
@@ -1,0 +1,31 @@
+BeforeAll {
+    $projectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+    . (Join-Path $projectRoot 'src/private/cli/ConvertFromNovaCopilotCliArgument.ps1')
+    . (Join-Path $projectRoot 'src/private/cli/GetNovaCliRequiredArgumentValue.ps1')
+
+    . (Join-Path $PSScriptRoot 'ConvertFromNovaInitCliArgument.TestSupport.ps1')
+}
+
+Describe 'ConvertFrom-NovaCopilotCliArgument' {
+    It 'reads path and short-name values' {
+        $options = ConvertFrom-NovaCopilotCliArgument -Arguments @('--path', '/tmp/x', '--short-name', 'NMT')
+        $options.Path | Should -Be '/tmp/x'
+        $options.ShortName | Should -Be 'NMT'
+    }
+
+    It 'sets override-warning, what-if, and verbose switches' {
+        $options = ConvertFrom-NovaCopilotCliArgument -Arguments @('--override-warning', '--what-if', '--verbose')
+        $options.OverrideWarning | Should -BeTrue
+        $options.WhatIf | Should -BeTrue
+        $options.Verbose | Should -BeTrue
+    }
+
+    It 'supports -o as a short alias for override-warning' {
+        $options = ConvertFrom-NovaCopilotCliArgument -Arguments @('-o')
+        $options.OverrideWarning | Should -BeTrue
+    }
+
+    It 'throws for unknown switches' {
+        {ConvertFrom-NovaCopilotCliArgument -Arguments @('--bogus')} | Should -Throw '*Unknown argument*'
+    }
+}

--- a/tests/private/cli/GetNovaCliCommandHelpDefinition.Tests.ps1
+++ b/tests/private/cli/GetNovaCliCommandHelpDefinition.Tests.ps1
@@ -9,6 +9,7 @@ Describe 'Get-NovaCliHelpCommandNameList' {
     It 'returns the known CLI command names' {
         $names = Get-NovaCliHelpCommandNameList
         $names | Should -Contain 'init'
+        $names | Should -Contain 'copilot'
         $names | Should -Contain 'release'
         $names | Should -Contain 'notification'
     }

--- a/tests/private/cli/InvokeNovaCliCommandRoute.TestSupport.ps1
+++ b/tests/private/cli/InvokeNovaCliCommandRoute.TestSupport.ps1
@@ -36,6 +36,10 @@ function Invoke-NovaCliInitCommand {
     param($Arguments, $ForwardedParameters, [switch]$WhatIfEnabled)
 }
 
+function Invoke-NovaCliCopilotCommand {
+    param($Arguments, $CommonParameters, $MutatingCommonParameters)
+}
+
 function Invoke-NovaCliUpdateCommand {
     param($Arguments, $ForwardedParameters)
 }

--- a/tests/private/cli/InvokeNovaCliCommandRoute.Tests.ps1
+++ b/tests/private/cli/InvokeNovaCliCommandRoute.Tests.ps1
@@ -186,6 +186,12 @@ Describe 'Invoke-NovaCliCommandRoute' {
         Invoke-NovaCliCommandRoute -InvocationContext (New-TestContext -Command 'init') | Should -Be 'init'
     }
 
+    It 'dispatches copilot' {
+        Mock Invoke-NovaCliCopilotCommand {'copilot'}
+        Mock Confirm-NovaCliRoutedCommand {}
+        Invoke-NovaCliCommandRoute -InvocationContext (New-TestContext -Command 'copilot') | Should -Be 'copilot'
+    }
+
     It 'dispatches bump' {
         Mock Invoke-NovaCliBumpRouteCommand { 'bumped' }
         Mock Confirm-NovaCliRoutedCommand {}

--- a/tests/private/cli/InvokeNovaCliCopilotCommand.TestSupport.ps1
+++ b/tests/private/cli/InvokeNovaCliCopilotCommand.TestSupport.ps1
@@ -1,0 +1,14 @@
+function ConvertFrom-NovaCopilotCliArgument {
+    param([string[]]$Arguments)
+    return @{Path = '/tmp/repo'; ShortName = 'NMT'}
+}
+
+function Invoke-NovaAgenticCopilotScaffold {
+    param($Path, $ShortName, $Verbose, $WhatIf)
+    return [pscustomobject]@{
+        Path = $Path
+        ShortName = $ShortName
+        Verbose = [bool]$Verbose
+        WhatIf = [bool]$WhatIf
+    }
+}

--- a/tests/private/cli/InvokeNovaCliCopilotCommand.Tests.ps1
+++ b/tests/private/cli/InvokeNovaCliCopilotCommand.Tests.ps1
@@ -1,26 +1,8 @@
 BeforeAll {
     $projectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+    . (Join-Path $projectRoot 'src/private/cli/GetNovaCliArgumentRoutingState.ps1')
     . (Join-Path $projectRoot 'src/private/cli/InvokeNovaCliCopilotCommand.ps1')
-
-    function ConvertFrom-NovaCopilotCliArgument {
-        param([string[]]$Arguments) return @{Path = '/tmp/repo'; ShortName = 'NMT'}
-    }
-    function Merge-NovaCliParameterSet {
-        param([hashtable]$BaseParameters, [hashtable]$AdditionalParameters)
-        foreach ($name in $AdditionalParameters.Keys) {
-            $BaseParameters[$name] = $AdditionalParameters[$name]
-        }
-        return $BaseParameters
-    }
-    function Invoke-NovaAgenticCopilotScaffold {
-        param($Path, $ShortName, $Verbose, $WhatIf)
-        return [pscustomobject]@{
-            Path = $Path
-            ShortName = $ShortName
-            Verbose = [bool]$Verbose
-            WhatIf = [bool]$WhatIf
-        }
-    }
+    . (Join-Path $PSScriptRoot 'InvokeNovaCliCopilotCommand.TestSupport.ps1')
 }
 
 Describe 'Invoke-NovaCliCopilotCommand' {

--- a/tests/private/cli/InvokeNovaCliCopilotCommand.Tests.ps1
+++ b/tests/private/cli/InvokeNovaCliCopilotCommand.Tests.ps1
@@ -1,0 +1,35 @@
+BeforeAll {
+    $projectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+    . (Join-Path $projectRoot 'src/private/cli/InvokeNovaCliCopilotCommand.ps1')
+
+    function ConvertFrom-NovaCopilotCliArgument {
+        param([string[]]$Arguments) return @{Path = '/tmp/repo'; ShortName = 'NMT'}
+    }
+    function Merge-NovaCliParameterSet {
+        param([hashtable]$BaseParameters, [hashtable]$AdditionalParameters)
+        foreach ($name in $AdditionalParameters.Keys) {
+            $BaseParameters[$name] = $AdditionalParameters[$name]
+        }
+        return $BaseParameters
+    }
+    function Invoke-NovaAgenticCopilotScaffold {
+        param($Path, $ShortName, $Verbose, $WhatIf)
+        return [pscustomobject]@{
+            Path = $Path
+            ShortName = $ShortName
+            Verbose = [bool]$Verbose
+            WhatIf = [bool]$WhatIf
+        }
+    }
+}
+
+Describe 'Invoke-NovaCliCopilotCommand' {
+    It 'merges parsed options with forwarded common parameters' {
+        $result = Invoke-NovaCliCopilotCommand -Arguments @('--short-name', 'NMT') -CommonParameters @{Verbose = $true} -MutatingCommonParameters @{WhatIf = $true}
+
+        $result.Path | Should -Be '/tmp/repo'
+        $result.ShortName | Should -Be 'NMT'
+        $result.Verbose | Should -BeTrue
+        $result.WhatIf | Should -BeTrue
+    }
+}

--- a/tests/private/quality/duplicates/AssertBuiltModuleHasNoDuplicateFunctionNames.Tests.ps1
+++ b/tests/private/quality/duplicates/AssertBuiltModuleHasNoDuplicateFunctionNames.Tests.ps1
@@ -41,6 +41,25 @@ function Get-Beta {}
         { Assert-BuiltModuleHasNoDuplicateFunctionName -ProjectInfo $projectInfo } | Should -Not -Throw
     }
 
+    It 'throws when the built module file does not exist' {
+        $missingPath = Join-Path $script:projectRoot 'dist/NovaModuleTools/NovaModuleTools.psm1'
+        $projectInfo = [pscustomobject]@{
+            ModuleFilePSM1 = $missingPath
+        }
+
+        {Assert-BuiltModuleHasNoDuplicateFunctionName -ProjectInfo $projectInfo} |
+                Should -Throw -ErrorId 'Nova.Environment.BuiltModuleFileNotFound'
+    }
+
+    It 'throws when the built module does not define any functions' {
+        $projectInfo = New-DuplicateValidationProjectInfo -ProjectRoot $script:projectRoot -ModuleContent '$value = 1' -SourceFileMap @{
+            'src/public/GetAlpha.ps1' = 'function Get-Alpha {}'
+        }
+
+        {Assert-BuiltModuleHasNoDuplicateFunctionName -ProjectInfo $projectInfo} |
+                Should -Throw -ErrorId 'Nova.Workflow.BuiltModuleFunctionListEmpty'
+    }
+
     It 'throws a source-mapped error when the built module contains duplicate top-level function names' {
         $projectInfo = New-DuplicateValidationProjectInfo -ProjectRoot $script:projectRoot -ModuleContent @'
 function Get-Alpha {}

--- a/tests/private/quality/duplicates/FormatDuplicateFunctionErrorMessage.Tests.ps1
+++ b/tests/private/quality/duplicates/FormatDuplicateFunctionErrorMessage.Tests.ps1
@@ -1,0 +1,67 @@
+BeforeAll {
+    $projectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)))
+    . (Join-Path $projectRoot 'src/private/quality/duplicates/GetDuplicateFunctionSourceLine.ps1')
+    . (Join-Path $projectRoot 'src/private/quality/duplicates/FormatDuplicateFunctionErrorMessage.ps1')
+
+    function New-TestDuplicateOccurrence {
+        param(
+            [Parameter(Mandatory)][string]$Name,
+            [Parameter(Mandatory)][int]$Line
+        )
+
+        return [pscustomobject]@{
+            Name = $Name
+            Extent = [pscustomobject]@{
+                StartLineNumber = $Line
+            }
+        }
+    }
+}
+
+Describe 'Format-DuplicateFunctionErrorMessage' {
+    It 'formats duplicate groups, dist lines, and source locations in sorted order' {
+        $duplicateGroup = @(
+            [pscustomobject]@{
+                Name = 'Get-Zeta'
+                Group = @(
+                    New-TestDuplicateOccurrence -Name 'Get-Zeta' -Line 12
+                    New-TestDuplicateOccurrence -Name 'Get-Zeta' -Line 4
+                )
+            }
+            [pscustomobject]@{
+                Name = 'Get-Alpha'
+                Group = @(
+                    New-TestDuplicateOccurrence -Name 'Get-Alpha' -Line 8
+                )
+            }
+        )
+        $sourceIndex = @{
+            'Get-Zeta' = @(
+                [pscustomobject]@{Path = 'src/public/GetZeta.ps1'; Line = 9}
+                [pscustomobject]@{Path = 'src/private/GetZeta.ps1'; Line = 2}
+            )
+            'Get-Alpha' = @(
+                [pscustomobject]@{Path = 'src/public/GetAlpha.ps1'; Line = 5}
+            )
+        }
+
+        $message = Format-DuplicateFunctionErrorMessage -Psm1Path '/repo/dist/NovaModuleTools.psm1' -DuplicateGroup $duplicateGroup -SourceIndex $sourceIndex
+        $lines = $message -split "`n"
+
+        $lines | Should -Be @(
+            'Duplicate top-level function names detected in built module: /repo/dist/NovaModuleTools.psm1'
+            ''
+            '- Get-Alpha'
+            '  - dist line 8'
+            '  - source files:'
+            '    - src/public/GetAlpha.ps1:5'
+            ''
+            '- Get-Zeta'
+            '  - dist line 4'
+            '  - dist line 12'
+            '  - source files:'
+            '    - src/private/GetZeta.ps1:2'
+            '    - src/public/GetZeta.ps1:9'
+        )
+    }
+}

--- a/tests/private/quality/duplicates/GetDuplicateFunctionSourceLine.Tests.ps1
+++ b/tests/private/quality/duplicates/GetDuplicateFunctionSourceLine.Tests.ps1
@@ -1,0 +1,33 @@
+BeforeAll {
+    $projectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)))
+    . (Join-Path $projectRoot 'src/private/quality/duplicates/GetDuplicateFunctionSourceLine.ps1')
+}
+
+Describe 'Get-DuplicateFunctionSourceLine' {
+    It 'returns an empty array when the source index is unavailable' {
+        @(Get-DuplicateFunctionSourceLine -Key 'Get-Alpha').Count | Should -Be 0
+    }
+
+    It 'returns an empty array when the source index does not contain the key' {
+        @(Get-DuplicateFunctionSourceLine -Key 'Get-Alpha' -SourceIndex @{Other = @()}).Count | Should -Be 0
+    }
+
+    It 'returns a sorted source list with a heading when the key exists' {
+        $sourceIndex = @{
+            'Get-Alpha' = @(
+                [pscustomobject]@{Path = 'src/public/GetAlpha.ps1'; Line = 8}
+                [pscustomobject]@{Path = 'src/private/GetAlpha.ps1'; Line = 3}
+                [pscustomobject]@{Path = 'src/private/GetAlpha.ps1'; Line = 1}
+            )
+        }
+
+        $result = Get-DuplicateFunctionSourceLine -Key 'Get-Alpha' -SourceIndex $sourceIndex
+
+        $result | Should -Be @(
+            '  - source files:'
+            '    - src/private/GetAlpha.ps1:1'
+            '    - src/private/GetAlpha.ps1:3'
+            '    - src/public/GetAlpha.ps1:8'
+        )
+    }
+}

--- a/tests/private/quality/duplicates/GetTopLevelFunctionAst.Tests.ps1
+++ b/tests/private/quality/duplicates/GetTopLevelFunctionAst.Tests.ps1
@@ -1,0 +1,38 @@
+BeforeAll {
+    $projectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)))
+    . (Join-Path $projectRoot 'src/private/quality/duplicates/GetTopLevelFunctionAst.ps1')
+
+    function Get-TestAst {
+        param([Parameter(Mandatory)][string]$ScriptText)
+
+        $tokens = $null
+        $errors = $null
+        return [System.Management.Automation.Language.Parser]::ParseInput($ScriptText, [ref]$tokens, [ref]$errors)
+    }
+}
+
+Describe 'Get-TopLevelFunctionAst' {
+    It 'returns only top-level functions when nested functions are present' {
+        $ast = Get-TestAst -ScriptText @'
+function Get-Outer {
+    function Get-Nested {
+    }
+
+    Get-Nested
+}
+
+function Get-Second {
+}
+'@
+
+        $result = Get-TopLevelFunctionAst -Ast $ast
+
+        @($result.Name) | Should -Be @('Get-Outer', 'Get-Second')
+    }
+
+    It 'returns an empty collection when the script has no functions' {
+        $ast = Get-TestAst -ScriptText '$value = 1'
+
+        @(Get-TopLevelFunctionAst -Ast $ast).Count | Should -Be 0
+    }
+}

--- a/tests/private/scaffold/GetNovaAgenticCopilotScaffoldWorkflowContext.Tests.ps1
+++ b/tests/private/scaffold/GetNovaAgenticCopilotScaffoldWorkflowContext.Tests.ps1
@@ -1,0 +1,72 @@
+BeforeAll {
+    $projectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+    . (Join-Path $projectRoot 'src/private/scaffold/GetNovaAgenticCopilotScaffoldWorkflowContext.ps1')
+
+    function Stop-NovaOperation {
+        param([string]$Message, [string]$ErrorId, [System.Management.Automation.ErrorCategory]$Category, $TargetObject)
+        $exception = [System.Exception]::new($Message)
+        $record = [System.Management.Automation.ErrorRecord]::new($exception, $ErrorId, $Category, $TargetObject)
+        throw $record
+    }
+}
+
+Describe 'Assert-NovaAgenticCopilotShortName' {
+    It 'throws when the short name is blank' {
+        {Assert-NovaAgenticCopilotShortName -ShortName ' '} | Should -Throw -ErrorId 'Nova.Validation.AgenticCopilotProjectShortNameMissing'
+    }
+
+    It 'throws when the short name is invalid' {
+        {Assert-NovaAgenticCopilotShortName -ShortName 'bad name'} | Should -Throw -ErrorId 'Nova.Validation.ScaffoldProjectShortNameInvalid'
+    }
+
+    It 'accepts an alphanumeric short name that starts with a letter' {
+        {Assert-NovaAgenticCopilotShortName -ShortName 'NMT1'} | Should -Not -Throw
+    }
+}
+
+Describe 'Test-NovaAgenticCopilotProjectUsesPester' {
+    It 'returns true when project info contains a Pester property' {
+        Test-NovaAgenticCopilotProjectUsesPester -ProjectInfo ([pscustomobject]@{Pester = @{}}) | Should -BeTrue
+    }
+
+    It 'returns false when project info does not contain a Pester property' {
+        Test-NovaAgenticCopilotProjectUsesPester -ProjectInfo ([pscustomobject]@{ProjectName = 'Demo'}) | Should -BeFalse
+    }
+}
+
+Describe 'Get-NovaAgenticCopilotScaffoldWorkflowContext' {
+    It 'builds the workflow context from project metadata and short name' {
+        Mock Get-NovaProjectInfo {
+            [pscustomobject]@{
+                ProjectRoot = '/repo'
+                ProjectName = 'Demo.Module'
+                Description = 'Demo module'
+                Pester = @{Enabled = $true}
+            }
+        }
+
+        $context = Get-NovaAgenticCopilotScaffoldWorkflowContext -Path '/repo' -ShortName 'NMT' -OverrideWarningRequested
+
+        $context.ProjectRoot | Should -Be '/repo'
+        $context.AnswerSet.ProjectName | Should -Be 'Demo.Module'
+        $context.AnswerSet.Description | Should -Be 'Demo module'
+        $context.AnswerSet.ProjectShortName | Should -Be 'NMT'
+        $context.AnswerSet.EnablePester | Should -Be 'Yes'
+        $context.OverrideWarningRequested | Should -BeTrue
+        $context.ManagedOverwritePathList | Should -Contain '.github/agents/'
+        $context.AddOnlyPathList | Should -Contain 'README.md'
+        $context.Action | Should -Be 'Apply Nova Agentic Copilot scaffold'
+    }
+
+    It 'marks projects without Pester as EnablePester = No' {
+        Mock Get-NovaProjectInfo {
+            [pscustomobject]@{
+                ProjectRoot = '/repo'
+                ProjectName = 'Demo.Module'
+                Description = 'Demo module'
+            }
+        }
+
+        (Get-NovaAgenticCopilotScaffoldWorkflowContext -Path '/repo' -ShortName 'NMT').AnswerSet.EnablePester | Should -Be 'No'
+    }
+}

--- a/tests/private/scaffold/InitializeNovaModuleAgenticCopilotScaffold.Tests.ps1
+++ b/tests/private/scaffold/InitializeNovaModuleAgenticCopilotScaffold.Tests.ps1
@@ -161,6 +161,12 @@ Describe 'Initialize-NovaModuleAgenticCopilotScaffold' {
         ConvertTo-NovaModuleAgenticCopilotNormalizedFileContent -Content "line1`r`nline2`r`n`r`n" | Should -Be "line1`r`nline2`r`n"
     }
 
+    It 'matches directory policy entries as case-insensitive prefixes' {
+        Test-NovaModuleAgenticCopilotPathMatchesPolicyEntry -RelativePath 'tests/private/My.Tests.ps1' -Entry 'tests/' | Should -BeTrue
+        Test-NovaModuleAgenticCopilotPathMatchesPolicyEntry -RelativePath 'Tests/private/My.Tests.ps1' -Entry 'tests/' | Should -BeTrue
+        Test-NovaModuleAgenticCopilotPathMatchesPolicyEntry -RelativePath 'docs/README.md' -Entry 'tests/' | Should -BeFalse
+    }
+
     It 'overwrites managed files and preserves add-only files when a scaffold policy is supplied' {
         $templateRoot = Join-Path $TestDrive 'policy-template'
         $projectRoot = Join-Path $TestDrive 'policy-project'

--- a/tests/private/scaffold/InitializeNovaModuleAgenticCopilotScaffold.Tests.ps1
+++ b/tests/private/scaffold/InitializeNovaModuleAgenticCopilotScaffold.Tests.ps1
@@ -160,4 +160,54 @@ Describe 'Initialize-NovaModuleAgenticCopilotScaffold' {
         ConvertTo-NovaModuleAgenticCopilotNormalizedFileContent -Content "line1`nline2" | Should -Be "line1`nline2`n"
         ConvertTo-NovaModuleAgenticCopilotNormalizedFileContent -Content "line1`r`nline2`r`n`r`n" | Should -Be "line1`r`nline2`r`n"
     }
+
+    It 'overwrites managed files and preserves add-only files when a scaffold policy is supplied' {
+        $templateRoot = Join-Path $TestDrive 'policy-template'
+        $projectRoot = Join-Path $TestDrive 'policy-project'
+        $managedTemplatePath = Join-Path $templateRoot 'CONTRIBUTING.md'
+        $addOnlyTemplatePath = Join-Path $templateRoot 'README.md'
+        $managedDestinationPath = Join-Path $projectRoot 'CONTRIBUTING.md'
+        $addOnlyDestinationPath = Join-Path $projectRoot 'README.md'
+        $null = New-Item -ItemType Directory -Path $templateRoot -Force
+        $null = New-Item -ItemType Directory -Path $projectRoot -Force
+        Set-Content -LiteralPath $managedTemplatePath -Value 'managed-template' -Encoding utf8 -NoNewline
+        Set-Content -LiteralPath $addOnlyTemplatePath -Value 'add-only-template' -Encoding utf8 -NoNewline
+        Set-Content -LiteralPath $managedDestinationPath -Value 'managed-existing' -Encoding utf8 -NoNewline
+        Set-Content -LiteralPath $addOnlyDestinationPath -Value 'add-only-existing' -Encoding utf8 -NoNewline
+        Mock Get-NovaModuleAgenticCopilotTemplateRoot {$templateRoot}
+
+        Initialize-NovaModuleAgenticCopilotScaffold -Answer @{
+            ProjectName = 'NovaAgentic'
+            ProjectShortName = 'NMT'
+            Description = 'Agentic scaffold'
+            EnablePester = 'No'
+        } -ProjectRoot $projectRoot -ScaffoldPolicy ([pscustomobject]@{
+            ManagedOverwritePathList = @('CONTRIBUTING.md')
+            AddOnlyPathList = @('README.md')
+        })
+
+        (Get-Content -LiteralPath $managedDestinationPath -Raw) | Should -Be "managed-template`n"
+        (Get-Content -LiteralPath $addOnlyDestinationPath -Raw) | Should -Be 'add-only-existing'
+    }
+
+    It 'skips template files outside the supplied scaffold policy' {
+        $templateRoot = Join-Path $TestDrive 'skip-template'
+        $projectRoot = Join-Path $TestDrive 'skip-project'
+        $ignoredTemplatePath = Join-Path $templateRoot 'ignored.md'
+        $null = New-Item -ItemType Directory -Path $templateRoot -Force
+        Set-Content -LiteralPath $ignoredTemplatePath -Value 'ignored-template' -Encoding utf8 -NoNewline
+        Mock Get-NovaModuleAgenticCopilotTemplateRoot {$templateRoot}
+
+        Initialize-NovaModuleAgenticCopilotScaffold -Answer @{
+            ProjectName = 'NovaAgentic'
+            ProjectShortName = 'NMT'
+            Description = 'Agentic scaffold'
+            EnablePester = 'No'
+        } -ProjectRoot $projectRoot -ScaffoldPolicy ([pscustomobject]@{
+            ManagedOverwritePathList = @('CONTRIBUTING.md')
+            AddOnlyPathList = @('README.md')
+        })
+
+        (Test-Path -LiteralPath (Join-Path $projectRoot 'ignored.md')) | Should -BeFalse
+    }
 }

--- a/tests/private/scaffold/InvokeNovaAgenticCopilotScaffoldWorkflow.TestSupport.ps1
+++ b/tests/private/scaffold/InvokeNovaAgenticCopilotScaffoldWorkflow.TestSupport.ps1
@@ -1,0 +1,15 @@
+function Initialize-NovaModuleAgenticCopilotScaffold {
+    param(
+        [hashtable]$Answer,
+        [string]$ProjectRoot,
+        [switch]$Example,
+        [AllowNull()][pscustomobject]$ScaffoldPolicy
+    )
+}
+
+function Stop-NovaOperation {
+    param([string]$Message, [string]$ErrorId, [System.Management.Automation.ErrorCategory]$Category, $TargetObject)
+    $exception = [System.Exception]::new($Message)
+    $record = [System.Management.Automation.ErrorRecord]::new($exception, $ErrorId, $Category, $TargetObject)
+    throw $record
+}

--- a/tests/private/scaffold/InvokeNovaAgenticCopilotScaffoldWorkflow.Tests.ps1
+++ b/tests/private/scaffold/InvokeNovaAgenticCopilotScaffoldWorkflow.Tests.ps1
@@ -1,0 +1,99 @@
+BeforeAll {
+    $projectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
+    . (Join-Path $projectRoot 'src/private/scaffold/InvokeNovaAgenticCopilotScaffoldWorkflow.ps1')
+
+    function Initialize-NovaModuleAgenticCopilotScaffold {
+        param(
+            [hashtable]$Answer,
+            [string]$ProjectRoot,
+            [switch]$Example,
+            [AllowNull()][pscustomobject]$ScaffoldPolicy
+        )
+    }
+
+    function Stop-NovaOperation {
+        param([string]$Message, [string]$ErrorId, [System.Management.Automation.ErrorCategory]$Category, $TargetObject)
+        $exception = [System.Exception]::new($Message)
+        $record = [System.Management.Automation.ErrorRecord]::new($exception, $ErrorId, $Category, $TargetObject)
+        throw $record
+    }
+}
+
+Describe 'Get-NovaAgenticCopilotScaffoldWarningMessage' {
+    It 'lists overwrite and add-only paths' {
+        $message = Get-NovaAgenticCopilotScaffoldWarningMessage -WorkflowContext ([pscustomobject]@{
+            ProjectRoot = '/repo'
+            ManagedOverwritePathList = @('.github/agents/', 'AGENTS.md')
+            AddOnlyPathList = @('README.md')
+        })
+
+        $message | Should -Match '\.github/agents/'
+        $message | Should -Match 'AGENTS\.md'
+        $message | Should -Match 'README\.md'
+    }
+}
+
+Describe 'Confirm-NovaAgenticCopilotScaffoldWarning' {
+    It 'skips prompting when OverrideWarningRequested is set' {
+        Mock Read-NovaAgenticCopilotScaffoldWarningChoice {throw 'should not be called'}
+
+        {
+            Confirm-NovaAgenticCopilotScaffoldWarning -WorkflowContext ([pscustomobject]@{
+                OverrideWarningRequested = $true
+                ProjectRoot = '/repo'
+                ManagedOverwritePathList = @()
+                AddOnlyPathList = @()
+            })
+        } | Should -Not -Throw
+    }
+
+    It 'throws a cancellation error when the user declines the apply' {
+        Mock Read-NovaAgenticCopilotScaffoldWarningChoice {1}
+
+        {
+            Confirm-NovaAgenticCopilotScaffoldWarning -WorkflowContext ([pscustomobject]@{
+                OverrideWarningRequested = $false
+                ProjectRoot = '/repo'
+                ManagedOverwritePathList = @('.github/agents/')
+                AddOnlyPathList = @('README.md')
+            })
+        } | Should -Throw -ErrorId 'Nova.Workflow.AgenticCopilotScaffoldCancelled'
+    }
+}
+
+Describe 'Invoke-NovaAgenticCopilotScaffoldWorkflow' {
+    BeforeEach {
+        Mock Confirm-NovaAgenticCopilotScaffoldWarning {}
+        Mock Initialize-NovaModuleAgenticCopilotScaffold {}
+        Mock Write-Message {}
+    }
+
+    It 'returns without applying when ShouldRun is false' {
+        Invoke-NovaAgenticCopilotScaffoldWorkflow -WorkflowContext ([pscustomobject]@{
+            ProjectRoot = '/repo'
+            ProjectInfo = [pscustomobject]@{ProjectName = 'Demo'}
+            AnswerSet = @{}
+            ScaffoldPolicy = [pscustomobject]@{}
+        })
+
+        Assert-MockCalled Initialize-NovaModuleAgenticCopilotScaffold -Times 0
+    }
+
+    It 'confirms, applies, and announces when ShouldRun is true' {
+        $workflowContext = [pscustomobject]@{
+            ProjectRoot = '/repo'
+            ProjectInfo = [pscustomobject]@{ProjectName = 'Demo'}
+            AnswerSet = @{ProjectName = 'Demo'; ProjectShortName = 'NMT'}
+            ScaffoldPolicy = [pscustomobject]@{ManagedOverwritePathList = @(); AddOnlyPathList = @()}
+            OverrideWarningRequested = $false
+            ManagedOverwritePathList = @('.github/agents/')
+            AddOnlyPathList = @('README.md')
+        }
+
+        Invoke-NovaAgenticCopilotScaffoldWorkflow -WorkflowContext $workflowContext -ShouldRun
+
+        Assert-MockCalled Confirm-NovaAgenticCopilotScaffoldWarning -Times 1
+        Assert-MockCalled Initialize-NovaModuleAgenticCopilotScaffold -Times 1
+        Assert-MockCalled Write-Message -Times 1
+    }
+}

--- a/tests/private/scaffold/InvokeNovaAgenticCopilotScaffoldWorkflow.Tests.ps1
+++ b/tests/private/scaffold/InvokeNovaAgenticCopilotScaffoldWorkflow.Tests.ps1
@@ -1,22 +1,7 @@
 BeforeAll {
     $projectRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $PSScriptRoot))
     . (Join-Path $projectRoot 'src/private/scaffold/InvokeNovaAgenticCopilotScaffoldWorkflow.ps1')
-
-    function Initialize-NovaModuleAgenticCopilotScaffold {
-        param(
-            [hashtable]$Answer,
-            [string]$ProjectRoot,
-            [switch]$Example,
-            [AllowNull()][pscustomobject]$ScaffoldPolicy
-        )
-    }
-
-    function Stop-NovaOperation {
-        param([string]$Message, [string]$ErrorId, [System.Management.Automation.ErrorCategory]$Category, $TargetObject)
-        $exception = [System.Exception]::new($Message)
-        $record = [System.Management.Automation.ErrorRecord]::new($exception, $ErrorId, $Category, $TargetObject)
-        throw $record
-    }
+    . (Join-Path $PSScriptRoot 'InvokeNovaAgenticCopilotScaffoldWorkflow.TestSupport.ps1')
 }
 
 Describe 'Get-NovaAgenticCopilotScaffoldWarningMessage' {
@@ -30,6 +15,35 @@ Describe 'Get-NovaAgenticCopilotScaffoldWarningMessage' {
         $message | Should -Match '\.github/agents/'
         $message | Should -Match 'AGENTS\.md'
         $message | Should -Match 'README\.md'
+    }
+}
+
+Describe 'Read-NovaAgenticCopilotScaffoldWarningChoice' {
+    It 'prompts with yes-no options and defaults to No' {
+        $script:promptCall = $null
+        $hostUi = [pscustomobject]@{}
+        $hostUi | Add-Member -MemberType ScriptMethod -Name PromptForChoice -Value {
+            param($caption, $message, $choices, $defaultChoice)
+
+            $script:promptCall = [pscustomobject]@{
+                Caption = $caption
+                Message = $message
+                Labels = @($choices | ForEach-Object Label)
+                HelpMessages = @($choices | ForEach-Object HelpMessage)
+                DefaultChoice = $defaultChoice
+            }
+
+            return 0
+        }
+
+        $selection = Read-NovaAgenticCopilotScaffoldWarningChoice -Message 'apply scaffold' -HostUi $hostUi
+
+        $selection | Should -Be 0
+        $script:promptCall.Caption | Should -Be 'Confirm'
+        $script:promptCall.Message | Should -Be 'apply scaffold'
+        $script:promptCall.Labels | Should -Be @('&Yes', '&No')
+        $script:promptCall.HelpMessages | Should -Be @('Apply the scaffold.', 'Cancel the operation.')
+        $script:promptCall.DefaultChoice | Should -Be 1
     }
 }
 

--- a/tests/public/InvokeNovaAgenticCopilotScaffold.TestSupport.ps1
+++ b/tests/public/InvokeNovaAgenticCopilotScaffold.TestSupport.ps1
@@ -1,0 +1,17 @@
+function Get-NovaAgenticCopilotScaffoldWorkflowContext {
+    param($Path, $ShortName, [switch]$OverrideWarningRequested)
+    $script:ctxArgs = @{
+        Path = $Path
+        ShortName = $ShortName
+        OverrideWarningRequested = [bool]$OverrideWarningRequested
+    }
+    return [pscustomobject]@{Target = $Path; Action = 'Apply'}
+}
+
+function Invoke-NovaAgenticCopilotScaffoldWorkflow {
+    param($WorkflowContext, [switch]$ShouldRun)
+    $script:workflowArgs = @{
+        WorkflowContext = $WorkflowContext
+        ShouldRun = [bool]$ShouldRun
+    }
+}

--- a/tests/public/InvokeNovaAgenticCopilotScaffold.Tests.ps1
+++ b/tests/public/InvokeNovaAgenticCopilotScaffold.Tests.ps1
@@ -1,0 +1,44 @@
+BeforeAll {
+    $projectRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+    . (Join-Path $projectRoot 'src/public/InvokeNovaAgenticCopilotScaffold.ps1')
+
+    function Get-NovaAgenticCopilotScaffoldWorkflowContext {
+        param($Path, $ShortName, [switch]$OverrideWarningRequested)
+        $script:ctxArgs = @{
+            Path = $Path
+            ShortName = $ShortName
+            OverrideWarningRequested = [bool]$OverrideWarningRequested
+        }
+        return [pscustomobject]@{Target = $Path; Action = 'Apply'}
+    }
+
+    function Invoke-NovaAgenticCopilotScaffoldWorkflow {
+        param($WorkflowContext, [switch]$ShouldRun)
+        $script:workflowArgs = @{
+            WorkflowContext = $WorkflowContext
+            ShouldRun = [bool]$ShouldRun
+        }
+    }
+}
+
+Describe 'Invoke-NovaAgenticCopilotScaffold' {
+    BeforeEach {
+        $script:ctxArgs = $null
+        $script:workflowArgs = $null
+    }
+
+    It 'forwards Path, ShortName, and OverrideWarning to the workflow context' {
+        Invoke-NovaAgenticCopilotScaffold -Path '/tmp/project' -ShortName 'NMT' -OverrideWarning
+
+        $script:ctxArgs.Path | Should -Be '/tmp/project'
+        $script:ctxArgs.ShortName | Should -Be 'NMT'
+        $script:ctxArgs.OverrideWarningRequested | Should -BeTrue
+        $script:workflowArgs.ShouldRun | Should -BeTrue
+    }
+
+    It 'invokes the workflow in WhatIf mode with ShouldRun disabled' {
+        Invoke-NovaAgenticCopilotScaffold -Path '/tmp/project' -ShortName 'NMT' -WhatIf
+
+        $script:workflowArgs.ShouldRun | Should -BeFalse
+    }
+}

--- a/tests/public/InvokeNovaAgenticCopilotScaffold.Tests.ps1
+++ b/tests/public/InvokeNovaAgenticCopilotScaffold.Tests.ps1
@@ -1,30 +1,20 @@
 BeforeAll {
     $projectRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
     . (Join-Path $projectRoot 'src/public/InvokeNovaAgenticCopilotScaffold.ps1')
-
-    function Get-NovaAgenticCopilotScaffoldWorkflowContext {
-        param($Path, $ShortName, [switch]$OverrideWarningRequested)
-        $script:ctxArgs = @{
-            Path = $Path
-            ShortName = $ShortName
-            OverrideWarningRequested = [bool]$OverrideWarningRequested
-        }
-        return [pscustomobject]@{Target = $Path; Action = 'Apply'}
-    }
-
-    function Invoke-NovaAgenticCopilotScaffoldWorkflow {
-        param($WorkflowContext, [switch]$ShouldRun)
-        $script:workflowArgs = @{
-            WorkflowContext = $WorkflowContext
-            ShouldRun = [bool]$ShouldRun
-        }
-    }
+    . (Join-Path $PSScriptRoot 'InvokeNovaAgenticCopilotScaffold.TestSupport.ps1')
 }
 
 Describe 'Invoke-NovaAgenticCopilotScaffold' {
     BeforeEach {
         $script:ctxArgs = $null
         $script:workflowArgs = $null
+    }
+
+    It 'defaults Path to the current location when Path is omitted' {
+        Invoke-NovaAgenticCopilotScaffold -ShortName 'NMT'
+
+        $script:ctxArgs.Path | Should -Be (Get-Location).Path
+        $script:workflowArgs.ShouldRun | Should -BeTrue
     }
 
     It 'forwards Path, ShortName, and OverrideWarning to the workflow context' {


### PR DESCRIPTION
## Summary
 
 - Added a new existing-project Agentic Copilot apply/refresh workflow through 
`Invoke-NovaAgenticCopilotScaffold` and `% nova copilot`.
 - This change was needed because Nova could add the Agentic Copilot scaffold during 
`Initialize-NovaModule`, but it did not have a supported way to add or refresh that scaffold in an already 
existing project.
 - Release impact: **both prerelease and future stable releases**. The repository is currently on 
`3.0.2-preview`, but the new public cmdlet/CLI workflow and docs are user-facing behavior for the next 
stable release as well.
 - Follow-up before release readiness: reviewer findings still need to be resolved for existing-project 
scaffold completeness and `nova copilot --confirm/-c` behavior/docs alignment.
 
 ## Affected area
 
 - [x] `nova` CLI or command routing
 - [x] Public PowerShell cmdlet behavior
 - [x] Scaffolding or `project.json` handling
 - [ ] Build, test, analyzer, coverage, or CI helper flow
 - [ ] Package, raw upload, or package metadata workflow
 - [ ] Publish, release, or GitHub Actions automation
 - [ ] Self-update or notification preference behavior
 - [x] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
 - [x] End-user docs (`docs/*.html`)
 - [x] Command help (`docs/NovaModuleTools/en-US/*.md`)
 - [ ] `src/resources/example/`
 - [ ] Dependency or manifest changes (`project.json`, workflow dependencies, release tooling)
 - [ ] Security-sensitive change
 - [ ] Documentation-only change
 - [ ] Other
 
 ## Review guidance
 
 - Start with the new public workflow: `src/public/InvokeNovaAgenticCopilotScaffold.ps1`, 
`src/private/scaffold/GetNovaAgenticCopilotScaffoldWorkflowContext.ps1`, 
`src/private/scaffold/InvokeNovaAgenticCopilotScaffoldWorkflow.ps1`, and the policy changes in 
`src/private/scaffold/InitializeNovaModuleAgenticCopilotScaffold.ps1`.
 - Then review CLI routing and help wiring in `src/private/cli/`, `src/resources/cli/help/copilot.psd1`, 
and `src/resources/cli/NovaCliHelp.txt`.
 - Finish with documentation alignment across 
`docs/NovaModuleTools/en-US/Invoke-NovaAgenticCopilotScaffold.md`, `docs/commands.html`, 
`docs/core-workflows.html`, `README.md`, `CHANGELOG.md`, and `RELEASE_NOTE.md`.
 - Known limitations / follow-up:
   - Existing-project scaffold apply may still point users at formatting helper/test files that are not 
copied by the approved write policy.
   - `nova copilot --confirm/-c` behavior and docs are not yet reconciled.
 
 ## Validation
 
 - [ ] `Invoke-NovaBuild`
 - [x] `Test-NovaBuild`
 - [ ] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
 - [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
 - [ ] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`, `%
 nova publish`, `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
 - [ ] Docs/example only; executable validation not needed
 
 Validation notes:
 
 ```text
 Ran: pwsh -NoLogo -NoProfile -File ./run.ps1
 Result: passed
 
 Additional checks already exercised during the change:
 - Test-MarkdownCommandHelp passed for docs/NovaModuleTools/en-US/Invoke-NovaAgenticCopilotScaffold.md
 - ./scripts/build/Sync-AgenticCopilotScaffold.ps1 passed
 - HelpUri updates across docs/NovaModuleTools/en-US/*.md validated structurally
 
 Not yet exercised directly:
 - No explicit end-to-end real-project run of % nova copilot
 - No explicit direct Invoke-NovaBuild run recorded outside the repository quality loop
 - No CI helper or publish/release path execution
 ```
 
 ## Documentation and release follow-up
 
 - [x] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation 
changed
 - [x] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
 - [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
 - [x] `RELEASE_NOTE.md` reviewed and updated if the change affects public cmdlet usage, CLI usage, 
configuration semantics, or migration expectations
 - [x] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
 - [x] `docs/*.html` updated if end-user workflows or examples changed
 - [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or 
upload workflow changed
 - [ ] No documentation, changelog, release-note, or example updates were needed
 
 ## Maintainability, compatibility, and risk
 
 - [x] Code Health / maintainability impact considered
 - [x] No breaking change
 - [ ] Breaking change
 - [ ] Security-sensitive change
 - [ ] CI, workflow, or release-pipeline impact
 - [ ] Dependency-review impact
 
 Risk, rollout, or rollback notes:
 
 ```text
 This is a user-facing workflow addition, not a release-automation change.
 
 Primary release risk is not semantic versioning or publish automation; it is behavioral consistency:
 1. existing-project scaffold refresh may reference files it does not actually copy
 2. nova copilot --confirm/-c behavior appears inconsistent with current docs/help
 
 Recommended before calling this release-ready:
 - resolve the two reviewer findings
 - run an end-to-end apply/refresh against a real existing project root
 - re-check changelog/release-note wording against the final shipped behavior after those fixes
 ```
 
 > [!IMPORTANT]
 > Do not use a public pull request to disclose a vulnerability before coordinated handling.
 > Use the private reporting path in `SECURITY.md` for new security issues.