### PR TITLE
feat(#255): Improve Test-NovaBuild error handling and add build-valida…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
+- `Test-NovaBuild` and `% nova test -b` now stop with a Nova-native error when a project has no `*.Integration.Tests.ps1` files, instead of leaking the raw async Pester exception.
+    - The new guidance explains where build-validation tests belong and reminds users to keep unit tests in `Invoke-NovaTest`.
+- The packaged example scaffold now includes a minimal `*.Integration.Tests.ps1` file that imports the built module and validates `Get-ExampleGreeting`, so `nova init -e` projects can pass `Test-NovaBuild`.
+
 ### Security
 
 ## [3.2.0] - 2026-05-31
@@ -510,4 +514,3 @@ This release was yanked because it removed the implicit `Pester` dependency, bef
 [0.0.6]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.5...Version_0.0.6
 [0.0.5]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.4...Version_0.0.5
 [0.0.4]: https://github.com/stiwicourage/NovaModuleTools/compare/Version_0.0.3...Version_0.0.4
-

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -14,6 +14,9 @@ This file summarizes the release notes for NovaModuleTools. **UNRELEASED** chang
 
 ### Fixed
 
+- `Test-NovaBuild` and `% nova test -b` now stop with a clear Nova-native error when a project has no `*.Integration.Tests.ps1` files, and the message now explains where build-validation tests belong plus when to use `Invoke-NovaTest` instead.
+- The packaged example scaffold now includes a minimal build-validation integration test that imports the built module and checks `Get-ExampleGreeting`, so `nova init -e` projects can pass `Test-NovaBuild`.
+
 ### Security
 
 ## [3.2.0] - 2026-05-31
@@ -259,4 +262,3 @@ This release was yanked because it removed the implicit `Pester` dependency befo
 ## [0.0.4] - 2024-06-25
 ### Added
 - First PowerShell Gallery release of NovaModuleTools with the initial module workflow support.
-

--- a/docs/NovaModuleTools/en-US/Test-NovaBuild.md
+++ b/docs/NovaModuleTools/en-US/Test-NovaBuild.md
@@ -35,6 +35,8 @@ This build-validation flow writes NUnit XML to `artifacts/TestResults.xml`.
 
 Unlike `Invoke-NovaTest`, this command does not enforce source-coverage targets. Use `Invoke-NovaTest` for the unit-test and code-coverage workflow, and use `Test-NovaBuild` when you need build-validation integration coverage that reflects the built module path.
 
+If the current project does not contain any `*.Integration.Tests.ps1` files, `Test-NovaBuild` stops with a Nova-native error that explains the expected naming and reminds you to use `Invoke-NovaTest` for unit tests.
+
 `-OverrideWarning` lets the nested build-validation flow continue even if the `src/public` layout guard reports zero or multiple top-level functions in a public file.
 
 With the default `BuildRecursiveFolders=true`, integration test files in nested folders under `tests` are discovered and run. Set `BuildRecursiveFolders=false` to limit discovery to top-level matching test files.

--- a/src/private/quality/GetNovaTestWorkflowContext.ps1
+++ b/src/private/quality/GetNovaTestWorkflowContext.ps1
@@ -39,9 +39,11 @@ function Get-NovaTestWorkflowContext {
         $pesterConfig.CodeCoverage.CoveragePercentTarget = $coverageConfiguration.CoveragePercentTarget
     }
 
-    $pesterConfig.Run.Path = @(
+    $runPath = @(
         Get-NovaPesterRunPath -ProjectInfo $projectInfo -IncludePattern $workflowProfile.IncludePattern -ExcludePattern $workflowProfile.ExcludePattern
     )
+    Assert-NovaDiscoveredTestPath -RunPath $runPath -ProjectInfo $projectInfo -WorkflowProfile $workflowProfile
+    $pesterConfig.Run.Path = $runPath
     $pesterConfig.Run.PassThru = $true
     $pesterConfig.Run.Exit = $true
     $pesterConfig.Run.Throw = $true
@@ -70,6 +72,29 @@ function Get-NovaTestWorkflowContext {
         Target = $testResultPath
         Operation = Get-NovaTestWorkflowOperation -TestMode $workflowProfile.Mode
     }
+}
+
+function Assert-NovaDiscoveredTestPath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][string[]]$RunPath,
+        [Parameter(Mandatory)][pscustomobject]$ProjectInfo,
+        [Parameter(Mandatory)][pscustomobject]$WorkflowProfile
+    )
+
+    if ($WorkflowProfile.Mode -ne 'BuildValidation' -or $RunPath.Count -gt 0) {
+        return
+    }
+
+    $expectedPath = Join-Path $ProjectInfo.TestsDir 'public/Get-CommandName.Integration.Tests.ps1'
+    $message = @(
+        "The current project does not contain any build-validation integration tests matching '$($WorkflowProfile.IncludePattern)'."
+        'Test-NovaBuild expects build-validation tests under the tests folder, for example tests/public/Get-CommandName.Integration.Tests.ps1.'
+        'Add at least one *.Integration.Tests.ps1 file, then rerun Test-NovaBuild.'
+        'Use Invoke-NovaTest for unit tests and Test-NovaBuild for build-validation integration tests.'
+    ) -join ' '
+
+    Stop-NovaOperation -Message $message -ErrorId 'Nova.Workflow.BuildValidationTestsMissing' -Category ObjectNotFound -TargetObject $expectedPath
 }
 
 function Get-NovaTestOptionValue {

--- a/src/resources/example/README.md
+++ b/src/resources/example/README.md
@@ -23,6 +23,7 @@ It is meant to help a new user understand the smallest useful setup that can:
 - `src/private/Get-ExampleConfiguration.ps1` – a private helper used by the public function
 - `src/resources/greeting-config.json` – a resource file bundled into the built module
 - `tests/public/Get-ExampleGreeting.Tests.ps1` – source-mirrored tests for the public function
+- `tests/public/Get-ExampleGreeting.Integration.Tests.ps1` – build-validation coverage that imports the built module and exercises the public command
 - `tests/private/Get-ExampleConfiguration.Tests.ps1` – source-mirrored tests for the private helper and resource resolution
 
 ## Quick start
@@ -36,6 +37,7 @@ If `./dist/NovaModuleTools` is not available yet, build `NovaModuleTools` from t
 ```text
 PS> Import-Module ./dist/NovaModuleTools -Force
 PS> Set-Location ./src/resources/example
+PS> Invoke-NovaTest
 PS> Test-NovaBuild
 PS> Invoke-NovaBuild
 PS> New-NovaModulePackage
@@ -52,6 +54,7 @@ PS> Install-Module NovaModuleTools
 PS> Import-Module NovaModuleTools
 PS> $module = Get-Module NovaModuleTools -ListAvailable | Select-Object -First 1
 PS> Set-Location (Join-Path $module.ModuleBase 'resources/example')
+PS> Invoke-NovaTest
 PS> Test-NovaBuild
 PS> Invoke-NovaBuild
 PS> New-NovaModulePackage
@@ -62,10 +65,16 @@ PS> Get-ExampleGreeting
 
 ## Expected result
 
-After `Test-NovaBuild`, the example tests run against `src/**/*.ps1` and JaCoCo coverage is written to:
+After `Invoke-NovaTest`, the example source-mirrored tests run against `src/**/*.ps1` and JaCoCo coverage is written to:
 
 ```text
 src/resources/example/artifacts/coverage.xml
+```
+
+After `Test-NovaBuild`, the example build-validation test imports the built module from:
+
+```text
+src/resources/example/dist/NovaExampleModule
 ```
 
 After `Invoke-NovaBuild`, the built module is written to:
@@ -120,6 +129,7 @@ This example is intentionally small, but it demonstrates the most important Nova
 - how public and private functions are combined into one module
 - how resource files are copied and used at runtime
 - how tests can run against source files before a build while still producing coverage
+- how build-validation tests can import the built module and check the public command surface
 - where the current package, packaging, and raw-upload configuration keys live in `project.json`
 
 If you want a new project scaffold, use `PS> Initialize-NovaModule` (`% nova init`). If you want a concrete project you can inspect, run, or copy through `% nova init --example` / `% nova init -e`, use this example folder.

--- a/src/resources/example/tests/public/Get-ExampleGreeting.Integration.Tests.ps1
+++ b/src/resources/example/tests/public/Get-ExampleGreeting.Integration.Tests.ps1
@@ -1,0 +1,13 @@
+BeforeAll {
+    $projectRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+    $moduleManifestPath = Join-Path $projectRoot 'dist/NovaExampleModule/NovaExampleModule.psd1'
+
+    Import-Module $moduleManifestPath -Force
+}
+
+Describe 'Get-ExampleGreeting integration' {
+    It 'imports the built module and returns the public greeting' {
+        (Get-Command -Name 'Get-ExampleGreeting' -Module 'NovaExampleModule') | Should -Not -BeNullOrEmpty
+        Get-ExampleGreeting -Name 'Build validation' | Should -Be 'Hello, Build validation!'
+    }
+}

--- a/tests/private/quality/GetNovaTestWorkflowContext.Tests.ps1
+++ b/tests/private/quality/GetNovaTestWorkflowContext.Tests.ps1
@@ -66,6 +66,19 @@ Describe 'Get-NovaTestWorkflowContext' {
         $result.Operation | Should -Be 'Build project, run build-validation integration tests, and write test results'
     }
 
+    It 'stops with an actionable error when build-validation tests are missing' {
+        $pesterConfig = & $script:getPesterConfig
+        $projectInfo = & $script:getProjectInfo -PesterSettings ([ordered]@{})
+
+        Mock Get-NovaProjectInfo {$projectInfo}
+        Mock New-PesterConfiguration {$pesterConfig}
+        Mock Get-NovaPesterRunPath {@()}
+
+        {
+            Get-NovaTestWorkflowContext -TestOption @{TestMode = 'BuildValidation'} -BoundParameters @{}
+        } | Should -Throw '*does not contain any build-validation integration tests matching ''*.Integration.Tests.ps1''*Use Invoke-NovaTest for unit tests and Test-NovaBuild for build-validation integration tests.*'
+    }
+
     It 'expands configured coverage paths into concrete project-relative source files' {
         $projectRoot = Join-Path $TestDrive 'coverage-project'
         foreach ($relativePath in @(
@@ -150,6 +163,41 @@ Describe 'Get-NovaTestWorkflowOperation' {
 
     It 'returns the unit-test operation text' {
         Get-NovaTestWorkflowOperation -TestMode 'Unit' | Should -Be 'Run unit tests and write test results'
+    }
+}
+
+Describe 'Assert-NovaDiscoveredTestPath' {
+    It 'returns silently when build-validation tests are present' {
+        {
+            Assert-NovaDiscoveredTestPath -RunPath @('/tmp/project/tests/public/Get-Thing.Integration.Tests.ps1') -ProjectInfo ([pscustomobject]@{
+                    TestsDir = '/tmp/project/tests'
+                }) -WorkflowProfile ([pscustomobject]@{
+                    Mode = 'BuildValidation'
+                    IncludePattern = '*.Integration.Tests.ps1'
+                })
+        } | Should -Not -Throw
+    }
+
+    It 'returns silently for unit-test workflows when no tests are discovered' {
+        {
+            Assert-NovaDiscoveredTestPath -RunPath @() -ProjectInfo ([pscustomobject]@{
+                    TestsDir = '/tmp/project/tests'
+                }) -WorkflowProfile ([pscustomobject]@{
+                    Mode = 'Unit'
+                    IncludePattern = '*.Tests.ps1'
+                })
+        } | Should -Not -Throw
+    }
+
+    It 'stops with the Nova build-validation guidance when no integration tests are discovered' {
+        {
+            Assert-NovaDiscoveredTestPath -RunPath @() -ProjectInfo ([pscustomobject]@{
+                    TestsDir = '/tmp/project/tests'
+                }) -WorkflowProfile ([pscustomobject]@{
+                    Mode = 'BuildValidation'
+                    IncludePattern = '*.Integration.Tests.ps1'
+                })
+        } | Should -Throw '*tests/public/Get-CommandName.Integration.Tests.ps1*'
     }
 }
 

--- a/tests/private/scaffold/CopyNovaExampleProjectTemplate.Tests.ps1
+++ b/tests/private/scaffold/CopyNovaExampleProjectTemplate.Tests.ps1
@@ -43,6 +43,7 @@ Describe 'Copy-NovaExampleProjectTemplate' {
 
         $projectJson.Pester.CodeCoverage.Enabled | Should -BeTrue
         Test-Path -LiteralPath (Join-Path $destination 'tests/public/Get-ExampleGreeting.Tests.ps1') | Should -BeTrue
+        Test-Path -LiteralPath (Join-Path $destination 'tests/public/Get-ExampleGreeting.Integration.Tests.ps1') | Should -BeTrue
         Test-Path -LiteralPath (Join-Path $destination 'tests/private/Get-ExampleConfiguration.Tests.ps1') | Should -BeTrue
     }
 }

--- a/tests/public/TestNovaBuild.Integration.Tests.ps1
+++ b/tests/public/TestNovaBuild.Integration.Tests.ps1
@@ -12,4 +12,18 @@ Describe 'Test-NovaBuild integration' {
             }
         } | Should -Not -Throw
     }
+
+    It 'fails with actionable guidance when the current project has no build-validation tests' {
+        $exampleProjectRoot = Join-Path $script:projectRoot 'src/resources/example'
+        $scenarioRoot = Join-Path $TestDrive 'missing-build-validation-tests'
+        $null = New-Item -ItemType Directory -Path $scenarioRoot -Force
+        Copy-Item -Path (Join-Path $exampleProjectRoot '*') -Destination $scenarioRoot -Recurse -Force
+        Remove-Item -LiteralPath (Join-Path $scenarioRoot 'tests/public/Get-ExampleGreeting.Integration.Tests.ps1') -Force
+
+        {
+            Invoke-NovaPublicCommandIntegrationInLocation -Path $scenarioRoot -ScriptBlock {
+                Test-NovaBuild
+            }
+        } | Should -Throw '*does not contain any build-validation integration tests matching ''*.Integration.Tests.ps1''*Use Invoke-NovaTest for unit tests and Test-NovaBuild for build-validation integration tests.*'
+    }
 }


### PR DESCRIPTION
## Summary
 
 - `Test-NovaBuild` and `% nova test -b` now fail with a clear Nova-native error when a project has no `*.Integration.Tests.ps1` files, instead of leaking a raw async Pester exception.
 - The failure guidance now tells users where build-validation integration tests belong and reminds them to use `Invoke-NovaTest` for unit tests.
 - The packaged example scaffold now includes a minimal integration test that imports the built module and smoke-tests `Get-ExampleGreeting`, so `nova init -e` projects can pass build-validation out of the box.
 - Changelog, release notes, command help, and example documentation were updated for the unreleased `3.2.1-preview` line. Closes #255.
 
 ## Affected area
 
 - [ ] `nova` CLI or command routing
 - [x] Public PowerShell cmdlet behavior
 - [ ] Scaffolding or `project.json` handling
 - [x] Build, test, analyzer, coverage, or CI helper flow
 - [ ] Package, raw upload, or package metadata workflow
 - [ ] Publish, release, or GitHub Actions automation
 - [ ] Self-update or notification preference behavior
 - [ ] Contributor documentation (`README.md`, `CONTRIBUTING.md`, repository workflow docs)
 - [ ] End-user docs (`docs/*.html`)
 - [x] Command help (`docs/NovaModuleTools/en-US/*.md`)
 - [x] `src/resources/example/`
 - [ ] Dependency or manifest changes (`project.json`, workflow dependencies, release tooling)
 - [ ] Security-sensitive change
 - [ ] Documentation-only change
 - [ ] Agentic Copilot Workflow + scaffold mirror + scaffold-sync guardrail test.
 - [ ] Other
 
 ## Review guidance
 
 - Start with `src/private/quality/GetNovaTestWorkflowContext.ps1`, especially the new build-validation test discovery guard and error path.
 - Then review the regression coverage in `tests/private/quality/GetNovaTestWorkflowContext.Tests.ps1` and `tests/public/TestNovaBuild.Integration.Tests.ps1`.
 - Finally review the scaffold/example updates in `src/resources/example/README.md`, `src/resources/example/tests/public/Get-ExampleGreeting.Integration.Tests.ps1`, and `tests/private/scaffold/CopyNovaExampleProjectTemplate.Tests.ps1`, plus the release-facing docs in `CHANGELOG.md`, `RELEASE_NOTE.md`, and `docs/NovaModuleTools/en-US/Test-NovaBuild.md`.
 - Trade-off: projects that truly have no build-validation integration tests still fail, but now fail intentionally with actionable Nova guidance instead of a leaked Pester exception.
 
 ## Validation
 
 - [ ] `Invoke-NovaBuild`
 - [ ] `Invoke-NovaTest`
 - [x] `Test-NovaBuild`
 - [ ] `./scripts/build/Invoke-ScriptAnalyzerCI.ps1`
 - [ ] `./scripts/build/ci/Invoke-NovaModuleToolsCI.ps1`
 - [x] Targeted Nova workflow validated (`% nova build`, `% nova test`, `% nova merge`, `% nova deploy`, `% nova publish`, `% nova release`, `% nova update`, `% nova notification`, or `% nova init` as relevant)
 - [ ] Docs/example only; executable validation not needed
 
 Validation notes:
 
 ```text
 ./run.ps1 passed.
 CodeScene pre-commit safeguard passed.
 CodeScene change-set analysis passed.
 Touched source/test files reported Code Health 10.0.
 Targeted behavior validated for Test-NovaBuild / % nova test -b, including the missing-integration-tests failure path and the scaffolded example integration-test path.
 ```
 
 ## Documentation and release follow-up
 
 - [ ] `README.md` reviewed and updated if contributor workflow, architecture, CI, release, or automation changed
 - [ ] `CONTRIBUTING.md` reviewed and updated if contribution expectations or review guidance changed
 - [x] `CHANGELOG.md` reviewed and updated if the change matters to users, maintainers, or contributors
 - [x] `RELEASE_NOTE.md` reviewed and updated if the change affects public cmdlet usage, CLI usage, configuration semantics, or migration expectations
 - [x] `docs/NovaModuleTools/en-US/` help updated if a public command or CLI behavior changed
 - [ ] `docs/*.html` updated if end-user workflows or examples changed
 - [x] `src/resources/example/` reviewed and updated if the real-world project layout, package model, or upload workflow changed
 - [ ] No documentation, changelog, release-note, or example updates were needed
 
 ## Maintainability, compatibility, and risk
 
 - [x] Code Health / maintainability impact considered
 - [x] No breaking change
 - [ ] Breaking change
 - [ ] Security-sensitive change
 - [ ] CI, workflow, or release-pipeline impact
 - [ ] Dependency-review impact
 
 Risk, rollout, or rollback notes:
 
 ```text
 This is unreleased 3.2.1-preview work only; no stable-release semantics, publish flow, or GitHub Actions automation changed.
 Primary risk is limited to build-validation test discovery behavior and the scaffolded example contents.
 Rollback is straightforward: revert the new discovery guard, example integration test, and aligned docs/release-note entries.
 ```