### PR TITLE
#238 fix: update Get-NovaProjectInfo and Update-NovaModuleTool comman…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Changed
 
+- `Get-NovaProjectInfo` now aligns its installed-version views with the existing CLI version contract.
+    - `-Installed` now returns the installed version of the current project/module from the local module path.
+    - `-InstalledNovaVersion` now returns the installed `NovaModuleTools` module name and version from PowerShell.
+- `Update-NovaModuleTool` now suggests `Get-NovaProjectInfo -InstalledNovaVersion` after a successful self-update so the PowerShell verification step checks the installed NovaModuleTools version directly.
+
 ### Deprecated
 
 ### Removed
@@ -468,4 +473,3 @@ This release was yanked because it removed the implicit `Pester` dependency, bef
 [0.0.6]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.5...Version_0.0.6
 [0.0.5]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.4...Version_0.0.5
 [0.0.4]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.3...Version_0.0.4
-

--- a/README.md
+++ b/README.md
@@ -130,7 +130,9 @@ To inspect the current project version, the installed version of the current pro
 `NovaModuleTools` tool version, use:
 
 ```powershell
+PS> Get-NovaProjectInfo -Version
 PS> Get-NovaProjectInfo -Installed
+PS> Get-NovaProjectInfo -InstalledNovaVersion
 % nova version
 % nova version --installed
 % nova version -i
@@ -140,7 +142,9 @@ PS> Get-NovaProjectInfo -Installed
 
 - `% nova version` shows the version from the current project's `project.json`
 - `% nova version --installed` / `% nova version -i` shows the locally installed version of the current project/module from the local module path
-- `Get-NovaProjectInfo -Installed` shows the installed `NovaModuleTools` module name and version from PowerShell
+- `Get-NovaProjectInfo -Version` shows the version from the current project's `project.json`
+- `Get-NovaProjectInfo -Installed` shows the locally installed version of the current project/module from PowerShell
+- `Get-NovaProjectInfo -InstalledNovaVersion` shows the installed `NovaModuleTools` module name and version from PowerShell
 - `% nova --version` / `% nova -v` shows the installed `NovaModuleTools` version
 
 ### CLI help

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -8,6 +8,11 @@ This file summarizes the release notes for NovaModuleTools. **UNRELEASED** chang
 
 ### Changed
 
+- `Get-NovaProjectInfo` now matches the CLI version split on the PowerShell surface.
+    - Use `-Installed` for the installed current project/module version.
+    - Use `-InstalledNovaVersion` for the installed `NovaModuleTools` version.
+- `Update-NovaModuleTool` now suggests `Get-NovaProjectInfo -InstalledNovaVersion` after a successful self-update.
+
 ### Deprecated
 
 ### Removed
@@ -226,4 +231,3 @@ This release was yanked because it removed the implicit `Pester` dependency befo
 ## [0.0.4] - 2024-06-25
 ### Added
 - First PowerShell Gallery release of NovaModuleTools with the initial module workflow support.
-

--- a/docs/NovaModuleTools/en-US/Get-NovaProjectInfo.md
+++ b/docs/NovaModuleTools/en-US/Get-NovaProjectInfo.md
@@ -1,10 +1,10 @@
----
+﻿---
 document type: cmdlet
 external help file: NovaModuleTools-Help.xml
-HelpUri: 'https://www.novamoduletools.com/project-json-reference.html'
+HelpUri: https://www.novamoduletools.com/project-json-reference.html
 Locale: en-US
 Module Name: NovaModuleTools
-ms.date: 05/06/2026
+ms.date: 05.25.2026
 PlatyPS schema version: 2024-05-01
 title: Get-NovaProjectInfo
 ---
@@ -17,23 +17,31 @@ Reads `project.json` and returns resolved NovaModuleTools project metadata or a 
 
 ## SYNTAX
 
-### ProjectInfo
+### ProjectInfo (Default)
 
-```text
-PS> Get-NovaProjectInfo [[-Path] <string>] [<CommonParameters>]
+```
+Get-NovaProjectInfo [[-Path] <string>] [<CommonParameters>]
 ```
 
 ### ProjectVersion
 
