### PR TITLE
Enhance progress tracking and testing for Nova workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- `Publish-NovaModule` now keeps its completion summary available after local publish import or CI session refresh steps reload the module, so local publish flows no longer fail with missing private release-helper functions at the end of a successful publish.
+- `Test-NovaBuild` and `% nova test` now keep the Nova progress display visibly active during long Pester runs instead of appearing stuck on one step while tests continue in the background.
+    - During the long Pester phase, Nova now uses the discovered test count plus completed test results to drive the progress bar, so the visible percentage tracks real test completion instead of elapsed time.
+    - The progress text now stays simple while the bar itself reflects the real test-driven completion state.
+    - The configured Pester output still flows live so `project.json` settings such as `Pester.Output.Verbosity = "Detailed"` remain visible.
+- Progress-enabled private workflows now have stronger mirrored progress-contract tests, and the repository adds a guardrail test so future `Write-Progress` workflows cannot land without matching test ownership.
+
 ### Security
 
 ## [3.1.0] - 2026-05-24

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -19,6 +19,10 @@ This file summarizes the release notes for NovaModuleTools. **UNRELEASED** chang
 
 ### Fixed
 
+- `Publish-NovaModule` no longer loses its completion summary after local publish import or CI session refresh steps reload the module.
+- `Test-NovaBuild` and `% nova test` now keep the Nova progress display visibly active during long Pester runs instead of appearing stuck on one step while tests continue.
+    - During the long Pester phase, Nova now drives the progress bar from discovered and completed Pester tests instead of elapsed time, keeps the progress text simple, and still shows configured Pester output such as `Pester.Output.Verbosity = "Detailed"`.
+
 ### Security
 
 ## [3.1.0] - 2026-05-24

