### PR TITLE
feat(#249): Add support for runtime-only data injection in Invoke-Nova…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Added `Invoke-NovaTest` as the dedicated NovaModuleTools unit-test command.
     - `% nova test` now routes to `Invoke-NovaTest`.
     - `Invoke-NovaTest` writes unit-test NUnit output to `artifacts/UnitTestResults.xml` and remains the code-coverage entry point.
+    - `Invoke-NovaTest` now accepts a guarded `-PesterConfigurationOverride` hook for runtime-only unit-test data injection through `Run.Container`, including `PSCredential` values supplied through `New-PesterContainer -Data`.
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,23 @@ Please also make sure your contribution includes the right kind of follow-up wor
   - keep public command unit ownership in `tests/public/<Command>.Tests.ps1`
   - keep per-command public integration ownership in `tests/public/<Command>.Integration.Tests.ps1` when built-module behavior itself needs validation
   - for destructive or environment-coupled commands, prefer safe `-WhatIf` integration coverage when appropriate
+  - when a unit test needs runtime-only data such as `PSCredential`, keep the secret out of the mirrored `*.Tests.ps1` file and inject it at execution time through `Invoke-NovaTest -PesterConfigurationOverride`
+
+    ```powershell
+    param($Credential)
+
+    Describe 'Publish-NovaModule credential flow' {
+        It 'receives the runtime-only credential' {
+            $Credential | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    $credential = Get-Credential
+    $container = New-PesterContainer -Path 'tests/public/PublishNovaModule.Tests.ps1' -Data @{ Credential = $credential }
+    Invoke-NovaTest -PesterConfigurationOverride @{ Run = @{ Container = @($container) } }
+    ```
+
+  - Nova v1 only accepts `Run.Container`, and each container must target a unit-test file that Nova already discovered for the current run
 - update help files in `docs/` when a command changes
 - update `README.md` when repository workflow, architecture, or contributor expectations change
 - update `CHANGELOG.md` when the change is relevant to users, maintainers, or future contributors

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ PS> Test-NovaBuild
 - `Invoke-NovaTest` is the unit-test entrypoint. Keep public command unit ownership in `tests/public/<Command>.Tests.ps1`.
 - `Test-NovaBuild` is the build-validation integration-test entrypoint. Keep per-command public integration ownership in `tests/public/<Command>.Integration.Tests.ps1` when the built command behavior itself needs coverage.
 - For destructive or environment-coupled commands, prefer safe `-WhatIf` integration coverage when that still proves `ShouldProcess` wiring and command behavior.
+- `Invoke-NovaTest` also supports a PowerShell-only `-PesterConfigurationOverride` hook for runtime-only unit-test data injection. In v1 Nova accepts only `Run.Container`, so you can pass `New-PesterContainer -Path ... -Data @{ Credential = $credential }` without turning the managed test workflow into arbitrary Pester passthrough.
 
 NovaModuleTools can self-update the installed module from PowerShell or the `nova` CLI launcher.
 

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -11,6 +11,7 @@ This file summarizes the release notes for NovaModuleTools. **UNRELEASED** chang
 - Added `Invoke-NovaTest` as the dedicated PowerShell unit-test command.
     - `% nova test` now maps to `Invoke-NovaTest`.
     - Unit-test NUnit results are now written to `artifacts/UnitTestResults.xml`.
+    - `Invoke-NovaTest` now supports guarded runtime-only test-data injection through `-PesterConfigurationOverride`, limited in v1 to `Run.Container` entries such as `New-PesterContainer -Data @{ Credential = $credential }`.
 
 ### Changed
 

--- a/docs/NovaModuleTools/en-US/Invoke-NovaTest.md
+++ b/docs/NovaModuleTools/en-US/Invoke-NovaTest.md
@@ -21,8 +21,9 @@ Runs the NovaModuleTools unit-test workflow for the current project.
 
 ```text
 PS> Invoke-NovaTest [[-TagFilter] <string[]>] [[-ExcludeTagFilter] <string[]>]
- [[-OutputVerbosity] <string>] [[-OutputRenderMode] <string>] [-OverrideWarning]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [[-OutputVerbosity] <string>] [[-OutputRenderMode] <string>]
+ [[-PesterConfigurationOverride] <hashtable>] [-OverrideWarning] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## ALIASES
@@ -36,6 +37,8 @@ The unit-test workflow writes NUnit XML to `artifacts/UnitTestResults.xml`.
 When `Pester.CodeCoverage.Enabled` is `true`, Nova also writes JaCoCo coverage to `artifacts/coverage.xml` and fails the run when the measured percentage is lower than `Pester.CodeCoverage.CoveragePercentTarget`.
 
 Use `Test-NovaBuild` when you need the separate build-validation integration flow that runs against the built module output.
+
+Use `-PesterConfigurationOverride` only when you need runtime-only unit-test data injection through file-backed `New-PesterContainer -Path` objects. In v1, Nova accepts only `Run.Container` and still keeps test discovery, output files, coverage, and required execution flags under Nova control.
 
 Use `-OverrideWarning` only when you intentionally want to bypass Nova's public-file export guard for the current unit-test run.
 
@@ -78,12 +81,22 @@ Overrides the Pester console output settings for the current unit-test run.
 ### EXAMPLE 5
 
 ```text
+PS> $credential = Get-Credential
+PS> $container = New-PesterContainer -Path 'tests/public/PublishNovaModule.Tests.ps1' -Data @{ Credential = $credential }
+PS> Invoke-NovaTest -PesterConfigurationOverride @{ Run = @{ Container = @($container) } }
+```
+
+Runs the standard Nova unit-test discovery set while injecting a runtime-only `PSCredential` into the selected test file through `Run.Container`.
+
+### EXAMPLE 6
+
+```text
 PS> Invoke-NovaTest -OverrideWarning
 ```
 
 Runs the unit-test workflow while explicitly bypassing Nova's public-file export guard for this invocation.
 
-### EXAMPLE 6
+### EXAMPLE 7
 
 ```text
 PS> Invoke-NovaTest -WhatIf
@@ -184,6 +197,27 @@ AcceptedValues:
 HelpMessage: ''
 ```
 
+### -PesterConfigurationOverride
+
+Advanced Pester configuration override for the current unit-test invocation. In v1, Nova accepts only `Run.Container`, and each container must be a file-backed `New-PesterContainer -Path` entry that matches a unit-test file already discovered by Nova.
+
+```yaml
+Type: System.Collections.Hashtable
+DefaultValue: ''
+SupportsWildcards: false
+Aliases: []
+ParameterSets:
+- Name: (All)
+  Position: 4
+  IsRequired: false
+  ValueFromPipeline: false
+  ValueFromPipelineByPropertyName: false
+  ValueFromRemainingArguments: false
+DontShow: false
+AcceptedValues: []
+HelpMessage: ''
+```
+
 ### -OverrideWarning
 
 Bypasses Nova's public-file export guard for this unit-test invocation.
@@ -269,5 +303,5 @@ Returns the Pester result object from the managed unit-test run.
 
 ## RELATED LINKS
 
-[Test-NovaBuild](Test-NovaBuild.md)
-[Invoke-NovaBuild](Invoke-NovaBuild.md)
+- [Test-NovaBuild](./Test-NovaBuild.md)
+- [Invoke-NovaBuild](./Invoke-NovaBuild.md)

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -356,8 +356,10 @@ PS&gt; Invoke-NovaBuild -ContinuousIntegration</code></pre>
                             <li data-command-visibility="powershell"><strong>Cmdlet extras:</strong>
                                 <code>Invoke-NovaTest</code> supports <code>-TagFilter</code>,
                                 <code>-ExcludeTagFilter</code>, <code>-OutputVerbosity</code>, and
-                                <code>-OutputRenderMode</code>. <code>Test-NovaBuild</code> supports the same options
-                                plus <code>-OverrideWarning</code>.</li>
+                                <code>-OutputRenderMode</code>, and the guarded
+                                <code>-PesterConfigurationOverride</code> hook for <code>Run.Container</code>.
+                                <code>Test-NovaBuild</code> supports the same output options plus
+                                <code>-OverrideWarning</code>.</li>
                         </ul>
                         <div class="surface-example" data-command-example>
                             <div class="surface-example__meta">
@@ -373,7 +375,10 @@ PS&gt; Invoke-NovaBuild -ContinuousIntegration</code></pre>
                             <div class="surface-example__surface" data-command-surface="powershell">
                                 <pre><code>PS&gt; Invoke-NovaTest
 PS&gt; Test-NovaBuild
-PS&gt; Invoke-NovaTest -TagFilter unit,fast</code></pre>
+PS&gt; Invoke-NovaTest -TagFilter unit,fast
+PS&gt; $credential = Get-Credential
+PS&gt; $container = New-PesterContainer -Path 'tests/public/PublishNovaModule.Tests.ps1' -Data @{ Credential = $credential }
+PS&gt; Invoke-NovaTest -PesterConfigurationOverride @{ Run = @{ Container = @($container) } }</code></pre>
                             </div>
                         </div>
                         <p><a class="text-link" href="./core-workflows.html#test">See the test workflow</a></p>

--- a/docs/core-workflows.html
+++ b/docs/core-workflows.html
@@ -246,7 +246,10 @@ PS&gt; Invoke-NovaBuild -ContinuousIntegration</code></pre>
 PS&gt; Test-NovaBuild
 PS&gt; Invoke-NovaTest -TagFilter unit,fast
 PS&gt; Test-NovaBuild -ExcludeTagFilter slow
-PS&gt; Invoke-NovaTest -OutputVerbosity Detailed -OutputRenderMode Ansi</code></pre>
+                        PS&gt; Invoke-NovaTest -OutputVerbosity Detailed -OutputRenderMode Ansi
+                        PS&gt; $credential = Get-Credential
+                        PS&gt; $container = New-PesterContainer -Path 'tests/public/PublishNovaModule.Tests.ps1' -Data @{ Credential = $credential }
+                        PS&gt; Invoke-NovaTest -PesterConfigurationOverride @{ Run = @{ Container = @($container) } }</code></pre>
                     </div>
                     <div class="surface-example__surface" data-command-surface="command-line" hidden>
                         <pre><code>% nova test
@@ -274,6 +277,11 @@ PS&gt; Invoke-NovaTest -OutputVerbosity Detailed -OutputRenderMode Ansi</code></
                         <code>-OutputRenderMode</code> are PowerShell cmdlet parameters, so switch to the PowerShell
                         view when you need those controls.</p>
                 </div>
+                <p data-command-visibility="powershell"><code>Invoke-NovaTest</code> also supports a guarded
+                    <code>-PesterConfigurationOverride</code> hook for runtime-only unit-test data. In v1 Nova accepts
+                    only <code>Run.Container</code>, so you can inject values such as <code>PSCredential</code> with
+                    file-backed <code>New-PesterContainer -Path</code> objects while Nova still owns discovery,
+                    coverage, result files, and the rest of the test workflow.</p>
                 <p data-command-visibility="powershell">Use <code>-WhatIf</code> if you want to preview the test run and
                     output path without creating the
                     results directory or invoking Pester.</p>

--- a/src/private/quality/GetNovaTestWorkflowContext.ps1
+++ b/src/private/quality/GetNovaTestWorkflowContext.ps1
@@ -47,8 +47,12 @@ function Get-NovaTestWorkflowContext {
     $pesterConfig.Run.Throw = $true
     $pesterConfig.Filter.Tag = Get-NovaTestOptionValue -TestOption $TestOption -Name TagFilter
     $pesterConfig.Filter.ExcludeTag = Get-NovaTestOptionValue -TestOption $TestOption -Name ExcludeTagFilter
-    Initialize-NovaPesterExecutionConfiguration -PesterConfig $pesterConfig -BoundParameters $BoundParameters -OutputVerbosity (Get-NovaTestOptionValue -TestOption $TestOption -Name OutputVerbosity) -OutputRenderMode (Get-NovaTestOptionValue -TestOption $TestOption -Name OutputRenderMode)
-
+    Initialize-NovaPesterExecutionConfiguration -PesterConfig $pesterConfig -BoundParameters $BoundParameters -ExecutionOption @{
+        PesterConfigurationOverride = Get-NovaTestOptionValue -TestOption $TestOption -Name PesterConfigurationOverride
+        ProjectRoot = $projectInfo.ProjectRoot
+        OutputVerbosity = Get-NovaTestOptionValue -TestOption $TestOption -Name OutputVerbosity
+        OutputRenderMode = Get-NovaTestOptionValue -TestOption $TestOption -Name OutputRenderMode
+    }
     $testResultPath = Get-NovaPesterTestResultPath -ProjectRoot $projectInfo.ProjectRoot -FileName $workflowProfile.TestResultFileName
 
     return [pscustomobject]@{

--- a/src/private/quality/InitializeNovaPesterExecutionConfiguration.ps1
+++ b/src/private/quality/InitializeNovaPesterExecutionConfiguration.ps1
@@ -3,11 +3,10 @@ function Initialize-NovaPesterExecutionConfiguration {
     param(
         [Parameter(Mandatory)][object]$PesterConfig,
         [Parameter(Mandatory)][hashtable]$BoundParameters,
-        [string]$OutputVerbosity,
-        [string]$OutputRenderMode
+        [AllowNull()][hashtable]$ExecutionOption
     )
 
-    $outputOptionOverrides = Get-NovaPesterOutputOptionOverride -PesterConfig $PesterConfig -BoundParameters $BoundParameters -OutputVerbosity $OutputVerbosity -OutputRenderMode $OutputRenderMode
+    $outputOptionOverrides = Get-NovaPesterOutputOptionOverride -PesterConfig $PesterConfig -BoundParameters $BoundParameters -OutputVerbosity (Get-NovaPesterOverrideValue -InputObject $ExecutionOption -Name 'OutputVerbosity') -OutputRenderMode (Get-NovaPesterOverrideValue -InputObject $ExecutionOption -Name 'OutputRenderMode')
     if ($null -ne $outputOptionOverrides) {
         if ($null -ne $outputOptionOverrides.Verbosity) {
             $PesterConfig.Output.Verbosity = $outputOptionOverrides.Verbosity
@@ -21,4 +20,210 @@ function Initialize-NovaPesterExecutionConfiguration {
     if ($PesterConfig.TestResult.PSObject.Properties.Name -contains 'Enabled') {
         $PesterConfig.TestResult.Enabled = $false
     }
+
+    $pesterConfigurationOverride = Get-NovaPesterOverrideValue -InputObject $ExecutionOption -Name 'PesterConfigurationOverride'
+    if ($null -ne $pesterConfigurationOverride) {
+        Initialize-NovaPesterContainerOverride -PesterConfig $PesterConfig -PesterConfigurationOverride $pesterConfigurationOverride -ProjectRoot (Get-NovaPesterOverrideValue -InputObject $ExecutionOption -Name 'ProjectRoot')
+    }
+}
+
+function Initialize-NovaPesterContainerOverride {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$PesterConfig,
+        [Parameter(Mandatory)][object]$PesterConfigurationOverride,
+        [string]$ProjectRoot
+    )
+
+    $overridePropertyNames = @(Get-NovaPesterOverridePropertyName -InputObject $PesterConfigurationOverride)
+    if ($overridePropertyNames.Count -eq 0) {
+        return
+    }
+
+    Assert-NovaAllowedPesterConfigurationOverridePath -PropertyName $overridePropertyNames -AllowedPropertyName 'Run' -Prefix ''
+    $runOverride = Get-NovaPesterOverrideValue -InputObject $PesterConfigurationOverride -Name 'Run'
+    $runPropertyNames = @(Get-NovaPesterOverridePropertyName -InputObject $runOverride)
+    Assert-NovaAllowedPesterConfigurationOverridePath -PropertyName $runPropertyNames -AllowedPropertyName 'Container' -Prefix 'Run'
+
+    $containerOverride = Get-NovaPesterOverrideValue -InputObject $runOverride -Name 'Container'
+    if ($null -eq $containerOverride) {
+        $containerOverride = @()
+    }
+    else {
+        $containerOverride = @($containerOverride)
+    }
+
+    if ($containerOverride.Count -eq 0) {
+        Stop-NovaOperation -Message "Invoke-NovaTest only supports PesterConfigurationOverride.Run.Container in v1. Provide one or more file-backed containers created with New-PesterContainer -Path." -ErrorId 'Nova.Validation.UnsupportedPesterConfigurationOverride' -Category InvalidArgument -TargetObject 'PesterConfigurationOverride.Run.Container'
+    }
+
+    $resolvedRunPath = @(Get-NovaResolvedPesterOverridePathSet -Path (Get-NovaPesterOverridePathInput -Path $PesterConfig.Run.Path) -ProjectRoot $ProjectRoot)
+    $providedContainerByPath = @{}
+    foreach ($container in $containerOverride) {
+        $resolvedContainerPath = Get-NovaValidatedPesterOverrideContainerPath -Container $container -ResolvedRunPath $resolvedRunPath -ProjectRoot $ProjectRoot
+        if ($providedContainerByPath.ContainsKey($resolvedContainerPath)) {
+            Stop-NovaOperation -Message "PesterConfigurationOverride.Run.Container cannot contain multiple containers for the same test path: $resolvedContainerPath" -ErrorId 'Nova.Validation.UnsupportedPesterConfigurationOverride' -Category InvalidArgument -TargetObject $resolvedContainerPath
+        }
+
+        $providedContainerByPath[$resolvedContainerPath] = $container
+    }
+
+    $finalContainer = foreach ($path in $resolvedRunPath) {
+        Resolve-NovaPesterContainerSelection -Path $path -ProvidedContainerByPath $providedContainerByPath
+    }
+
+    $PesterConfig.Run.Container = @($finalContainer)
+    $PesterConfig.Run.Path = @()
+}
+
+function Resolve-NovaPesterContainerSelection {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][hashtable]$ProvidedContainerByPath
+    )
+
+    if ($ProvidedContainerByPath.ContainsKey($Path)) {
+        return $ProvidedContainerByPath[$Path]
+    }
+
+    return New-PesterContainer -Path $Path
+}
+
+function Assert-NovaAllowedPesterConfigurationOverridePath {
+    [CmdletBinding()]
+    param(
+        [AllowEmptyCollection()][string[]]$PropertyName,
+        [Parameter(Mandatory)][string]$AllowedPropertyName,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Prefix
+    )
+
+    foreach ($name in @($PropertyName | Where-Object {-not [string]::IsNullOrWhiteSpace([string]$_)})) {
+        if ($name -eq $AllowedPropertyName) {
+            continue
+        }
+
+        $path = @($Prefix, $name | Where-Object {-not [string]::IsNullOrWhiteSpace([string]$_)}) -join '.'
+        Stop-NovaOperation -Message "Invoke-NovaTest only supports PesterConfigurationOverride.Run.Container in v1. Unsupported override path: $path" -ErrorId 'Nova.Validation.UnsupportedPesterConfigurationOverride' -Category InvalidArgument -TargetObject $path
+    }
+}
+
+function Get-NovaValidatedPesterOverrideContainerPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$Container,
+        [Parameter(Mandatory)][string[]]$ResolvedRunPath,
+        [string]$ProjectRoot
+    )
+
+    $containerType = [string](Get-NovaPesterOverrideValue -InputObject $Container -Name 'Type')
+    if ($containerType -ne 'File') {
+        Stop-NovaOperation -Message "Invoke-NovaTest only supports file-backed PesterConfigurationOverride.Run.Container entries created with New-PesterContainer -Path. ScriptBlock and other container types are not supported." -ErrorId 'Nova.Validation.UnsupportedPesterConfigurationOverride' -Category InvalidArgument -TargetObject $Container
+    }
+
+    $containerPath = [string](Get-NovaPesterOverrideValue -InputObject $Container -Name 'Item')
+    if ([string]::IsNullOrWhiteSpace($containerPath)) {
+        Stop-NovaOperation -Message 'PesterConfigurationOverride.Run.Container entries must expose a file path in the Item property.' -ErrorId 'Nova.Validation.UnsupportedPesterConfigurationOverride' -Category InvalidArgument -TargetObject $Container
+    }
+
+    $resolvedContainerPath = Resolve-NovaPesterOverridePath -Path $containerPath -ProjectRoot $ProjectRoot
+    if ($ResolvedRunPath -notcontains $resolvedContainerPath) {
+        Stop-NovaOperation -Message "Invoke-NovaTest only accepts PesterConfigurationOverride.Run.Container entries for unit-test files discovered by Nova. Unsupported container path: $resolvedContainerPath" -ErrorId 'Nova.Validation.UnsupportedPesterConfigurationOverride' -Category InvalidArgument -TargetObject $resolvedContainerPath
+    }
+
+    return $resolvedContainerPath
+}
+
+function Get-NovaResolvedPesterOverridePathSet {
+    [CmdletBinding()]
+    param(
+        [AllowEmptyCollection()][string[]]$Path,
+        [string]$ProjectRoot
+    )
+
+    $resolvedPath = New-Object 'System.Collections.Generic.List[string]'
+    foreach ($item in @($Path | Where-Object {-not [string]::IsNullOrWhiteSpace([string]$_)})) {
+        $resolvedItem = Resolve-NovaPesterOverridePath -Path $item -ProjectRoot $ProjectRoot
+        if (-not $resolvedPath.Contains($resolvedItem)) {
+            $resolvedPath.Add($resolvedItem)
+        }
+    }
+
+    return @($resolvedPath | Sort-Object)
+}
+
+function Get-NovaPesterOverridePathInput {
+    [CmdletBinding()]
+    param(
+        [AllowNull()][object]$Path
+    )
+
+    $pathValue = Get-NovaPesterOverrideValue -InputObject $Path -Name 'Value'
+    if ($null -ne $pathValue) {
+        return @($pathValue)
+    }
+
+    return @($Path)
+}
+
+function Resolve-NovaPesterOverridePath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [string]$ProjectRoot
+    )
+
+    $candidatePath = $Path
+    if (-not [System.IO.Path]::IsPathRooted($candidatePath) -and -not [string]::IsNullOrWhiteSpace($ProjectRoot)) {
+        $candidatePath = Join-Path $ProjectRoot $candidatePath
+    }
+
+    if (-not (Test-Path -LiteralPath $candidatePath -PathType Leaf)) {
+        Stop-NovaOperation -Message "PesterConfigurationOverride.Run.Container path does not exist: $candidatePath" -ErrorId 'Nova.Validation.UnsupportedPesterConfigurationOverride' -Category InvalidArgument -TargetObject $candidatePath
+    }
+
+    return (Resolve-Path -LiteralPath $candidatePath -ErrorAction Stop).Path
+}
+
+function Get-NovaPesterOverridePropertyName {
+    [CmdletBinding()]
+    param(
+        [AllowNull()][object]$InputObject
+    )
+
+    if ($null -eq $InputObject) {
+        return @()
+    }
+
+    if ($InputObject -is [System.Collections.IDictionary]) {
+        return @($InputObject.Keys)
+    }
+
+    return @($InputObject.PSObject.Properties.Name)
+}
+
+function Get-NovaPesterOverrideValue {
+    [CmdletBinding()]
+    param(
+        [AllowNull()][object]$InputObject,
+        [Parameter(Mandatory)][string]$Name
+    )
+
+    if ($null -eq $InputObject) {
+        return $null
+    }
+
+    if ($InputObject -is [System.Collections.IDictionary]) {
+        if ($InputObject.Contains($Name)) {
+            return $InputObject[$Name]
+        }
+
+        return $null
+    }
+
+    if ($InputObject.PSObject.Properties.Name -contains $Name) {
+        return $InputObject.$Name
+    }
+
+    return $null
 }

--- a/src/public/InvokeNovaTest.ps1
+++ b/src/public/InvokeNovaTest.ps1
@@ -10,16 +10,27 @@ function Invoke-NovaTest {
     )
 
     dynamicparam {
-        return Get-NovaDynamicOverrideWarningParameterDictionary
+        $dictionary = Get-NovaDynamicOverrideWarningParameterDictionary
+        $attributeCollection = [System.Collections.ObjectModel.Collection[System.Attribute]]::new()
+        $attributeCollection.Add([System.Management.Automation.ParameterAttribute]::new())
+        $runtimeParameter = [System.Management.Automation.RuntimeDefinedParameter]::new('PesterConfigurationOverride', [hashtable], $attributeCollection)
+        $dictionary.Add('PesterConfigurationOverride', $runtimeParameter)
+        return $dictionary
     }
 
     end {
+        $pesterConfigurationOverride = $null
+        if ($PSBoundParameters.ContainsKey('PesterConfigurationOverride')) {
+            $pesterConfigurationOverride = [hashtable]$PSBoundParameters.PesterConfigurationOverride
+        }
+
         $workflowContext = Get-NovaTestWorkflowContext -TestOption @{
             TestMode = 'Unit'
             TagFilter = $TagFilter
             ExcludeTagFilter = $ExcludeTagFilter
             OutputVerbosity = $OutputVerbosity
             OutputRenderMode = $OutputRenderMode
+            PesterConfigurationOverride = $pesterConfigurationOverride
         } -BoundParameters $PSBoundParameters
 
         $shouldRun = $PSCmdlet.ShouldProcess($workflowContext.Target, $workflowContext.Operation)

--- a/tests/private/quality/GetNovaTestWorkflowContext.TestSupport.ps1
+++ b/tests/private/quality/GetNovaTestWorkflowContext.TestSupport.ps1
@@ -23,7 +23,15 @@ function Get-NovaPesterTestResultPath {
 
     return (Join-Path $ProjectRoot $FileName)
 }
-function Initialize-NovaPesterExecutionConfiguration {param($PesterConfig, $BoundParameters, $OutputVerbosity, $OutputRenderMode)}
+function Initialize-NovaPesterExecutionConfiguration {
+    param($PesterConfig, $BoundParameters, $ExecutionOption)
+
+    $script:lastExecutionConfigurationRequest = [pscustomobject]@{
+        PesterConfig = $PesterConfig
+        BoundParameters = $BoundParameters
+        ExecutionOption = $ExecutionOption
+    }
+}
 function Get-NovaShouldProcessForwardingParameter {param([switch]$WhatIfEnabled) return @{}}
 function Write-NovaPesterTestResultArtifact {}
 function Write-NovaPesterTestResultReport {}

--- a/tests/private/quality/GetNovaTestWorkflowContext.Tests.ps1
+++ b/tests/private/quality/GetNovaTestWorkflowContext.Tests.ps1
@@ -9,6 +9,7 @@ Describe 'Get-NovaTestWorkflowContext' {
     BeforeEach {
         $script:lastRunPathRequest = $null
         $script:lastResultPathRequest = $null
+        $script:lastExecutionConfigurationRequest = $null
 
         Mock Test-ProjectSchema {}
         Mock Get-Module {[pscustomobject]@{Name = 'Pester'}} -ParameterFilter {$Name -eq 'Pester' -and $ListAvailable}
@@ -103,6 +104,42 @@ Describe 'Get-NovaTestWorkflowContext' {
             'src/private/quality/GetGamma.ps1'
             'src/classes/NovaThing.ps1'
         )
+    }
+
+    It 'forwards the guarded Pester configuration override to the execution configuration initializer' {
+        $pesterConfig = & $script:getPesterConfig
+        $projectInfo = & $script:getProjectInfo -PesterSettings ([ordered]@{})
+        $containerOverride = [pscustomobject]@{
+            Type = 'File'
+            Item = (Join-Path $projectInfo.ProjectRoot 'tests/Example.Tests.ps1')
+            Data = @{ Credential = 'placeholder' }
+        }
+        $override = @{
+            Run = @{
+                Container = @($containerOverride)
+            }
+        }
+
+        Mock Get-NovaProjectInfo {$projectInfo}
+        Mock New-PesterConfiguration {$pesterConfig}
+
+        $null = Get-NovaTestWorkflowContext -TestOption @{
+            TestMode = 'Unit'
+            OutputVerbosity = 'Diagnostic'
+            OutputRenderMode = 'Ansi'
+            PesterConfigurationOverride = $override
+        } -BoundParameters @{}
+
+        $script:lastExecutionConfigurationRequest.ExecutionOption.Keys | Sort-Object | Should -Be @(
+            'OutputRenderMode'
+            'OutputVerbosity'
+            'PesterConfigurationOverride'
+            'ProjectRoot'
+        )
+        $script:lastExecutionConfigurationRequest.ExecutionOption.ProjectRoot | Should -Be $projectInfo.ProjectRoot
+        $script:lastExecutionConfigurationRequest.ExecutionOption.OutputVerbosity | Should -Be 'Diagnostic'
+        $script:lastExecutionConfigurationRequest.ExecutionOption.OutputRenderMode | Should -Be 'Ansi'
+        $script:lastExecutionConfigurationRequest.ExecutionOption.PesterConfigurationOverride | Should -Be $override
     }
 }
 

--- a/tests/private/quality/InitializeNovaPesterExecutionConfiguration.Tests.ps1
+++ b/tests/private/quality/InitializeNovaPesterExecutionConfiguration.Tests.ps1
@@ -4,13 +4,79 @@ BeforeAll {
     . (Join-Path $projectRoot 'src/private/quality/InitializeNovaPesterExecutionConfiguration.ps1')
 }
 
+function script:Stop-NovaOperation {
+    param($Message, $ErrorId, $Category, $TargetObject)
+
+    throw $Message
+}
+
+function script:New-NovaPesterExecutionConfigurationScenario {
+    param(
+        [string]$ProjectName = 'project',
+        [string[]]$TestFileName = @('Alpha.Tests.ps1')
+    )
+
+    $projectPath = Join-Path $TestDrive $ProjectName
+    $testPath = foreach ($name in $TestFileName) {
+        $path = Join-Path $projectPath (Join-Path 'tests' $name)
+        New-Item -ItemType Directory -Path (Split-Path -Parent $path) -Force | Out-Null
+        Set-Content -LiteralPath $path -Value "# $name"
+        $path
+    }
+
+    $config = New-PesterConfiguration
+    $config.Run.Path = @($testPath)
+
+    return [pscustomobject]@{
+        ProjectPath = $projectPath
+        TestPath = @($testPath)
+        Config = $config
+    }
+}
+
+function script:New-NovaPesterExecutionConfigurationExecutionOption {
+    param(
+        [Parameter(Mandatory)][string]$ProjectPath,
+        [Parameter(Mandatory)][object[]]$Container
+    )
+
+    return @{
+        PesterConfigurationOverride = @{
+            Run = @{
+                Container = @($Container)
+            }
+        }
+        ProjectRoot = $ProjectPath
+    }
+}
+
+function script:Assert-NovaPesterExecutionConfigurationOverrideFailure {
+    param(
+        [Parameter(Mandatory)][object]$Config,
+        [Parameter(Mandatory)][string]$ProjectPath,
+        [Parameter(Mandatory)][object]$Override,
+        [Parameter(Mandatory)][string]$ExpectedMessage
+    )
+
+    {
+        Initialize-NovaPesterExecutionConfiguration -PesterConfig $Config -BoundParameters @{} -ExecutionOption @{
+            PesterConfigurationOverride = $Override
+            ProjectRoot = $ProjectPath
+        }
+    } | Should -Throw $ExpectedMessage
+}
+
 Describe 'Initialize-NovaPesterExecutionConfiguration' {
     It 'applies bound Verbosity/RenderMode and disables TestResult' {
         $config = [pscustomobject]@{
+            Run = [pscustomobject]@{Path=@(); Container=@()}
             Output = [pscustomobject]@{Verbosity='Default'; RenderMode='Default'}
             TestResult = [pscustomobject]@{Enabled=$true}
         }
-        Initialize-NovaPesterExecutionConfiguration -PesterConfig $config -BoundParameters @{OutputVerbosity='Detailed'; OutputRenderMode='Plaintext'} -OutputVerbosity 'Detailed' -OutputRenderMode 'Plaintext'
+        Initialize-NovaPesterExecutionConfiguration -PesterConfig $config -BoundParameters @{OutputVerbosity='Detailed'; OutputRenderMode='Plaintext'} -ExecutionOption @{
+            OutputVerbosity = 'Detailed'
+            OutputRenderMode = 'Plaintext'
+        }
         $config.Output.Verbosity | Should -Be 'Detailed'
         $config.Output.RenderMode | Should -Be 'Plaintext'
         $config.TestResult.Enabled | Should -BeFalse
@@ -18,10 +84,11 @@ Describe 'Initialize-NovaPesterExecutionConfiguration' {
 
     It 'leaves Output untouched when nothing is bound' {
         $config = [pscustomobject]@{
+            Run = [pscustomobject]@{Path=@(); Container=@()}
             Output = [pscustomobject]@{Verbosity='Default'; RenderMode='Default'}
             TestResult = [pscustomobject]@{Enabled=$true}
         }
-        Initialize-NovaPesterExecutionConfiguration -PesterConfig $config -BoundParameters @{}
+        Initialize-NovaPesterExecutionConfiguration -PesterConfig $config -BoundParameters @{} -ExecutionOption @{}
         $config.Output.Verbosity | Should -Be 'Default'
         $config.Output.RenderMode | Should -Be 'Default'
         $config.TestResult.Enabled | Should -BeFalse
@@ -29,9 +96,168 @@ Describe 'Initialize-NovaPesterExecutionConfiguration' {
 
     It 'does not touch TestResult when it has no Enabled property' {
         $config = [pscustomobject]@{
+            Run = [pscustomobject]@{Path=@(); Container=@()}
             Output = [pscustomobject]@{Verbosity='Default'; RenderMode='Default'}
             TestResult = [pscustomobject]@{Other='x'}
         }
-        { Initialize-NovaPesterExecutionConfiguration -PesterConfig $config -BoundParameters @{} } | Should -Not -Throw
+        { Initialize-NovaPesterExecutionConfiguration -PesterConfig $config -BoundParameters @{} -ExecutionOption @{} } | Should -Not -Throw
+    }
+
+    It 'converts Nova-owned run paths to container runs and overlays the approved container override' {
+        $scenario = New-NovaPesterExecutionConfigurationScenario -TestFileName @('Alpha.Tests.ps1', 'Beta.Tests.ps1')
+        $testPathA = $scenario.TestPath[0]
+        $testPathB = $scenario.TestPath[1]
+        $providedContainer = New-PesterContainer -Path $testPathA -Data @{ Credential = 'placeholder' }
+
+        Initialize-NovaPesterExecutionConfiguration -PesterConfig $scenario.Config -BoundParameters @{} -ExecutionOption (New-NovaPesterExecutionConfigurationExecutionOption -ProjectPath $scenario.ProjectPath -Container $providedContainer)
+
+        $scenario.Config.Run.Path.Value | Should -BeNullOrEmpty
+        $scenario.Config.Run.Container.Value | Should -HaveCount 2
+        $scenario.Config.Run.Container.Value[0] | Should -Be $providedContainer
+        $scenario.Config.Run.Container.Value[1].Item | Should -Be $testPathB
+        $scenario.Config.Run.Container.Value[1].Data.Count | Should -Be 0
+    }
+
+    It 'fails fast when a disallowed override path is provided' {
+        $config = [pscustomobject]@{
+            Run = [pscustomobject]@{Path=@(); Container=@()}
+            Output = [pscustomobject]@{Verbosity='Default'; RenderMode='Default'}
+            TestResult = [pscustomobject]@{Enabled=$true}
+        }
+
+        {
+            Initialize-NovaPesterExecutionConfiguration -PesterConfig $config -BoundParameters @{} -ExecutionOption @{
+                PesterConfigurationOverride = @{
+                    Output = @{
+                        Verbosity = 'Diagnostic'
+                    }
+                }
+            }
+        } | Should -Throw '*Unsupported override path: Output*'
+    }
+
+    It 'fails fast when <Name>' -TestCases @(
+        @{
+            Name = 'Run does not provide any containers'
+            Override = @{
+                Run = @{}
+            }
+            ExpectedMessage = '*Provide one or more file-backed containers*'
+        }
+        @{
+            Name = 'Run.Container is empty'
+            Override = @{
+                Run = @{
+                    Container = @()
+                }
+            }
+            ExpectedMessage = '*Provide one or more file-backed containers*'
+        }
+        @{
+            Name = 'a file-backed container does not expose an Item path'
+            Override = @{
+                Run = [pscustomobject]@{
+                    Container = @(
+                        [pscustomobject]@{
+                            Type = 'File'
+                            Data = $null
+                        }
+                    )
+                }
+            }
+            ExpectedMessage = '*must expose a file path in the Item property*'
+        }
+        @{
+            Name = 'a relative container path does not exist'
+            Override = @{
+                Run = @{
+                    Container = @(
+                        [pscustomobject]@{
+                            Type = 'File'
+                            Item = 'tests/Missing.Tests.ps1'
+                            Data = $null
+                        }
+                    )
+                }
+            }
+            ExpectedMessage = '*path does not exist*'
+        }
+    ) {
+        param($Override, $ExpectedMessage)
+
+        $scenario = New-NovaPesterExecutionConfigurationScenario
+        Assert-NovaPesterExecutionConfigurationOverrideFailure -Config $scenario.Config -ProjectPath $scenario.ProjectPath -Override $Override -ExpectedMessage $ExpectedMessage
+    }
+
+    It 'resolves relative container paths against ProjectRoot' {
+        $scenario = New-NovaPesterExecutionConfigurationScenario
+        $relativePath = [System.IO.Path]::GetRelativePath($scenario.ProjectPath, $scenario.TestPath[0])
+        $providedContainer = New-PesterContainer -Path $scenario.TestPath[0]
+        $providedContainer.Item = $relativePath
+
+        Initialize-NovaPesterExecutionConfiguration -PesterConfig $scenario.Config -BoundParameters @{} -ExecutionOption (
+            New-NovaPesterExecutionConfigurationExecutionOption -ProjectPath $scenario.ProjectPath -Container $providedContainer
+        )
+
+        $scenario.Config.Run.Container.Value | Should -HaveCount 1
+        $scenario.Config.Run.Container.Value[0] | Should -Be $providedContainer
+    }
+
+    It 'fails fast when a container points outside the Nova-discovered unit-test set' {
+        $projectPath = Join-Path $TestDrive 'project'
+        $testPath = Join-Path $projectPath 'tests/Alpha.Tests.ps1'
+        $otherPath = Join-Path $projectPath 'tests/Other.Tests.ps1'
+        New-Item -ItemType Directory -Path (Split-Path -Parent $testPath) -Force | Out-Null
+        Set-Content -LiteralPath $testPath -Value '# alpha'
+        Set-Content -LiteralPath $otherPath -Value '# other'
+
+        $config = [pscustomobject]@{
+            Run = [pscustomobject]@{
+                Path = @($testPath)
+                Container = @()
+            }
+            Output = [pscustomobject]@{Verbosity='Default'; RenderMode='Default'}
+            TestResult = [pscustomobject]@{Enabled=$true}
+        }
+
+        {
+            Initialize-NovaPesterExecutionConfiguration -PesterConfig $config -BoundParameters @{} -ExecutionOption @{
+                PesterConfigurationOverride = @{
+                    Run = @{
+                        Container = @(
+                            [pscustomobject]@{
+                                Type = 'File'
+                                Item = $otherPath
+                                Data = @{}
+                            }
+                        )
+                    }
+                }
+                ProjectRoot = $projectPath
+            }
+        } | Should -Throw '*Unsupported container path*'
+    }
+
+    It 'fails fast when the override contains duplicate containers for the same resolved test path' {
+        $scenario = New-NovaPesterExecutionConfigurationScenario
+
+        {
+            Initialize-NovaPesterExecutionConfiguration -PesterConfig $scenario.Config -BoundParameters @{} -ExecutionOption (
+                New-NovaPesterExecutionConfigurationExecutionOption -ProjectPath $scenario.ProjectPath -Container @(
+                    (New-PesterContainer -Path $scenario.TestPath[0] -Data @{ Name = 'first' })
+                    (New-PesterContainer -Path $scenario.TestPath[0] -Data @{ Name = 'second' })
+                )
+            )
+        } | Should -Throw '*multiple containers for the same test path*'
+    }
+
+    It 'fails fast when the override contains a non-file container type' {
+        $scenario = New-NovaPesterExecutionConfigurationScenario
+
+        {
+            Initialize-NovaPesterExecutionConfiguration -PesterConfig $scenario.Config -BoundParameters @{} -ExecutionOption (
+                New-NovaPesterExecutionConfigurationExecutionOption -ProjectPath $scenario.ProjectPath -Container (New-PesterContainer -ScriptBlock {})
+            )
+        } | Should -Throw '*ScriptBlock and other container types are not supported*'
     }
 }

--- a/tests/private/quality/InitializeNovaPesterExecutionConfiguration.Tests.ps1
+++ b/tests/private/quality/InitializeNovaPesterExecutionConfiguration.Tests.ps1
@@ -260,4 +260,12 @@ Describe 'Initialize-NovaPesterExecutionConfiguration' {
             )
         } | Should -Throw '*ScriptBlock and other container types are not supported*'
     }
+
+    It 'returns empty metadata when override helper inputs are null' {
+        $propertyNames = Get-NovaPesterOverridePropertyName -InputObject $null
+        $value = Get-NovaPesterOverrideValue -InputObject $null -Name 'Container'
+
+        $propertyNames | Should -HaveCount 0
+        $value | Should -BeNullOrEmpty
+    }
 }

--- a/tests/public/InvokeNovaTest.Integration.Tests.ps1
+++ b/tests/public/InvokeNovaTest.Integration.Tests.ps1
@@ -12,4 +12,42 @@ Describe 'Invoke-NovaTest integration' {
             }
         } | Should -Not -Throw
     }
+
+    It 'supports a guarded Run.Container override from the built module' {
+        {
+            Invoke-NovaPublicCommandIntegrationInProjectRoot -ProjectRoot $script:projectRoot -ScriptBlock {
+                $container = New-PesterContainer -Path 'tests/public/InvokeNovaTest.Tests.ps1' -Data @{ Name = 'runtime-value' }
+                Invoke-NovaTest -WhatIf -PesterConfigurationOverride @{
+                    Run = @{
+                        Container = @($container)
+                    }
+                }
+            }
+        } | Should -Not -Throw
+    }
+
+    It 'rejects non-file Run.Container overrides from the built module' {
+        {
+            Invoke-NovaPublicCommandIntegrationInProjectRoot -ProjectRoot $script:projectRoot -ScriptBlock {
+                $container = New-PesterContainer -ScriptBlock {}
+                Invoke-NovaTest -WhatIf -PesterConfigurationOverride @{
+                    Run = @{
+                        Container = @($container)
+                    }
+                }
+            }
+        } | Should -Throw '*ScriptBlock and other container types are not supported*'
+    }
+
+    It 'rejects unsupported override shapes from the built module' {
+        {
+            Invoke-NovaPublicCommandIntegrationInProjectRoot -ProjectRoot $script:projectRoot -ScriptBlock {
+                Invoke-NovaTest -WhatIf -PesterConfigurationOverride @{
+                    Run = @{
+                        Path = @('tests/public/InvokeNovaTest.Tests.ps1')
+                    }
+                }
+            }
+        } | Should -Throw '*Unsupported override path: Run.Path*'
+    }
 }

--- a/tests/public/InvokeNovaTest.Tests.ps1
+++ b/tests/public/InvokeNovaTest.Tests.ps1
@@ -34,12 +34,25 @@ Describe 'Invoke-NovaTest' {
     }
 
     It 'forwards unit-test options to the workflow context' {
-        Invoke-NovaTest -OverrideWarning -TagFilter 'fast' -ExcludeTagFilter 'integration' -OutputVerbosity 'Detailed'
+        $override = @{
+            Run = @{
+                Container = @(
+                    [pscustomobject]@{
+                        Type = 'File'
+                        Item = '/proj/tests/Example.Tests.ps1'
+                        Data = @{ Credential = 'placeholder' }
+                    }
+                )
+            }
+        }
+
+        Invoke-NovaTest -OverrideWarning -TagFilter 'fast' -ExcludeTagFilter 'integration' -OutputVerbosity 'Detailed' -PesterConfigurationOverride $override
 
         $script:testOption.TestMode | Should -Be 'Unit'
         $script:testOption.TagFilter | Should -Be @('fast')
         $script:testOption.ExcludeTagFilter | Should -Be @('integration')
         $script:testOption.OutputVerbosity | Should -Be 'Detailed'
+        $script:testOption.PesterConfigurationOverride | Should -Be $override
         $script:boundParameters.OverrideWarning | Should -BeTrue
         $script:shouldRun | Should -BeTrue
     }


### PR DESCRIPTION
## Summary
 
 - Added guarded `Invoke-NovaTest -PesterConfigurationOverride` support for runtime-only unit-test data injection through `Run.Container`, wired through the unit-test workflow context and execution configuration; docs, help, release notes, and tests were updated, and `Invoke-NovaTest` help `RELATED LINKS` now use valid bulleted relative links.
 - This was needed to let unit tests receive runtime-only values such as `PSCredential` without committing secrets into mirrored `*.Tests.ps1` files and without turning Nova's managed unit-test flow into arbitrary Pester passthrough; Nova still owns discovery, coverage, result files, and required execution flags.
 - Related to #249.
 - Release impact: this branch targets `develop` on `3.1.1-preview02`, so the immediate effect is prerelease-only; stable behavior is unchanged until the change is promoted to a future `main`-based stable release. No publish, tag, or push actions were performed.
 
 ## Affected area
 
 - [ ] `nova` CLI or command routing
 - [x] Public PowerShell cmdlet behavior
 - [ ] Scaffolding or `project.json` handling
 - [x] Build, test, analyzer, coverage, or CI helper flow
 - [ ] Package, raw upload, or package metadata workflow
 - [ ] Publish, release, or GitHub Actions automation
 - [ ] Self-update or notification preference behavior
 - [x] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
 - [x] End-user docs (`docs/*.html`)
 - [x] Command help (`docs/NovaModuleTools/en-US/*.md`)
 - [ ] `src/resources/example/`
 - [ ] Dependency or manifest changes (`project.json`, workflow dependencies, release tooling)
 - [ ] Security-sensitive change
 - [ ] Documentation-only change
 - [ ] Agentic Copilot Workflow + scaffold mirror + scaffold-sync guardrail test.
 - [ ] Other
 
 ## Review guidance
 
 - Start with `src/public/InvokeNovaTest.ps1`, then `src/private/quality/GetNovaTestWorkflowContext.ps1`, then `src/private/quality/InitializeNovaPesterExecutionConfiguration.ps1`.
 - Primary files changed: `src/public/`, `src/private/quality/`, `tests/private/quality/`, `tests/public/`, `docs/NovaModuleTools/en-US/Invoke-NovaTest.md`, `docs/commands.html`, `docs/core-workflows.html`, `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, and `RELEASE_NOTE.md`.
 - Main trade-off/limit: v1 accepts only file-backed `Run.Container` overrides for unit-test files Nova already discovered; unsupported override shapes and non-file containers fail fast by design.
 
 ## Validation
 
 - [x] `Invoke-NovaBuild`
 - [x] `Invoke-NovaTest`
 - [x] `Test-NovaBuild`
 - [ ] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
 - [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
 - [ ] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`, `% nova publish`, `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
 - [ ] Docs/example only; executable validation not needed
 
 Validation notes:
 
 ```text
 Passed:
 - Invoke-NovaTest
 - Test-NovaBuild
 - pwsh -NoLogo -NoProfile -File ./run.ps1
 - Test-MarkdownCommandHelp -Path ./docs/NovaModuleTools/en-US/Invoke-NovaTest.md -DetailView
 - CodeScene pre-commit safeguard
 
 run.ps1 includes the repository-local build/test quality loop, so this branch was exercised through the normal local wrapper rather than through the standalone CI helper scripts.
 
 No publish, tag, or push actions were performed.
 ```
 
 ## Documentation and release follow-up
 
 - [x] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
 - [x] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
 - [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
 - [x] `RELEASE_NOTE.md` reviewed and updated if the change affects public cmdlet usage, CLI usage, configuration semantics, or migration expectations
 - [x] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
 - [x] `docs/*.html` updated if end-user workflows or examples changed
 - [ ] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow changed
 - [ ] No documentation, changelog, release-note, or example updates were needed
 
 ## Maintainability, compatibility, and risk
 
 - [x] Code Health / maintainability impact considered
 - [x] No breaking change
 - [ ] Breaking change
 - [ ] Security-sensitive change
 - [x] CI, workflow, or release-pipeline impact
 - [ ] Dependency-review impact
 
 Risk, rollout, or rollback notes:
 
 ```text
 Immediate release impact is prerelease-only because develop is on 3.1.1-preview02 and Publish.yml uses develop for prerelease publication while stable releases come from main. Stable users are unaffected until a later stable promotion.
 
 Risk is contained to Invoke-NovaTest. The new hook is intentionally narrow: only Run.Container is accepted, containers must be file-backed, and paths must match Nova-discovered unit tests. Existing Invoke-NovaTest behavior is unchanged when the new parameter is not used.
 
 Rollback is straightforward: remove the guarded override path and matching docs/tests if needed.
 ```
 
 > [!IMPORTANT]
 > Do not use a public pull request to disclose a vulnerability before coordinated handling.
 > Use the private reporting path in `SECURITY.md` for new security issues.