-```text
-PS> Get-NovaProjectInfo [[-Path] <string>] [-Version] [<CommonParameters>]
+```
+Get-NovaProjectInfo [[-Path] <string>] [-Version] [<CommonParameters>]
 ```
 
-### InstalledVersion
+### InstalledProjectVersion
 
-```text
-PS> Get-NovaProjectInfo [-Installed] [<CommonParameters>]
 ```
+Get-NovaProjectInfo [-Installed] [<CommonParameters>]
+```
+
+### InstalledNovaVersion
+
+```
+Get-NovaProjectInfo [-InstalledNovaVersion] [<CommonParameters>]
+```
+
+## ALIASES
 
 ## DESCRIPTION
 
@@ -48,7 +56,11 @@ Use this command from scripts, tests, or troubleshooting when you want one objec
 
 When you use `-Version`, the command returns only the project version string instead of the full project object.
 
-When you use `-Installed`, the command returns the installed `NovaModuleTools` module name and version string instead of project metadata.
+When you use `-Installed`, the command returns the installed version of the current project/module from the local
+module path instead of project metadata.
+
+When you use `-InstalledNovaVersion`, the command returns the installed `NovaModuleTools` module name and version
+string.
 
 When `-Path` does not resolve to an existing project root folder, or the folder does not contain `project.json`,
 the command fails with an actionable error that tells you how to recover.
@@ -85,9 +97,59 @@ Returns only the version string from `project.json`.
 PS> Get-NovaProjectInfo -Installed
 ```
 
+Returns the installed version of the current project/module from the local module path.
+
+### EXAMPLE 5
+
+```text
+PS> Get-NovaProjectInfo -InstalledNovaVersion
+```
+
 Returns the installed `NovaModuleTools` module name and version string.
 
 ## PARAMETERS
+
+### -Installed
+
+Return the installed version of the current project/module from the local module path instead of project metadata.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: InstalledProjectVersion
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
+### -InstalledNovaVersion
+
+Return the installed `NovaModuleTools` module name and version string instead of project metadata.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+DefaultValue: False
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: InstalledNovaVersion
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
 
 ### -Path
 
@@ -99,18 +161,18 @@ DefaultValue: (Get-Location).Path
 SupportsWildcards: false
 Aliases: []
 ParameterSets:
-  - Name: ProjectInfo
-    Position: 0
-    IsRequired: false
-    ValueFromPipeline: false
-    ValueFromPipelineByPropertyName: false
-    ValueFromRemainingArguments: false
-  - Name: ProjectVersion
-    Position: 0
-    IsRequired: false
-    ValueFromPipeline: false
-    ValueFromPipelineByPropertyName: false
-    ValueFromRemainingArguments: false
+- Name: ProjectVersion
+  Position: 0
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+- Name: ProjectInfo
+  Position: 0
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
 DontShow: false
 AcceptedValues: []
 HelpMessage: ''
@@ -126,33 +188,12 @@ DefaultValue: False
 SupportsWildcards: false
 Aliases: []
 ParameterSets:
-  - Name: ProjectVersion
-    Position: Named
-    IsRequired: false
-    ValueFromPipeline: false
-    ValueFromPipelineByPropertyName: false
-    ValueFromRemainingArguments: false
-DontShow: false
-AcceptedValues: []
-HelpMessage: ''
-```
-
-### -Installed
-
-Return the installed `NovaModuleTools` module name and version string instead of project metadata.
-
-```yaml
-Type: System.Management.Automation.SwitchParameter
-DefaultValue: False
-SupportsWildcards: false
-Aliases: []
-ParameterSets:
-  - Name: InstalledVersion
-    Position: Named
-    IsRequired: false
-    ValueFromPipeline: false
-    ValueFromPipelineByPropertyName: false
-    ValueFromRemainingArguments: false
+- Name: ProjectVersion
+  Position: Named
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
 DontShow: false
 AcceptedValues: []
 HelpMessage: ''
@@ -160,9 +201,10 @@ HelpMessage: ''
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`,
-`-InformationVariable`, `-OutBuffer`, `-OutVariable`, `-PipelineVariable`, `-ProgressAction`, `-Verbose`,
-`-WarningAction`, and `-WarningVariable`.
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -184,6 +226,10 @@ Returned when you use `-Installed`.
 
 Returned by default. The object includes project metadata, defaulted build settings, and resolved paths.
 
+### System.String
+
+Returned when you use `-InstalledNovaVersion`.
+
 ## NOTES
 
 This command throws a clear error when `project.json` is missing or empty.