--- a/src/private/quality/InvokeNovaTestWorkflow.ps1
+++ b/src/private/quality/InvokeNovaTestWorkflow.ps1
@@ -71,11 +71,14 @@ function Invoke-NovaTestWorkflowExecution {
 
     $WorkflowContext.PesterConfig.TestResult.OutputPath = $WorkflowContext.TestResultPath
     $coverageTargetAssertion = Get-NovaCoverageTargetAssertionScriptBlock -WorkflowContext $WorkflowContext
-    $testResult = Invoke-NovaTestWorkflowStep -Activity $Activity -Status 'Running Pester tests' -PercentComplete 70 -Action {
-        Invoke-NovaPesterWithSuppressedProgress -Configuration $WorkflowContext.PesterConfig
+    $testProgressContext = [pscustomobject]@{
+        Activity = $Activity
+        StartPercentComplete = 70
+        EndPercentComplete = 94
     }
+    $testResult = Invoke-NovaPesterWithSuppressedProgress -Configuration $WorkflowContext.PesterConfig -ProgressContext $testProgressContext
 
-    Invoke-NovaTestWorkflowStep -Activity $Activity -Status 'Writing the test result report' -PercentComplete 85 -Action {
+    Invoke-NovaTestWorkflowStep -Activity $Activity -Status 'Writing the test result report' -PercentComplete 96 -Action {
         & $WorkflowContext.TestResultArtifactWriter.ScriptBlock -TestResult $testResult -OutputPath $WorkflowContext.TestResultPath -ReportWriter $WorkflowContext.TestResultReportWriter.ScriptBlock
     }
 
@@ -83,7 +86,7 @@ function Invoke-NovaTestWorkflowExecution {
         Stop-NovaOperation -Message (Get-NovaTestWorkflowFailureMessage -WorkflowContext $WorkflowContext) -ErrorId 'Nova.Workflow.TestRunFailed' -Category InvalidOperation -TargetObject $WorkflowContext.TestResultPath
     }
 
-    Invoke-NovaTestWorkflowStep -Activity $Activity -Status 'Checking the configured code coverage target' -PercentComplete 95 -Action {
+    Invoke-NovaTestWorkflowStep -Activity $Activity -Status 'Checking the configured code coverage target' -PercentComplete 99 -Action {
         & $coverageTargetAssertion -WorkflowContext $WorkflowContext -TestResult $testResult
     }
 
@@ -119,16 +122,316 @@ function Get-NovaTestWorkflowBuildStatus {
 function Invoke-NovaPesterWithSuppressedProgress {
     [CmdletBinding()]
     param(
+        [Parameter(Mandatory)][object]$Configuration,
+        [Parameter(Mandatory)][pscustomobject]$ProgressContext
+    )
+
+    $heartbeatMilliseconds = Get-NovaPropertyValue -InputObject $ProgressContext -Name 'HeartbeatMilliseconds'
+    if ($null -eq $heartbeatMilliseconds) {
+        $heartbeatMilliseconds = 2000
+    }
+
+    $execution = Get-NovaPesterExecution -Configuration $Configuration
+    try {
+        Write-NovaTestWorkflowPesterProgress -Execution $execution -ProgressContext $ProgressContext
+        while (-not (Wait-NovaPesterExecution -Execution $execution -TimeoutMilliseconds $HeartbeatMilliseconds)) {
+            Write-NovaPesterExecutionOutput -Execution $execution
+            Write-NovaTestWorkflowPesterProgress -Execution $execution -ProgressContext $ProgressContext
+        }
+
+        Write-NovaPesterExecutionOutput -Execution $execution
+        Write-NovaTestWorkflowPesterProgress -Execution $execution -ProgressContext $ProgressContext
+        return Receive-NovaPesterExecutionResult -Execution $execution
+    } finally {
+        Complete-NovaPesterExecution -Execution $execution
+    }
+}
+
+function Write-NovaPesterExecutionOutput {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Execution
+    )
+
+    $informationRecords = @(Get-NovaPesterExecutionInformationRecordBuffer -Execution $Execution)
+    $nextInformationRecordIndex = Get-NovaPropertyValue -InputObject $Execution -Name 'NextInformationRecordIndex'
+    if ($null -eq $nextInformationRecordIndex) {
+        $nextInformationRecordIndex = 0
+    }
+
+    while ($nextInformationRecordIndex -lt $informationRecords.Count) {
+        $record = $informationRecords[$nextInformationRecordIndex]
+        Invoke-NovaPesterExecutionProgressStateUpdate -Execution $Execution -Record $record
+        Write-NovaPesterInformationRecord -Record $record
+        $nextInformationRecordIndex += 1
+    }
+
+    $Execution.NextInformationRecordIndex = $nextInformationRecordIndex
+}
+
+function Get-NovaPesterExecutionInformationRecordBuffer {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Execution
+    )
+
+    $powershell = Get-NovaPropertyValue -InputObject $Execution -Name 'PowerShell'
+    if ($null -eq $powershell) {
+        return @()
+    }
+
+    return @(Get-NovaPropertyValue -InputObject $powershell.Streams -Name 'Information')
+}
+
+function Write-NovaPesterInformationRecord {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$Record
+    )
+
+    $messageData = Get-NovaPropertyValue -InputObject $Record -Name 'MessageData'
+    $tags = @(Get-NovaPropertyValue -InputObject $Record -Name 'Tags')
+    if (($tags -contains 'PSHOST') -and (Test-NovaPesterHostInformationMessage -MessageData $messageData)) {
+        Write-NovaPesterHostInformationMessage -MessageData $messageData
+        return
+    }
+
+    Write-Information -MessageData $messageData -Tags $tags -InformationAction Continue
+}
+
+function Invoke-NovaPesterExecutionProgressStateUpdate {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Execution,
+        [Parameter(Mandatory)][object]$Record
+    )
+
+    $messageText = Get-NovaPesterInformationMessageText -Record $Record
+    $discoveredTestCount = Get-NovaPesterDiscoveredTestCount -MessageText $messageText
+    if ($null -ne $discoveredTestCount) {
+        $Execution.TotalTestCount = $discoveredTestCount
+        return
+    }
+
+    if (Test-NovaPesterTestCompletionMessage -Record $Record -MessageText $messageText) {
+        $Execution.CompletedTestCount = (Get-NovaPropertyValue -InputObject $Execution -Name 'CompletedTestCount') + 1
+    }
+}
+
+function Get-NovaPesterInformationMessageText {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$Record
+    )
+
+    $messageData = Get-NovaPropertyValue -InputObject $Record -Name 'MessageData'
+    if (Test-NovaPesterHostInformationMessage -MessageData $messageData) {
+        return [string](Get-NovaPropertyValue -InputObject $messageData -Name 'Message')
+    }
+
+    return [string]$messageData
+}
+
+function Get-NovaPesterDiscoveredTestCount {
+    [CmdletBinding()]
+    param(
+        [AllowNull()][string]$MessageText
+    )
+
+    $match = [System.Text.RegularExpressions.Regex]::Match([string]$MessageText, 'Discovery found (?<Count>\d+) tests? in')
+    if (-not $match.Success) {
+        return $null
+    }
+
+    return [int]$match.Groups['Count'].Value
+}
+
+function Test-NovaPesterTestCompletionMessage {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$Record,
+        [AllowNull()][string]$MessageText
+    )
+
+    $messageData = Get-NovaPropertyValue -InputObject $Record -Name 'MessageData'
+    if (-not (Test-NovaPesterHostInformationMessage -MessageData $messageData)) {
+        return $false
+    }
+
+    if ($true -ne [bool](Get-NovaPropertyValue -InputObject $messageData -Name 'NoNewLine')) {
+        return $false
+    }
+
+    return [string]$MessageText -match '^\s+\[(\+|-|!|\?)\]\s+'
+}
+
+function Test-NovaPesterHostInformationMessage {
+    [CmdletBinding()]
+    param(
+        [AllowNull()][object]$MessageData
+    )
+
+    return $null -ne $MessageData -and $MessageData.PSObject.Properties.Name -contains 'Message'
+}
+
+function Write-NovaPesterHostInformationMessage {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$MessageData
+    )
+
+    $writeHostParameters = @{
+        Object = $MessageData.Message
+    }
+
+    if ($true -eq [bool](Get-NovaPropertyValue -InputObject $MessageData -Name 'NoNewLine')) {
+        $writeHostParameters.NoNewline = $true
+    }
+
+    foreach ($colorName in 'ForegroundColor', 'BackgroundColor') {
+        $colorValue = Get-NovaPropertyValue -InputObject $MessageData -Name $colorName
+        if ($null -ne $colorValue) {
+            $writeHostParameters[$colorName] = $colorValue
+        }
+    }
+
+    Write-Host @writeHostParameters
+}
+
+function Get-NovaPesterExecution {
+    [CmdletBinding()]
+    param(
         [Parameter(Mandatory)][object]$Configuration
     )
 
-    $previousProgressPreference = $global:ProgressPreference
-    $global:ProgressPreference = 'SilentlyContinue'
-    try {
-        return Invoke-NovaPester -Configuration $Configuration
-    } finally {
-        $global:ProgressPreference = $previousProgressPreference
+    $powershell = [powershell]::Create()
+    $command = @'
+param($Configuration)
+Import-Module Pester -ErrorAction Stop
+$previousProgressPreference = $global:ProgressPreference
+$global:ProgressPreference = 'SilentlyContinue'
+try {
+    Invoke-Pester -Configuration $Configuration
+} finally {
+    $global:ProgressPreference = $previousProgressPreference
+}
+'@
+    $null = $powershell.AddScript($command).AddArgument($Configuration)
+
+    return [pscustomobject]@{
+        PowerShell = $powershell
+        AsyncResult = $powershell.BeginInvoke()
+        CompletedTestCount = 0
+        NextInformationRecordIndex = 0
+        TotalTestCount = $null
+        LastProgressStatus = $null
+        LastProgressPercentComplete = $null
     }
+}
+
+function Wait-NovaPesterExecution {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Execution,
+        [Parameter(Mandatory)][int]$TimeoutMilliseconds
+    )
+
+    return $Execution.AsyncResult.AsyncWaitHandle.WaitOne($TimeoutMilliseconds)
+}
+
+function Receive-NovaPesterExecutionResult {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Execution
+    )
+
+    $output = $Execution.PowerShell.EndInvoke($Execution.AsyncResult)
+    return @($output | Select-Object -Last 1)[0]
+}
+
+function Complete-NovaPesterExecution {
+    [CmdletBinding()]
+    param(
+        [AllowNull()][pscustomobject]$Execution
+    )
+
+    if ($null -eq $Execution) {
+        return
+    }
+
+    $powershell = Get-NovaPropertyValue -InputObject $Execution -Name 'PowerShell'
+    if ($null -eq $powershell) {
+        return
+    }
+
+    $powershell.Dispose()
+}
+
+function Write-NovaTestWorkflowPesterProgress {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Execution,
+        [Parameter(Mandatory)][pscustomobject]$ProgressContext
+    )
+
+    $activity = Get-NovaPropertyValue -InputObject $ProgressContext -Name 'Activity'
+    $startPercentComplete = Get-NovaPropertyValue -InputObject $ProgressContext -Name 'StartPercentComplete'
+    $endPercentComplete = Get-NovaPropertyValue -InputObject $ProgressContext -Name 'EndPercentComplete'
+    $totalTestCount = Get-NovaPropertyValue -InputObject $Execution -Name 'TotalTestCount'
+    $completedTestCount = Get-NovaPropertyValue -InputObject $Execution -Name 'CompletedTestCount'
+    $status = Get-NovaTestWorkflowPesterStatus -TotalTestCount $totalTestCount
+    $percentComplete = Get-NovaTestWorkflowPesterPercentComplete -StartPercentComplete $startPercentComplete -EndPercentComplete $endPercentComplete -CompletedTestCount $completedTestCount -TotalTestCount $totalTestCount
+
+    if (($Execution.LastProgressStatus -eq $status) -and ($Execution.LastProgressPercentComplete -eq $percentComplete)) {
+        return
+    }
+
+    Write-Progress -Activity $activity -Status $status -PercentComplete $percentComplete
+    $Execution.LastProgressStatus = $status
+    $Execution.LastProgressPercentComplete = $percentComplete
+}
+
+function Get-NovaTestWorkflowPesterStatus {
+    [CmdletBinding()]
+    param(
+        [AllowNull()][object]$TotalTestCount
+    )
+
+    if ($null -eq $TotalTestCount) {
+        return 'Discovering Pester tests'
+    }
+
+    return 'Running Pester tests'
+}
+
+function Get-NovaTestWorkflowPesterPercentComplete {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][int]$StartPercentComplete,
+        [Parameter(Mandatory)][int]$EndPercentComplete,
+        [Parameter(Mandatory)][int]$CompletedTestCount,
+        [AllowNull()][object]$TotalTestCount
+    )
+
+    if ($null -eq $TotalTestCount) {
+        return $StartPercentComplete
+    }
+
+    if ($TotalTestCount -le 0) {
+        return $EndPercentComplete
+    }
+
+    $progressRange = $EndPercentComplete - $StartPercentComplete
+    $percentComplete = $StartPercentComplete + [int][math]::Floor(($CompletedTestCount / $TotalTestCount) * $progressRange)
+    if ($percentComplete -gt $EndPercentComplete) {
+        return $EndPercentComplete
+    }
+
+    if ($percentComplete -lt $StartPercentComplete) {
+        return $StartPercentComplete
+    }
+
+    return $percentComplete
 }
 
 function Get-NovaTestWorkflowFailureMessage {

--- a/src/private/release/InvokeNovaPublishWorkflow.ps1
+++ b/src/private/release/InvokeNovaPublishWorkflow.ps1
@@ -58,6 +58,9 @@ function Invoke-NovaPublishWorkflow {
     $progressActivity = 'Running Nova publish workflow'
     $importedLocalModule = $false
     $restoredBuiltModule = $false
+    $resolvedResult = Get-NovaPublishWorkflowResolvedResult -WorkflowContext $WorkflowContext -WhatIfEnabled:$whatIfEnabled
+    $messageWriter = (Get-Command -Name Write-Message -CommandType Function -ErrorAction Stop).ScriptBlock
+    $resultWriter = (Get-Command -Name Write-NovaPublishWorkflowResolvedResult -CommandType Function -ErrorAction Stop).ScriptBlock
 
     try {
         Invoke-NovaPublishWorkflowStep -Activity $progressActivity -Status (Get-NovaPublishWorkflowValidationStatus -WorkflowContext $WorkflowContext) -PercentComplete 35 -Action {
@@ -86,7 +89,7 @@ function Invoke-NovaPublishWorkflow {
         Write-Progress -Activity $progressActivity -Completed
     }
 
-    Write-NovaPublishWorkflowResult -WorkflowContext $WorkflowContext -WhatIfEnabled:$whatIfEnabled -ImportedLocalModule:$importedLocalModule -RestoredBuiltModule:$restoredBuiltModule
+    & $resultWriter -Result $resolvedResult -MessageWriter $messageWriter -ImportedLocalModule:$importedLocalModule -RestoredBuiltModule:$restoredBuiltModule
 }
 
 function Get-NovaPublishWorkflowValidationStatus {
@@ -122,32 +125,53 @@ function Get-NovaPublishWorkflowPublishStatus {
     return "Publishing to $targetDescription"
 }
 
-function Write-NovaPublishWorkflowResult {
+function Get-NovaPublishWorkflowResolvedResult {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][pscustomobject]$WorkflowContext,
-        [switch]$WhatIfEnabled,
+        [switch]$WhatIfEnabled
+    )
+
+    $localManifestPath = $null
+    if ($WorkflowContext.PSObject.Properties.Name -contains 'LocalPublishActivation') {
+        $localManifestPath = Get-NovaPublishWorkflowPropertyValue -InputObject $WorkflowContext.LocalPublishActivation -Name 'ManifestPath'
+    }
+
+    return [pscustomobject]@{
+        StatusMessage = Get-NovaPublishWorkflowStatusMessage -WorkflowContext $WorkflowContext -WhatIfEnabled:$WhatIfEnabled
+        PublishTarget = $WorkflowContext.PublishInvocation.Target
+        SkipTestsRequested = $WorkflowContext.SkipTestsRequested
+        LocalManifestPath = $localManifestPath
+        NextStepLines = @(Get-NovaPublishWorkflowNextStepLine -WorkflowContext $WorkflowContext -WhatIfEnabled:$WhatIfEnabled)
+    }
+}
+
+function Write-NovaPublishWorkflowResolvedResult {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Result,
+        [Parameter(Mandatory)][scriptblock]$MessageWriter,
         [switch]$ImportedLocalModule,
         [switch]$RestoredBuiltModule
     )
 
-    Write-Message (Get-NovaPublishWorkflowStatusMessage -WorkflowContext $WorkflowContext -WhatIfEnabled:$WhatIfEnabled) -color Green
-    Write-Message "Publish target: $( $WorkflowContext.PublishInvocation.Target )"
+    & $MessageWriter $Result.StatusMessage -color Green
+    & $MessageWriter "Publish target: $( $Result.PublishTarget )"
 
-    if ($WorkflowContext.SkipTestsRequested) {
-        Write-Message 'Pre-publish tests were skipped for this run.'
+    if ($Result.SkipTestsRequested) {
+        & $MessageWriter 'Pre-publish tests were skipped for this run.'
     }
 
-    if ($ImportedLocalModule) {
-        Write-Message "The published local module is loaded from $( $WorkflowContext.LocalPublishActivation.ManifestPath )."
+    if ($ImportedLocalModule -and -not [string]::IsNullOrWhiteSpace($Result.LocalManifestPath)) {
+        & $MessageWriter "The published local module is loaded from $( $Result.LocalManifestPath )."
     }
 
     if ($RestoredBuiltModule) {
-        Write-Message 'The freshly built dist module is loaded again for later commands in this session.'
+        & $MessageWriter 'The freshly built dist module is loaded again for later commands in this session.'
     }
 
-    foreach ($line in (Get-NovaPublishWorkflowNextStepLine -WorkflowContext $WorkflowContext -WhatIfEnabled:$WhatIfEnabled)) {
-        Write-Message $line
+    foreach ($line in $Result.NextStepLines) {
+        & $MessageWriter $line
     }
 }
 
@@ -190,4 +214,30 @@ function Get-NovaPublishWorkflowNextStepLine {
         'Next step:'
         "Find-Module $( $WorkflowContext.ProjectInfo.ProjectName ) -Repository $( $WorkflowContext.PublishInvocation.Target )"
     )
+}
+
+function Get-NovaPublishWorkflowPropertyValue {
+    [CmdletBinding()]
+    param(
+        [AllowNull()][object]$InputObject,
+        [Parameter(Mandatory)][string]$Name
+    )
+
+    if ($null -eq $InputObject) {
+        return $null
+    }
+
+    if ($InputObject -is [System.Collections.IDictionary]) {
+        if ( $InputObject.Contains($Name)) {
+            return $InputObject[$Name]
+        }
+
+        return $null
+    }
+
+    if ($InputObject.PSObject.Properties.Name -contains $Name) {
+        return $InputObject.$Name
+    }
+
+    return $null
 }

--- a/src/private/release/InvokeNovaReleaseWorkflow.ps1
+++ b/src/private/release/InvokeNovaReleaseWorkflow.ps1
@@ -55,6 +55,9 @@ function Invoke-NovaReleaseWorkflow {
     $whatIfEnabled = Test-NovaReleaseWorkflowWhatIfEnabled -WorkflowParams $workflowParams
     $progressActivity = 'Running Nova release workflow'
     $versionResult = $null
+    $resolvedResult = Get-NovaReleaseWorkflowResolvedResult -WorkflowContext $WorkflowContext -WhatIfEnabled:$whatIfEnabled
+    $messageWriter = (Get-Command -Name Write-Message -CommandType Function -ErrorAction Stop).ScriptBlock
+    $resultWriter = (Get-Command -Name Write-NovaReleaseWorkflowResolvedResult -CommandType Function -ErrorAction Stop).ScriptBlock
 
     try {
         Invoke-NovaReleaseWorkflowStep -Activity $progressActivity -Status 'Building the current project state' -PercentComplete 15 -Action {
@@ -88,7 +91,7 @@ function Invoke-NovaReleaseWorkflow {
         Write-Progress -Activity $progressActivity -Completed
     }
 
-    Write-NovaReleaseWorkflowResult -WorkflowContext $WorkflowContext -VersionResult $versionResult -WhatIfEnabled:$whatIfEnabled -ShouldRestoreBuiltModule:$shouldRestoreBuiltModule
+    & $resultWriter -Result $resolvedResult -MessageWriter $messageWriter -VersionResult $versionResult -ShouldRestoreBuiltModule:$shouldRestoreBuiltModule
     return $versionResult
 }
 
@@ -147,30 +150,46 @@ function Get-NovaReleasePublishStepStatus {
     return "Publishing release to $targetDescription"
 }
 
-function Write-NovaReleaseWorkflowResult {
+function Get-NovaReleaseWorkflowResolvedResult {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][pscustomobject]$WorkflowContext,
+        [switch]$WhatIfEnabled
+    )
+
+    return [pscustomobject]@{
+        ProjectInfo = $WorkflowContext.ProjectInfo
+        PublishTarget = $WorkflowContext.PublishInvocation.Target
+        SkipTestsRequested = ($WorkflowContext.PSObject.Properties.Name -contains 'SkipTestsRequested') -and $WorkflowContext.SkipTestsRequested
+        NextStepLines = @(Get-NovaReleaseWorkflowNextStepLine -WorkflowContext $WorkflowContext -WhatIfEnabled:$WhatIfEnabled)
+        WhatIfEnabled = [bool]$WhatIfEnabled
+    }
+}
+
+function Write-NovaReleaseWorkflowResolvedResult {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][pscustomobject]$Result,
+        [Parameter(Mandatory)][scriptblock]$MessageWriter,
         [AllowNull()][object]$VersionResult,
-        [switch]$WhatIfEnabled,
         [switch]$ShouldRestoreBuiltModule
     )
 
     $resolvedVersion = Get-NovaReleaseWorkflowResultVersion -VersionResult $VersionResult
-    $statusMessage = Get-NovaReleaseWorkflowStatusMessage -ProjectInfo $WorkflowContext.ProjectInfo -Version $resolvedVersion -WhatIfEnabled:$WhatIfEnabled
-    Write-Message $statusMessage -color Green
-    Write-Message "Publish target: $( $WorkflowContext.PublishInvocation.Target )"
+    $statusMessage = Get-NovaReleaseWorkflowStatusMessage -ProjectInfo $Result.ProjectInfo -Version $resolvedVersion -WhatIfEnabled:$Result.WhatIfEnabled
+    & $MessageWriter $statusMessage -color Green
+    & $MessageWriter "Publish target: $( $Result.PublishTarget )"
 
-    if ($WorkflowContext.SkipTestsRequested) {
-        Write-Message 'Pre-release tests were skipped for this run.'
+    if ($Result.SkipTestsRequested) {
+        & $MessageWriter 'Pre-release tests were skipped for this run.'
     }
 
     if ($ShouldRestoreBuiltModule) {
-        Write-Message 'The freshly built dist module is loaded again for later commands in this session.'
+        & $MessageWriter 'The freshly built dist module is loaded again for later commands in this session.'
     }
 
-    foreach ($line in (Get-NovaReleaseWorkflowNextStepLine -WorkflowContext $WorkflowContext -WhatIfEnabled:$WhatIfEnabled)) {
-        Write-Message $line
+    foreach ($line in $Result.NextStepLines) {
+        & $MessageWriter $line
     }
 }
 

--- a/tests/ProgressWorkflowGuardrails.Tests.ps1
+++ b/tests/ProgressWorkflowGuardrails.Tests.ps1
@@ -1,0 +1,29 @@
+BeforeAll {
+    $script:repoRoot = Split-Path -Parent $PSScriptRoot
+    $script:srcRoot = Join-Path $script:repoRoot 'src/private'
+    $script:testRoot = Join-Path $script:repoRoot 'tests/private'
+}
+
+Describe 'Progress workflow guardrails' {
+    It 'each private workflow that writes progress has a mirrored test file' {
+        $progressWorkflowPaths = @(
+            Get-ChildItem -LiteralPath $script:srcRoot -Filter '*.ps1' -Recurse -File |
+                Where-Object {
+                    Select-String -Path $_.FullName -Pattern '\bWrite-Progress\b' -Quiet
+                } |
+                ForEach-Object {
+                    ([System.IO.Path]::GetRelativePath($script:repoRoot, $_.FullName)).Replace('\', '/')
+                } |
+                Sort-Object
+        )
+
+        $missingTests = foreach ($sourcePath in $progressWorkflowPaths) {
+            $expectedTestPath = $sourcePath.Replace('src/private/', 'tests/private/').Replace('.ps1', '.Tests.ps1')
+            if (-not (Test-Path -LiteralPath (Join-Path $script:repoRoot $expectedTestPath))) {
+                $expectedTestPath
+            }
+        }
+
+        $missingTests | Should -BeNullOrEmpty -Because "Missing mirrored progress tests: $( $missingTests -join ', ' )"
+    }
+}

--- a/tests/private/build/InvokeNovaBuildWorkflow.Tests.ps1
+++ b/tests/private/build/InvokeNovaBuildWorkflow.Tests.ps1
@@ -36,6 +36,13 @@ Describe 'Invoke-NovaBuildWorkflow' {
             Assert-MockCalled Invoke-NovaModuleUpdateNotificationSafely -Times 1
             Assert-MockCalled Import-NovaBuiltModuleForCi -Times 0
             Assert-MockCalled Write-Progress -Times 9
+            Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+                $Status -eq 'Validating public command layout' -and $PercentComplete -eq 10
+            }
+            Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+                $Status -eq 'Checking update notifications' -and $PercentComplete -eq 94
+            }
+            Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {$Completed}
             Assert-MockCalled Write-Message -Times 3
             Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
                 $Text -eq 'Built Nova module: NovaModuleTools' -and $color -eq 'Green'
@@ -77,6 +84,10 @@ Describe 'Invoke-NovaBuildWorkflow' {
             $global:steps -join ',' | Should -Be 'public-layout,reset,module,duplicates,manifest,help,resources,notification,ci'
             Assert-MockCalled Import-NovaBuiltModuleForCi -Times 1
             Assert-MockCalled Write-Progress -Times 10
+            Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+                $Status -eq 'Refreshing the current session with the built module' -and $PercentComplete -eq 98
+            }
+            Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {$Completed}
             Assert-MockCalled Write-Message -Times 3
         } finally {
             Remove-Variable -Name steps -Scope Global -ErrorAction SilentlyContinue

--- a/tests/private/package/InvokeNovaPackageUploadWorkflow.Tests.ps1
+++ b/tests/private/package/InvokeNovaPackageUploadWorkflow.Tests.ps1
@@ -24,6 +24,16 @@ Describe 'Invoke-NovaPackageUploadWorkflow' {
         Should -Invoke Invoke-NovaPackageArtifactUpload -Times 2
         Should -Invoke Write-Progress -Times 2 -ParameterFilter {-not $Completed}
         Should -Invoke Write-Progress -Times 1 -ParameterFilter {$Completed}
+        Should -Invoke Write-Progress -Times 1 -ParameterFilter {
+            (-not $Completed) -and
+            $Status -eq 'Uploading a.nupkg (1 of 2)' -and
+            $PercentComplete -eq 0
+        }
+        Should -Invoke Write-Progress -Times 1 -ParameterFilter {
+            (-not $Completed) -and
+            $Status -eq 'Uploading b.nupkg (2 of 2)' -and
+            $PercentComplete -eq 50
+        }
     }
 
     It 'uses a generic progress status when the artifact file name is blank' {

--- a/tests/private/package/InvokeNovaPackageWorkflow.Tests.ps1
+++ b/tests/private/package/InvokeNovaPackageWorkflow.Tests.ps1
@@ -22,6 +22,10 @@ Describe 'Invoke-NovaPackageWorkflow' {
         $script:validated | Should -BeTrue
         Should -Invoke Invoke-NovaPackageArtifactCreation -Times 0
         Assert-MockCalled Write-Progress -Times 2
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Building and testing package input' -and $PercentComplete -eq 30
+        }
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {$Completed}
         $result | Should -BeNullOrEmpty
     }
 
@@ -36,6 +40,10 @@ Describe 'Invoke-NovaPackageWorkflow' {
         }) -ShouldRun
         Should -Invoke Invoke-NovaPackageArtifactCreation -Times 1
         Assert-MockCalled Write-Progress -Times 3
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Creating package artifacts' -and $PercentComplete -eq 85
+        }
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {$Completed}
         Assert-MockCalled Write-Message -Times 3
         Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
             $Text -eq 'Created 1 package artifact for Demo' -and $color -eq 'Green'
@@ -56,6 +64,10 @@ Describe 'Invoke-NovaPackageWorkflow' {
 
         $script:validated | Should -BeTrue
         Assert-MockCalled Write-Message -Times 3
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Building package input with tests skipped' -and $PercentComplete -eq 30
+        }
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {$Completed}
         Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
             $Text -eq 'Package plan ready for Demo' -and $color -eq 'Green'
         }

--- a/tests/private/quality/InvokeNovaTestWorkflow.Tests.ps1
+++ b/tests/private/quality/InvokeNovaTestWorkflow.Tests.ps1
@@ -451,6 +451,21 @@ Describe 'Write-NovaPesterExecutionOutput' {
             $MessageData -eq 'discovery' -and $Tags.Count -eq 1 -and $Tags[0] -eq 'Pester' -and $InformationAction -eq 'Continue'
         }
     }
+
+    It 'initializes the record index to zero when the property value is null' {
+        $execution = [pscustomobject]@{
+            PowerShell = [pscustomobject]@{
+                Streams = [pscustomobject]@{Information = @()}
+            }
+            CompletedTestCount = 0
+            TotalTestCount = $null
+            NextInformationRecordIndex = $null
+        }
+
+        Write-NovaPesterExecutionOutput -Execution $execution
+
+        $execution.NextInformationRecordIndex | Should -Be 0
+    }
 }
 
 Describe 'Get-NovaTestWorkflowCoverageMessage' {
@@ -487,5 +502,90 @@ Describe 'Get-NovaTestWorkflowPesterPercentComplete' {
 
     It 'caps completed test progress at the configured end percent' {
         Get-NovaTestWorkflowPesterPercentComplete -StartPercentComplete 70 -EndPercentComplete 94 -CompletedTestCount 5 -TotalTestCount 4 | Should -Be 94
+    }
+
+    It 'returns the end percent immediately when the total test count is zero' {
+        Get-NovaTestWorkflowPesterPercentComplete -StartPercentComplete 70 -EndPercentComplete 94 -CompletedTestCount 0 -TotalTestCount 0 | Should -Be 94
+    }
+
+    It 'returns the start percent when the computed value falls below the range minimum' {
+        Get-NovaTestWorkflowPesterPercentComplete -StartPercentComplete 94 -EndPercentComplete 70 -CompletedTestCount 5 -TotalTestCount 4 | Should -Be 94
+    }
+}
+
+Describe 'Get-NovaPesterExecutionInformationRecordBuffer' {
+    It 'returns an empty array when the execution has no PowerShell' {
+        $execution = [pscustomobject]@{PowerShell = $null}
+        $result = @(Get-NovaPesterExecutionInformationRecordBuffer -Execution $execution)
+        $result.Count | Should -Be 0
+    }
+}
+
+Describe 'Get-NovaPesterExecution' {
+    It 'returns an execution object with the expected initial properties' {
+        $execution = $null
+        try {
+            $execution = Get-NovaPesterExecution -Configuration ([pscustomobject]@{})
+            $execution.PowerShell | Should -Not -BeNullOrEmpty
+            $execution.AsyncResult | Should -Not -BeNullOrEmpty
+            $execution.CompletedTestCount | Should -Be 0
+            $execution.NextInformationRecordIndex | Should -Be 0
+            $execution.TotalTestCount | Should -BeNullOrEmpty
+            $execution.LastProgressStatus | Should -BeNullOrEmpty
+            $execution.LastProgressPercentComplete | Should -BeNullOrEmpty
+        } finally {
+            if ($null -ne $execution -and $null -ne $execution.PowerShell) {
+                $execution.PowerShell.Dispose()
+            }
+        }
+    }
+}
+
+Describe 'Wait-NovaPesterExecution' {
+    It 'returns true when the async operation completes within the timeout' {
+        $ps = [powershell]::Create()
+        $null = $ps.AddScript('return 0')
+        $asyncResult = $ps.BeginInvoke()
+        $execution = [pscustomobject]@{PowerShell = $ps; AsyncResult = $asyncResult}
+        try {
+            $result = Wait-NovaPesterExecution -Execution $execution -TimeoutMilliseconds 30000
+            $result | Should -BeTrue
+        } finally {
+            $ps.Dispose()
+        }
+    }
+}
+
+Describe 'Receive-NovaPesterExecutionResult' {
+    It 'returns the last output object from the completed execution' {
+        $ps = [powershell]::Create()
+        $null = $ps.AddScript('[pscustomobject]@{Result = "Passed"}')
+        $asyncResult = $ps.BeginInvoke()
+        $execution = [pscustomobject]@{PowerShell = $ps; AsyncResult = $asyncResult}
+        try {
+            $null = $asyncResult.AsyncWaitHandle.WaitOne(30000)
+            $result = Receive-NovaPesterExecutionResult -Execution $execution
+            $result.Result | Should -Be 'Passed'
+        } finally {
+            $ps.Dispose()
+        }
+    }
+}
+
+Describe 'Complete-NovaPesterExecution' {
+    It 'returns immediately when the execution is null' {
+        { Complete-NovaPesterExecution -Execution $null } | Should -Not -Throw
+    }
+
+    It 'returns immediately when the PowerShell property is null' {
+        $execution = [pscustomobject]@{PowerShell = $null}
+        { Complete-NovaPesterExecution -Execution $execution } | Should -Not -Throw
+    }
+
+    It 'disposes the PowerShell instance' {
+        $ps = [powershell]::Create()
+        $null = $ps.AddScript('return 0')
+        $execution = [pscustomobject]@{PowerShell = $ps}
+        { Complete-NovaPesterExecution -Execution $execution } | Should -Not -Throw
     }
 }

--- a/tests/private/quality/InvokeNovaTestWorkflow.Tests.ps1
+++ b/tests/private/quality/InvokeNovaTestWorkflow.Tests.ps1
@@ -9,6 +9,7 @@ Describe 'Invoke-NovaTestWorkflow' {
     BeforeEach {
         Mock Write-Message {}
         Mock Write-Progress {}
+        Mock Invoke-NovaPesterWithSuppressedProgress {[pscustomobject]@{Result = 'Passed'}}
     }
 
     It 'uses the pre-resolved coverage assertion after the Pester run' {
@@ -27,12 +28,21 @@ Describe 'Invoke-NovaTestWorkflow' {
 
         try {
             Mock Test-Path {$true}
-            Mock Invoke-NovaPester {[pscustomobject]@{Result = 'Passed'}}
 
             {Invoke-NovaTestWorkflow -WorkflowContext $workflowContext} | Should -Not -Throw
             $global:coverageAssertionRan | Should -BeTrue
             Assert-MockCalled Write-Message -Times 4
-            Assert-MockCalled Write-Progress -Times 5
+            Assert-MockCalled Write-Progress -Times 4
+            Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+                $Status -eq 'Preparing the test result directory' -and $PercentComplete -eq 40
+            }
+            Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+                $Status -eq 'Writing the test result report' -and $PercentComplete -eq 96
+            }
+            Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+                $Status -eq 'Checking the configured code coverage target' -and $PercentComplete -eq 99
+            }
+            Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {$Completed}
             Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
                 $Text -eq 'Pester tests passed for NovaModuleTools' -and $color -eq 'Green'
             }
@@ -73,7 +83,7 @@ Describe 'Invoke-NovaTestWorkflow' {
         }
 
         Mock Test-Path {$true}
-        Mock Invoke-NovaPester {$PesterResult}.GetNewClosure()
+        Mock Invoke-NovaPesterWithSuppressedProgress {$PesterResult}.GetNewClosure()
 
         $thrown = $null
         try {Invoke-NovaTestWorkflow -WorkflowContext $workflowContext} catch {$thrown = $_}
@@ -96,7 +106,7 @@ Describe 'Invoke-NovaTestWorkflow' {
         }
 
         Mock Test-Path {$true}
-        Mock Invoke-NovaPester {
+        Mock Invoke-NovaPesterWithSuppressedProgress {
             [pscustomobject]@{Result = 'Passed'; CodeCoverage = [pscustomobject]@{CoveragePercent = 10}}
         }
 
@@ -137,60 +147,6 @@ Describe 'Invoke-NovaTestWorkflow' {
         }
 
         Get-NovaConfiguredCoveragePercentTarget -WorkflowContext $workflowContext | Should -BeNullOrEmpty
-    }
-
-    It 'suppresses global progress output around the Pester run and restores the previous preference' {
-        $workflowContext = [pscustomobject]@{
-            ProjectInfo = [pscustomobject]@{ProjectName = 'NovaModuleTools'; Pester = [ordered]@{}}
-            TestResultDirectory = '/tmp/nova-project/artifacts'
-            TestResultPath = '/tmp/nova-project/artifacts/TestResults.xml'
-            PesterConfig = [pscustomobject]@{TestResult = [pscustomobject]@{OutputPath = $null}}
-            TestResultArtifactWriter = [pscustomobject]@{ScriptBlock = {}}
-            TestResultReportWriter = [pscustomobject]@{ScriptBlock = {}}
-        }
-
-        $previous = $global:ProgressPreference
-        $global:ProgressPreference = 'Continue'
-        $global:observedProgressPreferenceDuringPester = $null
-        try {
-            Mock Test-Path {$true}
-            Mock Invoke-NovaPester {
-                $global:observedProgressPreferenceDuringPester = $global:ProgressPreference
-                [pscustomobject]@{Result = 'Passed'}
-            }
-
-            Invoke-NovaTestWorkflow -WorkflowContext $workflowContext
-
-            $global:observedProgressPreferenceDuringPester | Should -Be 'SilentlyContinue'
-            $global:ProgressPreference | Should -Be 'Continue'
-        } finally {
-            $global:ProgressPreference = $previous
-            Remove-Variable -Name observedProgressPreferenceDuringPester -Scope Global -ErrorAction SilentlyContinue
-        }
-    }
-
-    It 'restores the previous progress preference even when Pester throws' {
-        $workflowContext = [pscustomobject]@{
-            ProjectInfo = [pscustomobject]@{ProjectName = 'NovaModuleTools'; Pester = [ordered]@{}}
-            TestResultDirectory = '/tmp/nova-project/artifacts'
-            TestResultPath = '/tmp/nova-project/artifacts/TestResults.xml'
-            PesterConfig = [pscustomobject]@{TestResult = [pscustomobject]@{OutputPath = $null}}
-            TestResultArtifactWriter = [pscustomobject]@{ScriptBlock = {}}
-            TestResultReportWriter = [pscustomobject]@{ScriptBlock = {}}
-        }
-
-        $previous = $global:ProgressPreference
-        $global:ProgressPreference = 'Continue'
-        try {
-            Mock Test-Path {$true}
-            Mock Invoke-NovaPester {throw 'boom'}
-
-            {Invoke-NovaTestWorkflow -WorkflowContext $workflowContext} | Should -Throw
-
-            $global:ProgressPreference | Should -Be 'Continue'
-        } finally {
-            $global:ProgressPreference = $previous
-        }
     }
 
     It 'handles workflow execution control for <Name>' -ForEach @(
@@ -242,7 +198,7 @@ Describe 'Invoke-NovaTestWorkflow' {
         $workflowContext = New-NovaInvokeNovaTestWorkflowContext -BuildRequested $BuildRequested -WorkflowParams $WorkflowParams
         Mock Invoke-NovaBuild {}
         Mock Test-Path {$true}
-        Mock Invoke-NovaPester {$PesterResult}
+        Mock Invoke-NovaPesterWithSuppressedProgress {$PesterResult}
 
         $thrown = $null
         try {
@@ -268,7 +224,7 @@ Describe 'Invoke-NovaTestWorkflow' {
         }
 
         Should -Invoke Invoke-NovaBuild -Times $ExpectedBuildCalls
-        Should -Invoke Invoke-NovaPester -Times $ExpectedPesterCalls
+        Should -Invoke Invoke-NovaPesterWithSuppressedProgress -Times $ExpectedPesterCalls
         Assert-MockCalled Write-Message -Times $ExpectedMessageCount
     }
 
@@ -282,7 +238,7 @@ Describe 'Invoke-NovaTestWorkflow' {
             TestResultArtifactWriter = [pscustomobject]@{ScriptBlock = {}}
             TestResultReportWriter = [pscustomobject]@{ScriptBlock = {}}
         }
-        Mock Invoke-NovaPester {[pscustomobject]@{Result = 'Passed'}}
+        Mock Invoke-NovaPesterWithSuppressedProgress {[pscustomobject]@{Result = 'Passed'}}
         try {
             Invoke-NovaTestWorkflow -WorkflowContext $workflowContext
             Test-Path -LiteralPath $tempDir | Should -BeTrue
@@ -299,17 +255,18 @@ Describe 'Invoke-NovaTestWorkflow' {
             }
         }
         Mock Invoke-NovaBuild {}
-        Mock Invoke-NovaPester {}
+        Mock Invoke-NovaPesterWithSuppressedProgress {}
 
         Invoke-NovaTestWorkflow -WorkflowContext $workflowContext
 
         Should -Invoke Invoke-NovaBuild -Times 1
-        Should -Invoke Invoke-NovaPester -Times 0
+        Should -Invoke Invoke-NovaPesterWithSuppressedProgress -Times 0
         Assert-MockCalled Write-Message -Times 5
         Assert-MockCalled Write-Progress -Times 2
         Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
             $Status -eq 'Previewing the build-before-test workflow' -and $PercentComplete -eq 20
         }
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {$Completed}
         Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
             $Text -eq 'Test plan ready for NovaModuleTools' -and $color -eq 'Green'
         }
@@ -321,6 +278,179 @@ Describe 'Invoke-NovaTestWorkflow' {
         }
     }
 
+}
+
+Describe 'Invoke-NovaPesterWithSuppressedProgress' {
+    BeforeEach {
+        $script:outputCallCount = 0
+        Mock Complete-NovaPesterExecution {}
+    }
+
+    It 'writes progress from discovered and completed tests until the Pester execution completes' {
+        $execution = [pscustomobject]@{
+            PowerShell = [pscustomobject]@{}
+            AsyncResult = [pscustomobject]@{}
+            CompletedTestCount = 0
+            TotalTestCount = $null
+            LastProgressStatus = $null
+            LastProgressPercentComplete = $null
+        }
+        $waitResults = [System.Collections.Queue]::new()
+        $waitResults.Enqueue($false)
+        $waitResults.Enqueue($false)
+        $waitResults.Enqueue($true)
+
+        Mock Write-Progress {}
+        Mock Get-NovaPesterExecution {$execution}
+        Mock Wait-NovaPesterExecution {$waitResults.Dequeue()}
+        Mock Receive-NovaPesterExecutionResult {[pscustomobject]@{Result = 'Passed'}}
+        Mock Write-NovaPesterExecutionOutput {
+            switch ($script:outputCallCount) {
+                0 {$Execution.TotalTestCount = 2}
+                1 {$Execution.CompletedTestCount = 1}
+                2 {$Execution.CompletedTestCount = 2}
+            }
+
+            $script:outputCallCount += 1
+        }
+
+        $result = Invoke-NovaPesterWithSuppressedProgress -Configuration ([pscustomobject]@{}) -ProgressContext ([pscustomobject]@{
+            Activity = 'Running Nova test workflow'
+            StartPercentComplete = 70
+            EndPercentComplete = 94
+            HeartbeatMilliseconds = 2000
+        })
+
+        $result.Result | Should -Be 'Passed'
+        Should -Invoke Get-NovaPesterExecution -Times 1
+        Should -Invoke Wait-NovaPesterExecution -Times 3
+        Should -Invoke Write-NovaPesterExecutionOutput -Times 3
+        Should -Invoke Receive-NovaPesterExecutionResult -Times 1
+        Should -Invoke Complete-NovaPesterExecution -Times 1
+        Should -Invoke Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Discovering Pester tests' -and $PercentComplete -eq 70
+        }
+        Should -Invoke Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Running Pester tests' -and $PercentComplete -eq 70
+        }
+        Should -Invoke Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Running Pester tests' -and $PercentComplete -eq 82
+        }
+        Should -Invoke Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Running Pester tests' -and $PercentComplete -eq 94
+        }
+    }
+
+    It 'stops the async execution when receiving the Pester result throws' {
+        $execution = [pscustomobject]@{
+            PowerShell = [pscustomobject]@{}
+            AsyncResult = [pscustomobject]@{}
+            CompletedTestCount = 0
+            TotalTestCount = $null
+            LastProgressStatus = $null
+            LastProgressPercentComplete = $null
+        }
+
+        Mock Write-Progress {}
+        Mock Get-NovaPesterExecution {$execution}
+        Mock Wait-NovaPesterExecution {$true}
+        Mock Receive-NovaPesterExecutionResult {throw 'boom'}
+        Mock Write-NovaPesterExecutionOutput {}
+
+        { Invoke-NovaPesterWithSuppressedProgress -Configuration ([pscustomobject]@{}) -ProgressContext ([pscustomobject]@{
+                Activity = 'Running Nova test workflow'
+                StartPercentComplete = 70
+                EndPercentComplete = 94
+            }) } | Should -Throw
+        Should -Invoke Write-NovaPesterExecutionOutput -Times 1
+        Should -Invoke Complete-NovaPesterExecution -Times 1
+    }
+}
+
+Describe 'Write-NovaPesterExecutionOutput' {
+    BeforeEach {
+        Mock Write-Host {}
+        Mock Write-Information {}
+    }
+
+    It 'writes pending host information records, tracks discovery, and advances the cursor' {
+        $execution = [pscustomobject]@{
+            PowerShell = [pscustomobject]@{
+                Streams = [pscustomobject]@{
+                    Information = @(
+                        [pscustomobject]@{
+                            Tags = @('PSHOST')
+                            MessageData = [pscustomobject]@{
+                                Message = 'Discovery found 2 tests in 50ms.'
+                                NoNewLine = $false
+                                ForegroundColor = $null
+                                BackgroundColor = $null
+                            }
+                        }
+                        [pscustomobject]@{
+                            Tags = @('PSHOST')
+                            MessageData = [pscustomobject]@{
+                                Message = '  [+] first'
+                                NoNewLine = $true
+                                ForegroundColor = 'DarkGreen'
+                                BackgroundColor = $null
+                            }
+                        }
+                        [pscustomobject]@{
+                            Tags = @('PSHOST')
+                            MessageData = [pscustomobject]@{
+                                Message = ' second'
+                                NoNewLine = $false
+                                ForegroundColor = 'DarkGray'
+                                BackgroundColor = $null
+                            }
+                        }
+                    )
+                }
+            }
+            CompletedTestCount = 0
+            NextInformationRecordIndex = 0
+            TotalTestCount = $null
+        }
+
+        Write-NovaPesterExecutionOutput -Execution $execution
+        Write-NovaPesterExecutionOutput -Execution $execution
+
+        $execution.NextInformationRecordIndex | Should -Be 3
+        $execution.CompletedTestCount | Should -Be 1
+        $execution.TotalTestCount | Should -Be 2
+        Should -Invoke Write-Host -Times 1 -ParameterFilter {
+            $Object -eq '  [+] first' -and $NoNewline -and $ForegroundColor -eq 'DarkGreen'
+        }
+        Should -Invoke Write-Host -Times 1 -ParameterFilter {
+            $Object -eq ' second' -and -not $NoNewline -and $ForegroundColor -eq 'DarkGray'
+        }
+        Should -Invoke Write-Information -Times 0
+    }
+
+    It 'forwards non-host information records through Write-Information' {
+        $execution = [pscustomobject]@{
+            PowerShell = [pscustomobject]@{
+                Streams = [pscustomobject]@{
+                    Information = @(
+                        [pscustomobject]@{
+                            Tags = @('Pester')
+                            MessageData = 'discovery'
+                        }
+                    )
+                }
+            }
+            NextInformationRecordIndex = 0
+        }
+
+        Write-NovaPesterExecutionOutput -Execution $execution
+
+        $execution.NextInformationRecordIndex | Should -Be 1
+        Should -Invoke Write-Host -Times 0
+        Should -Invoke Write-Information -Times 1 -ParameterFilter {
+            $MessageData -eq 'discovery' -and $Tags.Count -eq 1 -and $Tags[0] -eq 'Pester' -and $InformationAction -eq 'Continue'
+        }
+    }
 }
 
 Describe 'Get-NovaTestWorkflowCoverageMessage' {
@@ -343,5 +473,19 @@ Describe 'Get-NovaTestWorkflowCoverageMessage' {
         }
 
         Get-NovaTestWorkflowCoverageMessage -WorkflowContext $workflowContext -TestResult $testResult | Should -Be 'Measured code coverage: 66.67% (target: 90%)'
+    }
+}
+
+Describe 'Get-NovaTestWorkflowPesterPercentComplete' {
+    It 'uses discovered and completed test counts to calculate progress' {
+        Get-NovaTestWorkflowPesterPercentComplete -StartPercentComplete 70 -EndPercentComplete 94 -CompletedTestCount 1 -TotalTestCount 2 | Should -Be 82
+    }
+
+    It 'stays at the start percent until discovery finds the total test count' {
+        Get-NovaTestWorkflowPesterPercentComplete -StartPercentComplete 70 -EndPercentComplete 94 -CompletedTestCount 0 -TotalTestCount $null | Should -Be 70
+    }
+
+    It 'caps completed test progress at the configured end percent' {
+        Get-NovaTestWorkflowPesterPercentComplete -StartPercentComplete 70 -EndPercentComplete 94 -CompletedTestCount 5 -TotalTestCount 4 | Should -Be 94
     }
 }