@@ -191,7 +237,9 @@ This command throws a clear error when `project.json` is missing or empty.
 If `-Path` points to a file or a folder that does not exist, `Get-NovaProjectInfo` tells you to rerun it from a
 Nova project root or pass `-Path` to the folder that contains `project.json`.
 
-`-Installed` does not require a project path or a `project.json` file.
+`-Installed` resolves the current Nova project and then reads the installed module version from the local module path.
+
+`-InstalledNovaVersion` does not require a project path or a `project.json` file.
 
 ## RELATED LINKS
 

--- a/docs/NovaModuleTools/en-US/Update-NovaModuleTools.md
+++ b/docs/NovaModuleTools/en-US/Update-NovaModuleTools.md
@@ -40,7 +40,7 @@ Stable updates do not require prerelease confirmation.
 
 When a newer version is available, `Update-NovaModuleTool` shows progress while it installs the update and reads the release-notes link from the updated module. Every command path ends with a visible summary: up-to-date, preview, cancelled, or updated.
 
-After a successful update, `Update-NovaModuleTool` prints the release notes link from the installed module manifest and suggests `Get-NovaProjectInfo -Installed` as the next verification step.
+After a successful update, `Update-NovaModuleTool` prints the release notes link from the installed module manifest and suggests `Get-NovaProjectInfo -InstalledNovaVersion` as the next verification step.
 
 ## EXAMPLES
 

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -268,7 +268,7 @@ PS&gt; Invoke-NovaAgenticCopilotScaffold -Path ~/Work/MyModule -ShortName NMT -O
                             <li><strong>Use when:</strong> you need to confirm what Nova resolved from
                                 <code>project.json</code></li>
                             <li data-command-visibility="powershell"><strong>Extra views:</strong>
-                                <code>-Version</code> and <code>-Installed</code></li>
+                                <code>-Version</code>, <code>-Installed</code>, and <code>-InstalledNovaVersion</code></li>
                         </ul>
                         <div class="surface-example" data-command-example>
                             <div class="surface-example__meta">
@@ -282,8 +282,9 @@ PS&gt; Invoke-NovaAgenticCopilotScaffold -Path ~/Work/MyModule -ShortName NMT -O
                             <div class="surface-example__surface" data-command-surface="powershell">
                                 <pre><code>PS&gt; Get-NovaProjectInfo
 PS&gt; Get-NovaProjectInfo -Version
-PS&gt; Get-NovaProjectInfo -Installed</code></pre>
-                            </div>
+PS&gt; Get-NovaProjectInfo -Installed
+PS&gt; Get-NovaProjectInfo -InstalledNovaVersion</code></pre>
+                           </div>
                         </div>
                         <p><a class="text-link" href="./project-json-reference.html">See project.json behavior</a></p>
                     </article>
@@ -589,7 +590,8 @@ PS&gt; Update-NovaModuleVersion -ContinuousIntegration</code></pre>
                             </li>
                             <li data-command-visibility="powershell"><strong>Use:</strong>
                                 <code>Get-NovaProjectInfo -Version</code> for <code>project.json</code> and
-                                <code>Get-NovaProjectInfo -Installed</code> for the installed NovaModuleTools tool
+                                <code>Get-NovaProjectInfo -Installed</code> for the installed current project/module and
+                                <code>Get-NovaProjectInfo -InstalledNovaVersion</code> for the installed NovaModuleTools tool
                                 version
                             </li>
                         </ul>
@@ -608,7 +610,8 @@ PS&gt; Update-NovaModuleVersion -ContinuousIntegration</code></pre>
                             </div>
                             <div class="surface-example__surface" data-command-surface="powershell">
                                 <pre><code>PS&gt; Get-NovaProjectInfo -Version
-PS&gt; Get-NovaProjectInfo -Installed</code></pre>
+PS&gt; Get-NovaProjectInfo -Installed
+PS&gt; Get-NovaProjectInfo -InstalledNovaVersion</code></pre>
                             </div>
                         </div>
                         <p><a class="text-link" href="./versioning-and-updates.html#version-views">See version view

--- a/docs/versioning-and-updates.html
+++ b/docs/versioning-and-updates.html
@@ -113,14 +113,14 @@
                             <td>Use this when you want to know what your project will build and publish as.</td>
                         </tr>
                         <tr>