--- a/tests/private/release/InvokeNovaPublishWorkflow.Tests.ps1
+++ b/tests/private/release/InvokeNovaPublishWorkflow.Tests.ps1
@@ -232,3 +232,20 @@ Describe 'Invoke-NovaPublishWorkflow' {
         }
     }
 }
+
+Describe 'Get-NovaPublishWorkflowPropertyValue' {
+    It 'returns the value from a dictionary when the key exists' {
+        $dict = @{Name = 'test-value'}
+        Get-NovaPublishWorkflowPropertyValue -InputObject $dict -Name 'Name' | Should -Be 'test-value'
+    }
+
+    It 'returns null from a dictionary when the key does not exist' {
+        $dict = @{Other = 'test-value'}
+        Get-NovaPublishWorkflowPropertyValue -InputObject $dict -Name 'Missing' | Should -BeNullOrEmpty
+    }
+
+    It 'returns null when a PSObject does not have the named property' {
+        $obj = [pscustomobject]@{Exists = 'yes'}
+        Get-NovaPublishWorkflowPropertyValue -InputObject $obj -Name 'Missing' | Should -BeNullOrEmpty
+    }
+}

--- a/tests/private/release/InvokeNovaPublishWorkflow.Tests.ps1
+++ b/tests/private/release/InvokeNovaPublishWorkflow.Tests.ps1
@@ -48,11 +48,19 @@ Describe 'Invoke-NovaPublishWorkflowCiRestore' {
 
 Describe 'Invoke-NovaPublishWorkflow' {
     BeforeEach {
+        . (Join-Path $projectRoot 'src/private/release/InvokeNovaPublishWorkflow.ps1')
         $script:validationCalls = 0
         $script:publishCalls = 0
         $script:localImportCalls = 0
         $script:ciImportCalls = 0
-        Mock Write-Message {}
+        $script:messages = @()
+        Set-Item -Path Function:\Write-Message -Value {
+            param($Text, $color)
+            $script:messages += [pscustomobject]@{
+                Text = $Text
+                Color = $color
+            }
+        }
         Mock Write-Progress {}
     }
 
@@ -72,13 +80,16 @@ Describe 'Invoke-NovaPublishWorkflow' {
         $script:publishCalls | Should -Be 1
         $script:localImportCalls | Should -Be 0
         Assert-MockCalled Write-Progress -Times 3
-        Assert-MockCalled Write-Message -Times 4
-        Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
-            $Text -eq 'Published Nova module: NovaModuleTools' -and $color -eq 'Green'
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Building and testing publish output' -and $PercentComplete -eq 35
         }
-        Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
-            $Text -eq 'Find-Module NovaModuleTools -Repository PSGallery'
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Publishing to repository PSGallery' -and $PercentComplete -eq 75
         }
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {$Completed}
+        $script:messages.Count | Should -Be 4
+        ($script:messages | Where-Object {$_.Text -eq 'Published Nova module: NovaModuleTools' -and $_.Color -eq 'Green'}).Count | Should -Be 1
+        ($script:messages | Where-Object {$_.Text -eq 'Find-Module NovaModuleTools -Repository PSGallery'}).Count | Should -Be 1
     }
 
     It 'imports the local published module, restores the built module in CI, and reports the result' {
@@ -104,19 +115,18 @@ Describe 'Invoke-NovaPublishWorkflow' {
         $script:localImportCalls | Should -Be 1
         $script:ciImportCalls | Should -Be 1
         Assert-MockCalled Write-Progress -Times 5
-        Assert-MockCalled Write-Message -Times 6
-        Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
-            $Text -eq 'Pre-publish tests were skipped for this run.'
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Importing the published local module' -and $PercentComplete -eq 90
         }
-        Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
-            $Text -eq 'The published local module is loaded from /m/Mod.psd1.'
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Refreshing the current session with the built module' -and $PercentComplete -eq 98
         }
-        Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
-            $Text -eq 'The freshly built dist module is loaded again for later commands in this session.'
-        }
-        Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
-            $Text -eq 'Get-NovaProjectInfo -Installed'
-        }
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {$Completed}
+        $script:messages.Count | Should -Be 7
+        ($script:messages | Where-Object {$_.Text -eq 'Pre-publish tests were skipped for this run.'}).Count | Should -Be 1
+        ($script:messages | Where-Object {$_.Text -eq 'The published local module is loaded from /m/Mod.psd1.'}).Count | Should -Be 1
+        ($script:messages | Where-Object {$_.Text -eq 'The freshly built dist module is loaded again for later commands in this session.'}).Count | Should -Be 1
+        ($script:messages | Where-Object {$_.Text -eq 'Get-NovaProjectInfo -Installed'}).Count | Should -Be 1
     }
 
     It 'writes a publish plan summary in WhatIf mode without importing or restoring modules' {
@@ -139,12 +149,86 @@ Describe 'Invoke-NovaPublishWorkflow' {
         $script:publishCalls | Should -Be 1
         $script:localImportCalls | Should -Be 0
         $script:ciImportCalls | Should -Be 0
-        Assert-MockCalled Write-Message -Times 4
-        Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
-            $Text -eq 'Publish plan ready for NovaModuleTools' -and $color -eq 'Green'
+        $script:messages.Count | Should -Be 4
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Previewing publish to repository PSGallery' -and $PercentComplete -eq 75
         }
-        Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
-            $Text -eq 'Run Publish-NovaModule without -WhatIf when you are ready to publish the module.'
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {$Completed}
+        ($script:messages | Where-Object {$_.Text -eq 'Publish plan ready for NovaModuleTools' -and $_.Color -eq 'Green'}).Count | Should -Be 1
+        ($script:messages | Where-Object {$_.Text -eq 'Run Publish-NovaModule without -WhatIf when you are ready to publish the module.'}).Count | Should -Be 1
+    }
+
+    It 'still writes the result after the local publish import refreshes the module session' {
+        $originalStatusMessage = (Get-Command -Name Get-NovaPublishWorkflowStatusMessage -CommandType Function).ScriptBlock
+        $originalNextStepLine = (Get-Command -Name Get-NovaPublishWorkflowNextStepLine -CommandType Function).ScriptBlock
+        Mock Invoke-NovaBuildValidation {$script:validationCalls += 1}
+        $ctx = [pscustomobject]@{
+            PublishParams = @{}
+            PublishInvocation = [pscustomobject]@{
+                Action = {param() $script:publishCalls += 1}
+                IsLocal = $true
+                Target = '/modules'
+                Parameters = [pscustomobject]@{ProjectInfo = [pscustomobject]@{ProjectName='NovaModuleTools'}}
+            }
+            LocalPublishActivation = [pscustomobject]@{
+                ManifestPath='/m/NovaModuleTools.psd1'
+                ImportAction = {
+                    param($ProjectName,$ManifestPath)
+                    $script:localImportCalls += 1
+                    Remove-Item Function:\Get-NovaPublishWorkflowStatusMessage -ErrorAction SilentlyContinue
+                    Remove-Item Function:\Get-NovaPublishWorkflowNextStepLine -ErrorAction SilentlyContinue
+                }
+            }
+            ProjectInfo = [pscustomobject]@{ProjectName = 'NovaModuleTools'}
+            WorkflowParams = @{}
+            SkipTestsRequested = $true
+            ContinuousIntegrationRequested = $false
+        }
+
+        try {
+            { Invoke-NovaPublishWorkflow -WorkflowContext $ctx -ShouldRun } | Should -Not -Throw
+
+            $script:localImportCalls | Should -Be 1
+            ($script:messages | Where-Object {$_.Text -eq 'Published Nova module: NovaModuleTools' -and $_.Color -eq 'Green'}).Count | Should -Be 1
+            ($script:messages | Where-Object {$_.Text -eq 'The published local module is loaded from /m/NovaModuleTools.psd1.'}).Count | Should -Be 1
+        } finally {
+            Set-Item -Path Function:\Get-NovaPublishWorkflowStatusMessage -Value $originalStatusMessage
+            Set-Item -Path Function:\Get-NovaPublishWorkflowNextStepLine -Value $originalNextStepLine
+        }
+    }
+
+    It 'still writes the result after the CI restore refreshes the module session' {
+        $originalStatusMessage = (Get-Command -Name Get-NovaPublishWorkflowStatusMessage -CommandType Function).ScriptBlock
+        $originalNextStepLine = (Get-Command -Name Get-NovaPublishWorkflowNextStepLine -CommandType Function).ScriptBlock
+        Mock Invoke-NovaBuildValidation {$script:validationCalls += 1}
+        $ctx = [pscustomobject]@{
+            PublishParams = @{}
+            PublishInvocation = [pscustomobject]@{
+                Action = {param() $script:publishCalls += 1}
+                IsLocal = $false
+                Target = 'PSGallery'
+            }
+            LocalPublishActivation = $null
+            ProjectInfo = [pscustomobject]@{ProjectName = 'NovaModuleTools'}
+            WorkflowParams = @{}
+            SkipTestsRequested = $false
+            ContinuousIntegrationRequested = $true
+        }
+
+        Mock Import-NovaBuiltModuleForCi {
+            $script:ciImportCalls += 1
+            Remove-Item Function:\Get-NovaPublishWorkflowStatusMessage -ErrorAction SilentlyContinue
+            Remove-Item Function:\Get-NovaPublishWorkflowNextStepLine -ErrorAction SilentlyContinue
+        }
+
+        try {
+            { Invoke-NovaPublishWorkflow -WorkflowContext $ctx -ShouldRun } | Should -Not -Throw
+
+            $script:ciImportCalls | Should -Be 1
+            ($script:messages | Where-Object {$_.Text -eq 'Published Nova module: NovaModuleTools' -and $_.Color -eq 'Green'}).Count | Should -Be 1
+        } finally {
+            Set-Item -Path Function:\Get-NovaPublishWorkflowStatusMessage -Value $originalStatusMessage
+            Set-Item -Path Function:\Get-NovaPublishWorkflowNextStepLine -Value $originalNextStepLine
         }
     }
 }