-                            <td><code>% nova version --installed</code> or <code>% nova version -i</code></td>
+                            <td><code>Get-NovaProjectInfo -Installed</code> or <code>% nova version --installed</code></td>
                             <td>The version installed locally for the current project/module from the module path.</td>
                             <td>Use this when you want to compare the installed copy against the current working
                                 project.
                             </td>
                         </tr>
                         <tr>
-                            <td><code>Get-NovaProjectInfo -Installed</code> or <code>% nova --version</code></td>
+                            <td><code>Get-NovaProjectInfo -InstalledNovaVersion</code> or <code>% nova --version</code></td>
                             <td>The installed NovaModuleTools version.</td>
                             <td>Use this when you are troubleshooting Nova itself or checking whether the tool needs an
                                 update.
@@ -137,7 +137,8 @@
                     </div>
                     <div class="surface-example__surface" data-command-surface="powershell">
                         <pre><code>PS&gt; Get-NovaProjectInfo -Version
-PS&gt; Get-NovaProjectInfo -Installed</code></pre>
+PS&gt; Get-NovaProjectInfo -Installed
+PS&gt; Get-NovaProjectInfo -InstalledNovaVersion</code></pre>
                     </div>
                     <div class="surface-example__surface" data-command-surface="command-line" hidden>
                         <pre><code>% nova version
@@ -146,12 +147,6 @@ PS&gt; Get-NovaProjectInfo -Installed</code></pre>
 % nova --version
 % nova -v</code></pre>
                     </div>
-                </div>
-                <div class="surface-note" data-command-visibility="powershell">
-                    <p><strong>PowerShell note:</strong> project version lookup and installed-tool version lookup both
-                        have direct
-                        cmdlet forms. The installed current-project module view remains launcher-oriented on this page,
-                        as shown in the comparison table above.</p>
                 </div>
             </section>
 

--- a/src/private/update/InvokeNovaModuleSelfUpdateWorkflow.ps1
+++ b/src/private/update/InvokeNovaModuleSelfUpdateWorkflow.ps1
@@ -215,6 +215,6 @@ function Get-NovaModuleSelfUpdateWorkflowNextStepLine {
 
     return @(
         'Next step:'
-        'Get-NovaProjectInfo -Installed'
+        'Get-NovaProjectInfo -InstalledNovaVersion'
     )
 }