--- a/tests/private/release/InvokeNovaReleaseWorkflow.Tests.ps1
+++ b/tests/private/release/InvokeNovaReleaseWorkflow.Tests.ps1
@@ -65,12 +65,20 @@ Describe 'Test-NovaReleaseWorkflowShouldRestoreBuiltModule' {
 
 Describe 'Invoke-NovaReleaseWorkflow' {
     BeforeEach {
+        . (Join-Path $projectRoot 'src/private/release/InvokeNovaReleaseWorkflow.ps1')
         $script:buildCalls = 0
         $script:testCalls = 0
         $script:versionCalls = 0
         $script:restoreCalls = 0
         $script:publishCalls = 0
-        Mock Write-Message {}
+        $script:messages = @()
+        Set-Item -Path Function:\Write-Message -Value {
+            param($Text, $color)
+            $script:messages += [pscustomobject]@{
+                Text = $Text
+                Color = $color
+            }
+        }
         Mock Write-Progress {}
     }
 
@@ -92,13 +100,28 @@ Describe 'Invoke-NovaReleaseWorkflow' {
         $script:publishCalls | Should -Be 1
         $script:restoreCalls | Should -Be 1
         Assert-MockCalled Write-Progress -Times 6
-        Assert-MockCalled Write-Message -Times 5
-        Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
-            $Text -eq 'Released Nova module: NovaModuleTools 1.0.0' -and $color -eq 'Green'
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Building the current project state' -and $PercentComplete -eq 15
         }
-        Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
-            $Text -eq 'Get-NovaProjectInfo -Version'
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Running pre-release tests' -and $PercentComplete -eq 35
         }
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Updating the project version' -and $PercentComplete -eq 55
+        }
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Rebuilding release output' -and $PercentComplete -eq 75
+        }
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Publishing release to repository PSGallery' -and $PercentComplete -eq 90
+        }
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Refreshing the current session with the built module' -and $PercentComplete -eq 98
+        }
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {$Completed}
+        $script:messages.Count | Should -Be 5
+        ($script:messages | Where-Object {$_.Text -eq 'Released Nova module: NovaModuleTools 1.0.0' -and $_.Color -eq 'Green'}).Count | Should -Be 1
+        ($script:messages | Where-Object {$_.Text -eq 'Get-NovaProjectInfo -Version'}).Count | Should -Be 1
     }
 
     It 'skips tests when SkipTestsRequested and skips restore when not CI' {
@@ -112,12 +135,12 @@ Describe 'Invoke-NovaReleaseWorkflow' {
         $null = Invoke-NovaReleaseWorkflow -WorkflowContext $ctx
         $script:testCalls | Should -Be 0
         $script:restoreCalls | Should -Be 0
-        Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
-            $Text -eq 'Pre-release tests were skipped for this run.'
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Publishing release to the local module path' -and $PercentComplete -eq 90
         }
-        Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
-            $Text -eq 'Get-NovaProjectInfo -Installed'
-        }
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {$Completed}
+        ($script:messages | Where-Object {$_.Text -eq 'Pre-release tests were skipped for this run.'}).Count | Should -Be 1
+        ($script:messages | Where-Object {$_.Text -eq 'Get-NovaProjectInfo -Installed'}).Count | Should -Be 1
     }
 
     It 'writes a release plan summary in WhatIf mode without restoring the built module' {
@@ -133,11 +156,44 @@ Describe 'Invoke-NovaReleaseWorkflow' {
         $null = Invoke-NovaReleaseWorkflow -WorkflowContext $ctx
 
         $script:restoreCalls | Should -Be 0
-        Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
-            $Text -eq 'Release plan ready for NovaModuleTools -> 1.0.0' -and $color -eq 'Green'
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Planning the next release version' -and $PercentComplete -eq 55
         }
-        Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
-            $Text -eq 'Run Invoke-NovaRelease without -WhatIf when you are ready to apply the release.'
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Previewing publish to repository PSGallery' -and $PercentComplete -eq 90
+        }
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {$Completed}
+        ($script:messages | Where-Object {$_.Text -eq 'Release plan ready for NovaModuleTools -> 1.0.0' -and $_.Color -eq 'Green'}).Count | Should -Be 1
+        ($script:messages | Where-Object {$_.Text -eq 'Run Invoke-NovaRelease without -WhatIf when you are ready to apply the release.'}).Count | Should -Be 1
+    }
+
+    It 'still writes the result after the CI restore refreshes the module session' {
+        $originalStatusMessage = (Get-Command -Name Get-NovaReleaseWorkflowStatusMessage -CommandType Function).ScriptBlock
+        $originalNextStepLine = (Get-Command -Name Get-NovaReleaseWorkflowNextStepLine -CommandType Function).ScriptBlock
+        $ctx = [pscustomobject]@{
+            WorkflowParams = @{}
+            PublishParams = @{}
+            PublishInvocation = [pscustomobject]@{Action = {param() $script:publishCalls += 1}; Target = 'PSGallery'; IsLocal = $false}
+            ProjectInfo = [pscustomobject]@{ProjectName = 'NovaModuleTools'}
+            ContinuousIntegrationRequested = $true
+            SkipTestsRequested = $false
+            OverrideWarningRequested = $false
+        }
+
+        Mock Import-NovaBuiltModuleForCi {
+            $script:restoreCalls += 1
+            Remove-Item Function:\Get-NovaReleaseWorkflowStatusMessage -ErrorAction SilentlyContinue
+            Remove-Item Function:\Get-NovaReleaseWorkflowNextStepLine -ErrorAction SilentlyContinue
+        }
+
+        try {
+            { Invoke-NovaReleaseWorkflow -WorkflowContext $ctx } | Should -Not -Throw
+
+            $script:restoreCalls | Should -Be 1
+            ($script:messages | Where-Object {$_.Text -eq 'Released Nova module: NovaModuleTools 1.0.0' -and $_.Color -eq 'Green'}).Count | Should -Be 1
+        } finally {
+            Set-Item -Path Function:\Get-NovaReleaseWorkflowStatusMessage -Value $originalStatusMessage
+            Set-Item -Path Function:\Get-NovaReleaseWorkflowNextStepLine -Value $originalNextStepLine
         }
     }
 }

--- a/tests/private/scaffold/InvokeNovaAgenticCopilotScaffoldWorkflow.Tests.ps1
+++ b/tests/private/scaffold/InvokeNovaAgenticCopilotScaffoldWorkflow.Tests.ps1
@@ -110,6 +110,13 @@ Describe 'Invoke-NovaAgenticCopilotScaffoldWorkflow' {
         Assert-MockCalled Confirm-NovaAgenticCopilotScaffoldWarning -Times 1
         Assert-MockCalled Initialize-NovaModuleAgenticCopilotScaffold -Times 1
         Assert-MockCalled Write-Progress -Times 3
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Confirming overwrite warning' -and $PercentComplete -eq 20
+        }
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Refreshing managed scaffold files' -and $PercentComplete -eq 75
+        }
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {$Completed}
         Assert-MockCalled Write-Message -Times 5
         Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
             $Message -eq 'Agentic Copilot scaffold applied to Demo' -and $color -eq 'Green'

--- a/tests/private/scaffold/InvokeNovaModuleInitializationWorkflow.Tests.ps1
+++ b/tests/private/scaffold/InvokeNovaModuleInitializationWorkflow.Tests.ps1
@@ -27,6 +27,13 @@ Describe 'Invoke-NovaModuleInitializationWorkflow' {
         Assert-MockCalled Write-NovaModuleProjectJson -Times 1
         Assert-MockCalled Initialize-NovaModuleAgenticCopilotScaffold -Times 0
         Assert-MockCalled Write-Progress -Times 3
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Creating scaffold files' -and $PercentComplete -eq 25
+        }
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Writing project.json' -and $PercentComplete -eq 60
+        }
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {$Completed}
         Assert-MockCalled Write-Message -Times 4
         Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
             $InputObject -eq 'Created Nova module scaffold: DemoModule' -and $color -eq 'Green'