--- a/src/public/GetNovaProjectInfo.ps1
+++ b/src/public/GetNovaProjectInfo.ps1
@@ -6,11 +6,17 @@ function Get-NovaProjectInfo {
         [string]$Path = (Get-Location).Path,
         [Parameter(ParameterSetName = 'ProjectVersion')]
         [switch]$Version,
-        [Parameter(ParameterSetName = 'InstalledVersion')]
-        [switch]$Installed
+        [Parameter(ParameterSetName = 'InstalledProjectVersion')]
+        [switch]$Installed,
+        [Parameter(ParameterSetName = 'InstalledNovaVersion')]
+        [switch]$InstalledNovaVersion
     )
 
     if ($Installed) {
+        return Get-NovaInstalledProjectVersion
+    }
+
+    if ($InstalledNovaVersion) {
         $module = $ExecutionContext.SessionState.Module
         $installedVersion = Get-NovaCliInstalledVersion -Module $module
         return Format-NovaCliVersionString -Name $module.Name -Version $installedVersion

--- a/tests/ArchitectureGuardrails.Tests.ps1
+++ b/tests/ArchitectureGuardrails.Tests.ps1
@@ -83,7 +83,7 @@ Describe 'Architecture guardrails' {
     It 'public command files use only their approved Nova helper surface' {
         $testCases = @(
             [pscustomobject]@{Path = 'src/public/DeployNovaPackage.ps1'; ExpectedHelpers = @('Get-NovaPackageUploadWorkflowContext', 'Get-NovaProjectInfo', 'Invoke-NovaPackageUploadWorkflow', 'New-NovaPackageUploadDynamicParameterDictionary', 'New-NovaPackageUploadOption', 'Write-NovaPackageUploadResultOutput', 'Write-NovaPackageUploadWorkflowContext')}
-            [pscustomobject]@{Path = 'src/public/GetNovaProjectInfo.ps1'; ExpectedHelpers = @('Format-NovaCliVersionString', 'Get-NovaCliInstalledVersion', 'Get-NovaProjectInfoContext', 'Get-NovaProjectInfoResult')}
+            [pscustomobject]@{Path = 'src/public/GetNovaProjectInfo.ps1'; ExpectedHelpers = @('Format-NovaCliVersionString', 'Get-NovaCliInstalledVersion', 'Get-NovaInstalledProjectVersion', 'Get-NovaProjectInfoContext', 'Get-NovaProjectInfoResult')}
             [pscustomobject]@{Path = 'src/public/GetNovaUpdateNotificationPreference.ps1'; ExpectedHelpers = @('Get-NovaUpdateNotificationPreferenceStatus')}
             [pscustomobject]@{Path = 'src/public/InitializeNovaModule.ps1'; ExpectedHelpers = @('Get-NovaModuleInitializationWorkflowContext', 'Invoke-NovaModuleInitializationWorkflow')}
             [pscustomobject]@{Path = 'src/public/InstallNovaCli.ps1'; ExpectedHelpers = @('Get-NovaCliInstallWorkflowContext', 'Invoke-NovaCliInstallWorkflow', 'Write-NovaModuleReleaseNotesLink')}

--- a/tests/private/update/InvokeNovaModuleSelfUpdateWorkflow.Tests.ps1
+++ b/tests/private/update/InvokeNovaModuleSelfUpdateWorkflow.Tests.ps1
@@ -149,7 +149,7 @@ Describe 'Invoke-NovaModuleSelfUpdateWorkflow' {
         $result.Updated | Should -BeTrue
         $result.ReleaseNotesUri | Should -Be 'https://example.com/n'
         Assert-MockCalled Write-Message -Times 1 -ParameterFilter {$Text -eq 'Updated NovaModuleTools to version 1.1.0.' -and $color -eq 'Green'}
-        Assert-MockCalled Write-Message -Times 1 -ParameterFilter {$Text -eq 'Get-NovaProjectInfo -Installed'}
+        Assert-MockCalled Write-Message -Times 1 -ParameterFilter {$Text -eq 'Get-NovaProjectInfo -InstalledNovaVersion'}
         Assert-MockCalled Write-Progress -Times 3
     }
 }

--- a/tests/public/GetNovaProjectInfo.TestSupport.ps1
+++ b/tests/public/GetNovaProjectInfo.TestSupport.ps1
@@ -1,4 +1,5 @@
 function Get-NovaCliInstalledVersion {param($Module) return '1.2.3'}
+function Get-NovaInstalledProjectVersion { return 'ProjectX 9.8.7' }
 function Format-NovaCliVersionString {param($Name, $Version) return "$Name $Version"}
 function Get-NovaProjectInfoContext {param($Path) return [pscustomobject]@{Path=$Path}}
 function Get-NovaProjectInfoResult {param($WorkflowContext, [switch]$Version)

--- a/tests/public/GetNovaProjectInfo.Tests.ps1
+++ b/tests/public/GetNovaProjectInfo.Tests.ps1
@@ -6,8 +6,12 @@ BeforeAll {
 }
 
 Describe 'Get-NovaProjectInfo' {
-    It 'returns a formatted installed version when -Installed is set' {
-        Get-NovaProjectInfo -Installed | Should -Match 'NovaModuleTools 1\.2\.3|.+1\.2\.3'
+    It 'returns the installed project version when -Installed is set' {
+        Get-NovaProjectInfo -Installed | Should -Be 'ProjectX 9.8.7'
+    }
+
+    It 'returns the installed NovaModuleTools version when -InstalledNovaVersion is set' {
+        Get-NovaProjectInfo -InstalledNovaVersion | Should -Match 'NovaModuleTools 1\.2\.3|.+1\.2\.3'
     }
 
     It 'returns the project info result when -Version is not set' {


### PR DESCRIPTION
## Summary
 
 - Aligned the PowerShell version-reporting surface with the existing CLI split by changing `Get-NovaProjectInfo -Installed` to mean the installed current project/module version and adding `Get-NovaProjectInfo -InstalledNovaVersion` for the installed `NovaModuleTools` version.
 - Updated the self-update next-step guidance plus README, command help, website docs, changelog, and release notes so the new PowerShell contract is documented consistently.
 - Link pending.
 
 ## Affected area
 
 - [ ] `nova` CLI or command routing
 - [x] Public PowerShell cmdlet behavior
 - [ ] Scaffolding or `project.json` handling
 - [ ] Build, test, analyzer, coverage, or CI helper flow
 - [ ] Package, raw upload, or package metadata workflow
 - [ ] Publish, release, or GitHub Actions automation
 - [x] Self-update or notification preference behavior
 - [x] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
 - [x] End-user docs (`docs/*.html`)
 - [x] Command help (`docs/NovaModuleTools/en-US/*.md`)
 - [ ] `src/resources/example/`
 - [ ] Dependency or manifest changes (`project.json`, workflow dependencies, release tooling)
 - [ ] Security-sensitive change
 - [ ] Documentation-only change
 - [ ] Agentic Copilot Workflow + scaffold mirror + scaffold-sync guardrail test.
 - [ ] Other
 
 ## Review guidance
 
 - Start with `src/public/GetNovaProjectInfo.ps1`, then check the PowerShell-only follow-on guidance in `src/private/update/InvokeNovaModuleSelfUpdateWorkflow.ps1`.
 - Primary changed areas: `src/public/`, `src/private/update/`, `tests/public/`, `tests/private/update/`, `tests/ArchitectureGuardrails.Tests.ps1`, `docs/NovaModuleTools/en-US/`, `README.md`, `CHANGELOG.md`, and `RELEASE_NOTE.md`.
 - This is a PowerShell behavior change, but it intentionally aligns the cmdlet surface with the already-established CLI semantics. CLI behavior is unchanged. `project.json` remains `3.1.1-preview`, so the staged change currently targets the prerelease line and would roll into the next stable release unless superseded.
 
 ## Validation
 
 - [x] `Invoke-NovaBuild`
 - [x] `Test-NovaBuild`
 - [ ] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
 - [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
 - [ ] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`, `% nova publish`, `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
 - [ ] Docs/example only; executable validation not needed
 
 Validation notes:
 
 ```text
 pwsh -NoLogo -NoProfile -File ./run.ps1
 - passed
 - includes repository quality loop and reported no ScriptAnalyzer findings
 
 pwsh -NoLogo -NoProfile -Command "Test-NovaBuild"
 - passed
 
 pwsh -NoLogo -NoProfile -Command "Invoke-NovaBuild | Out-Null; Import-Module ./dist/NovaModuleTools/NovaModuleTools.psd1 -Force; Import-Module Microsoft.PowerShell.PlatyPS -Force; Update-MarkdownCommandHelp -Path ./docs/NovaModuleTools/en-US/Get-NovaProjectInfo.md -NoBackup | Out-Null; Test-MarkdownCommandHelp -Path ./docs/NovaModuleTools/en-US/Get-NovaProjectInfo.md"
 - passed
 
 CodeScene pre-commit safeguard: passed
 CodeScene change-set analysis vs main: passed
 ```
 
 ## Documentation and release follow-up
 
 - [x] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
 - [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
 - [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
 - [x] `RELEASE_NOTE.md` reviewed and updated if the change affects public cmdlet usage, CLI usage, configuration semantics, or migration expectations
 - [x] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
 - [x] `docs/*.html` updated if end-user workflows or examples changed
 - [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow changed
 - [ ] No documentation, changelog, release-note, or example updates were needed
 
 ## Maintainability, compatibility, and risk
 
 - [x] Code Health / maintainability impact considered
 - [x] No breaking change
 - [ ] Breaking change
 - [ ] Security-sensitive change
 - [ ] CI, workflow, or release-pipeline impact
 - [ ] Dependency-review impact
 
 Risk, rollout, or rollback notes:
 
 ```text
 Compatibility impact:
 - PowerShell behavior change: scripts/users that previously used `Get-NovaProjectInfo -Installed` to inspect NovaModuleTools itself must switch to `Get-NovaProjectInfo -InstalledNovaVersion`.
 
 Migration note:
 - PowerShell now maps to three views:
   - `Get-NovaProjectInfo -Version` -> project.json version
   - `Get-NovaProjectInfo -Installed` -> installed current project/module version
   - `Get-NovaProjectInfo -InstalledNovaVersion` -> installed NovaModuleTools version
 
 Release impact:
 - No publish or branch-release automation semantics changed.
 - Changelog and release notes are release-ready under `Unreleased -> Changed`.
 - This affects both prerelease and future stable consumers because it changes public cmdlet semantics, but it does not alter stable-vs-prerelease publishing logic.
 ```
 
 > [!IMPORTANT]
 > Do not use a public pull request to disclose a vulnerability before coordinated handling.
 > Use the private reporting path in `SECURITY.md` for new security issues.