@@ -52,6 +59,10 @@ Describe 'Invoke-NovaModuleInitializationWorkflow' {
 
         Assert-MockCalled Initialize-NovaModuleAgenticCopilotScaffold -Times 1
         Assert-MockCalled Write-Progress -Times 4
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Applying Agentic Copilot starter' -and $PercentComplete -eq 85
+        }
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {$Completed}
     }
 
     It 'suggests Test-NovaBuild as the next step for the example scaffold' {
@@ -69,6 +80,7 @@ Describe 'Invoke-NovaModuleInitializationWorkflow' {
 
         Invoke-NovaModuleInitializationWorkflow -WorkflowContext $exampleContext
 
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {$Completed}
         Assert-MockCalled Write-Message -Times 1 -ParameterFilter {
             $InputObject -eq 'Test-NovaBuild'
         }

--- a/tests/private/update/InvokeNovaModuleSelfUpdateWorkflow.Tests.ps1
+++ b/tests/private/update/InvokeNovaModuleSelfUpdateWorkflow.Tests.ps1
@@ -148,6 +148,13 @@ Describe 'Invoke-NovaModuleSelfUpdateWorkflow' {
 
         $result.Updated | Should -BeTrue
         $result.ReleaseNotesUri | Should -Be 'https://example.com/n'
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Installing version 1.1.0' -and $PercentComplete -eq 80
+        }
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {
+            $Status -eq 'Reading release notes from the updated module' -and $PercentComplete -eq 95
+        }
+        Assert-MockCalled Write-Progress -Times 1 -ParameterFilter {$Completed}
         Assert-MockCalled Write-Message -Times 1 -ParameterFilter {$Text -eq 'Updated NovaModuleTools to version 1.1.0.' -and $color -eq 'Green'}
         Assert-MockCalled Write-Message -Times 1 -ParameterFilter {$Text -eq 'Get-NovaProjectInfo -InstalledNovaVersion'}
         Assert-MockCalled Write-Progress -Times 3


### PR DESCRIPTION
Summary

 - Fixed stalled progress reporting in Test-NovaBuild / % nova test by driving the long Pester phase from discovered and completed test counts instead of elapsed time.
 - Hardened publish/release result reporting so completion summaries still print after local-module import or CI session refresh paths reload the module/session.
 - Added stronger mirrored progress-contract coverage plus a guardrail test for private workflows that use Write-Progress.
 - Why needed: long test runs looked visually stuck, and publish/release workflows could lose their end-of-run summary after module/session refresh behavior.
 - Related work: #240

Affected area

 - [ ]  nova CLI or command routing
 - [X]  Public PowerShell cmdlet behavior
 - [ ]  Scaffolding or project.json handling
 - [X]  Build, test, analyzer, coverage, or CI helper flow
 - [ ]  Package, raw upload, or package metadata workflow
 - [X]  Publish, release, or GitHub Actions automation
 - [ ]  Self-update or notification preference behavior
 - [ ]  Contributor documentation (README.md, CONTRIBUTING.md, repository workflow docs)
 - [ ]  End-user docs (docs/*.html)
 - [ ]  Command help (docs/NovaModuleTools/en-US/*.md)
 - [ ]  src/resources/example/
 - [ ]  Dependency or manifest changes (project.json, workflow dependencies, release tooling)
 - [ ]  Security-sensitive change
 - [ ]  Documentation-only change
 - [ ]  Agentic Copilot Workflow + scaffold mirror + scaffold-sync guardrail test.
 - [ ]  Other

Review guidance

 - Start with src/private/quality/InvokeNovaTestWorkflow.ps1.
 - Then review src/private/release/InvokeNovaPublishWorkflow.ps1 and src/private/release/InvokeNovaReleaseWorkflow.ps1.
 - Main supporting tests: tests/private/quality/InvokeNovaTestWorkflow.Tests.ps1, tests/private/release/InvokeNovaPublishWorkflow.Tests.ps1, tests/private/release/InvokeNovaReleaseWorkflow.Tests.ps1, and tests/ProgressWorkflowGuardrails.Tests.ps1.
 - Release-prep gap: unreleased notes currently mention the Publish-NovaModule summary fix, but not the matching Invoke-NovaRelease fix now present in the branch.

Validation

 - [ ]  Invoke-NovaBuild
 - [X]  Test-NovaBuild
 - [ ]  ./scripts/build/Invoke-ScriptAnalyzerCI.ps1
 - [ ]  ./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1
 - [ ]  Targeted Nova workflow validated (% nova build, % nova test, % nova merge, % nova deploy, % nova publish, % nova release, % nova update, % nova notification, or % nova init as relevant)
 - [ ]  Docs/example only; executable validation not needed

Validation notes:

 pwsh -NoLogo -NoProfile -File ./run.ps1
 
 - PSScriptAnalyzer: no findings
 - Pester: 1156 passed, 4 skipped, 0 failed
 - Coverage: 99.23% (target 99%)
 - Relevant suites included:
   - tests/ProgressWorkflowGuardrails.Tests.ps1
   - tests/private/quality/InvokeNovaTestWorkflow.Tests.ps1
   - tests/private/release/InvokeNovaPublishWorkflow.Tests.ps1
   - tests/private/release/InvokeNovaReleaseWorkflow.Tests.ps1
 - No end-to-end PSGallery publish or release/tag flow was executed in this review.

Documentation and release follow-up

 - [ ]  README.md reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
 - [ ]  CONTRIBUTING.md reviewed and updated if contribution expectations or review guidance changed
 - [ ]  CHANGELOG.md reviewed and updated if the change matters to users, maintainers, or contributors
 - [ ]  RELEASE_NOTE.md reviewed and updated if the change affects public cmdlet usage, CLI usage, configuration semantics, or migration expectations
 - [ ]  docs/NovaModuleTools/en-US/ help updated if a public command or CLI behavior changed
 - [ ]  docs/*.html updated if end-user workflows or examples changed
 - [ ]  src/resources/example/ reviewed and updated if the real-world project layout, package model, or upload workflow changed
 - [ ]  No documentation, changelog, release-note, or example updates were needed

Maintainability, compatibility, and risk

 - [X]  Code Health / maintainability impact considered
 - [X]  No breaking change
 - [ ]  Breaking change
 - [ ]  Security-sensitive change
 - [X]  CI, workflow, or release-pipeline impact
 - [ ]  Dependency-review impact

Risk, rollout, or rollback notes:

 Patch-level release impact only. No project.json version change and no Publish.yml diff in this branch.
 
 Current branch remains on the develop prerelease track (3.1.1-preview), so the fixes apply to prerelease consumption first and should roll into the next stable release.
 
 Primary remaining release-prep risk: changelog/release-note drift. The branch includes an Invoke-NovaRelease completion-summary resilience fix that is covered by tests but not currently called out in CHANGELOG.md / RELEASE_NOTE.md.